### PR TITLE
Fix a build error on Linux

### DIFF
--- a/support-lib/cpp/DataRef.hpp
+++ b/support-lib/cpp/DataRef.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <string.h>
 
 #if !defined(DATAREF_JNI) && !defined(DATAREF_OBJC)
   #if defined(__ANDROID__)

--- a/support-lib/cpp/DataRef.hpp
+++ b/support-lib/cpp/DataRef.hpp
@@ -4,7 +4,7 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <string.h>
+#include <cstring>
 
 #if !defined(DATAREF_JNI) && !defined(DATAREF_OBJC)
   #if defined(__ANDROID__)


### PR DESCRIPTION
The current djinni master yields build errors on Linux as below:

'''

ERROR: /content/djinni/support-lib/BUILD:11:11: Compiling support-lib/cpp/DataRef.cpp failed: (Exit 1): gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++0x' -MD -MF ... (remaining 42 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
support-lib/cpp/DataRef.cpp: In constructor 'snapchat::djinni::DataRef::DataRef(const void*, size_t)':
support-lib/cpp/DataRef.cpp:170:5: error: 'memcpy' was not declared in this scope
     memcpy(mutableBuf(), data, len);
     ^~~~~~
support-lib/cpp/DataRef.cpp:170:5: note: suggested alternative: 'wmemcpy'
     memcpy(mutableBuf(), data, len);
     ^~~~~~
     wmemcpy
support-lib/cpp/DataRef.cpp: At global scope:
support-lib/cpp/DataRef.cpp:194:2: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
 }};
  ^
support-lib/cpp/DataRef.cpp:194:2: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
Target //test-suite:djinni-java-tests failed to build
[144 / 201] 1 / 1 tests, 1 failed; checking cached actions; last test: //test-\
Use --verbose_failures to see the command lines of failed build steps.
[144 / 201] 1 / 1 tests, 1 failed; checking cached actions; last test: //test-\
INFO: Elapsed time: 150.425s, Critical Path: 12.61s
[144 / 201] 1 / 1 tests, 1 failed; checking cached actions; last test: //test-\
INFO: 144 processes: 6 internal, 137 processwrapper-sandbox, 1 worker.
[144 / 201] 1 / 1 tests, 1 failed; checking cached actions; last test: //test-\
FAILED: Build did NOT complete successfully
//test-suite:djinni-java-tests                                  FAILED TO BUILD

FAILED: Build did NOT complete successfully
[ ]


'''

This PR did a quick a fix, to enable djinni to build and test on Linux. The updates have been tested on macOS Catalina 10.15.7 and Linux-5.4.104+-x86_64-with-Ubuntu-18.04-bionic.

