### PR TITLE
Remove the dependency on java.util.Optional because it requires Android API level 24

### DIFF
--- a/support-lib/java/com/snapchat/djinni/Outcome.java
+++ b/support-lib/java/com/snapchat/djinni/Outcome.java
@@ -2,7 +2,6 @@ package com.snapchat.djinni;
 
 import java.util.function.Function;
 import java.util.Objects;
-import java.util.Optional;
 
 public abstract class Outcome<Result, Error> {
     // No default construction. This object can only be created via the static
@@ -15,8 +14,8 @@ public abstract class Outcome<Result, Error> {
         if (o == null) return false;
         if (!(o instanceof Outcome)) return false;
         Outcome other = (Outcome) o;
-        return match(x -> x.equals(other.result().orElse(null)),
-                     x -> x.equals(other.error().orElse(null)));
+        return match(x -> x.equals(other.resultOr(null)),
+                     x -> x.equals(other.errorOrNull()));
     }
 
     @Override
@@ -30,17 +29,13 @@ public abstract class Outcome<Result, Error> {
     public abstract <R> R match(Function<? super Result, ? extends R> handleResult,
                                 Function<? super Error, ? extends R> handleError);
 
-    // Provide access to result as optional
-    public Optional<Result> result() {
-        return this.match(Optional::of, x -> Optional.empty());
-    }
     // Returns either result or default value
     public Result resultOr(Result defaultResult) {
         return this.match(x -> x, x -> defaultResult);
     }
-    // Provide access to error as optional
-    public Optional<Error> error() {
-        return this.match(x -> Optional.empty(), Optional::of);
+
+    public Error errorOrNull() {
+        return this.match(x -> null, x -> x);
     }
     
     // Construct Outcome from result

--- a/test-suite/handwritten-src/java/com/dropbox/djinni/test/OutcomeTest.java
+++ b/test-suite/handwritten-src/java/com/dropbox/djinni/test/OutcomeTest.java
@@ -8,14 +8,14 @@ public class OutcomeTest extends TestCase {
         // construct result outcome in native and pass to objc
         Outcome r = TestOutcome.getSuccessOutcome();
         // results are equal
-        assertEquals(r.result().get(), "hello");
+        assertEquals(r.resultOr(""), "hello");
         // outcome objects compare equal
         assertEquals(r, Outcome.fromResult("hello"));
 
         // construct error outcome in native and pass to objc
         Outcome e = TestOutcome.getErrorOutcome();
         // error values are equal
-        assertEquals(e.error().get(), 42);
+        assertEquals(e.errorOrNull(), 42);
         // outcome objects compare equal
         assertEquals(e, Outcome.fromError(42));
 
@@ -37,11 +37,11 @@ public class OutcomeTest extends TestCase {
 
         // test outcome as nested object
         NestedOutcome nr = TestOutcome.getNestedSuccessOutcome();
-        assertEquals(nr.getO().result().get(), Integer.valueOf(42));
+        assertEquals(nr.getO().resultOr(null), Integer.valueOf(42));
         assertEquals(nr, new NestedOutcome(Outcome.fromResult(42)));
 
         NestedOutcome ne = TestOutcome.getNestedErrorOutcome();
-        assertEquals(ne.getO().error().get(), "hello");
+        assertEquals(ne.getO().errorOrNull(), "hello");
         assertEquals(ne, new NestedOutcome(Outcome.fromError("hello")));
 
         assertEquals(TestOutcome.putNestedSuccessOutcome(new NestedOutcome(Outcome.fromResult(42))), 42);

--- a/test-suite/handwritten-src/java/com/dropbox/djinni/test/ProtoTest.java
+++ b/test-suite/handwritten-src/java/com/dropbox/djinni/test/ProtoTest.java
@@ -54,6 +54,6 @@ public class ProtoTest extends TestCase {
         assertEquals(p.getName(), "tom");
 
         Outcome<Person, Integer> r = ProtoTests.stringToProtoOutcome("tom");
-        assertEquals(r.result().get().getName(), "tom");
+        assertEquals(r.resultOr(null).getName(), "tom");
     }
 }


### PR DESCRIPTION
It prevents us from using the Outcome<> type on older Android devices.

There is another Optional type provided by [Guava](https://guava.dev/releases/19.0/api/docs/com/google/common/base/Optional.html).  However using that also complicates our dependencies.

Since providing the result and error as optionals is not essential, I decide to simply remove this and encourage the end user to use `resultOr()` and `errorOrNull()` instead.

If you really want optional, it's also easy to achieve with the `match()` function, but I will leave this to the user code as it is easier to know what is available in user code than in the support library.