### PR TITLE
Fix -Werror in DataRef.cpp

### DIFF
--- a/support-lib/cpp/DataRef.cpp
+++ b/support-lib/cpp/DataRef.cpp
@@ -188,8 +188,8 @@ static void DataRefHelper_nativeDestroy(JNIEnv* /*unused*/, jclass /*unused*/, j
 }
 
 static const JNINativeMethod kNativeMethods[] = {{
-    "nativeDestroy",
-    "(J)V",
+    (char*) "nativeDestroy",
+    (char*) "(J)V",
     reinterpret_cast<void*>(&DataRefHelper_nativeDestroy),
 }};
 


### PR DESCRIPTION
Noticed a small thing (-Werror) with djinni while building our project. Just would like to fix it.

"
INFO: From Compiling support-lib/cpp/DataRef.cpp:
support-lib/cpp/DataRef.cpp:191:5: warning: ISO C++11 does not allow conversion from string literal to 'char *' [-Wwritable-strings]
    "nativeDestroy",
    ^
support-lib/cpp/DataRef.cpp:192:5: warning: ISO C++11 does not allow conversion from string literal to 'char *' [-Wwritable-strings]
    "(J)V",
    ^
2 warnings generated.
"

See https://stackoverflow.com/questions/20944784/why-is-conversion-from-string-constant-to-char-valid-in-c-but-invalid-in-c/20944858 for further context.