### PR TITLE
Remove dependency on java.util.function.Function which requires Android API level 24

### DIFF
--- a/support-lib/java/com/snapchat/djinni/Outcome.java
+++ b/support-lib/java/com/snapchat/djinni/Outcome.java
@@ -1,9 +1,16 @@
 package com.snapchat.djinni;
 
-import java.util.function.Function;
 import java.util.Objects;
 
 public abstract class Outcome<Result, Error> {
+
+    public interface ResultHandler<R, Result> {
+        public R apply(Result r);
+    }
+    public interface ErrorHandler<R, Error> {
+        public R apply(Error e);
+    }
+    
     // No default construction. This object can only be created via the static
     // factory methods.
     private Outcome() {}
@@ -26,8 +33,8 @@ public abstract class Outcome<Result, Error> {
     }
     
     // Provide access to result or error through functions
-    public abstract <R> R match(Function<? super Result, ? extends R> handleResult,
-                                Function<? super Error, ? extends R> handleError);
+    public abstract <R> R match(ResultHandler<R, Result> handleResult,
+                                ErrorHandler<R, Error> handleError);
 
     // Returns either result or default value
     public Result resultOr(Result defaultResult) {
@@ -42,8 +49,8 @@ public abstract class Outcome<Result, Error> {
     public static <Result, Error> Outcome<Result, Error> fromResult(Result value) {
         return new Outcome<Result, Error>() {
             @Override
-            public <R> R match(Function<? super Result, ? extends R> handleResult,
-                               Function<? super Error, ? extends R> handleError) {
+            public <R> R match(ResultHandler<R, Result> handleResult,
+                               ErrorHandler<R, Error> handleError) {
                 return handleResult.apply(value);
             }
         };
@@ -52,8 +59,8 @@ public abstract class Outcome<Result, Error> {
     public static <Result, Error> Outcome<Result, Error> fromError(Error error) {
         return new Outcome<Result, Error>() {
             @Override
-            public <R> R match(Function<? super Result, ? extends R> handleResult,
-                               Function<? super Error, ? extends R> handleError) {
+            public <R> R match(ResultHandler<R, Result> handleResult,
+                               ErrorHandler<R, Error> handleError) {
                 return handleError.apply(error);
             }
         };


### PR DESCRIPTION
 java.util.function.Function requires Android API level 24.  Requiring it reduces the number of devices Djinni can support. This PR removes the dependency on that API.