### PR TITLE
[Bazel] Use scoped name for maven install

### DIFF
--- a/bzl/setup_deps.bzl
+++ b/bzl/setup_deps.bzl
@@ -10,6 +10,7 @@ def djinni_setup_deps():
     scala_repositories()
 
     maven_install(
+        name = "maven_djinni",
         artifacts = [
             "com.google.code.findbugs:jsr305:3.0.2",
             "junit:junit:4.12",

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -28,7 +28,7 @@ java_library(
     srcs = glob(["generated-src/java/**/*.java"]),
     deps = [
         "//support-lib:djinni-support-java",
-        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven_djinni//:com_google_code_findbugs_jsr305",
     ],
 )
 

--- a/perftest/BUILD
+++ b/perftest/BUILD
@@ -27,7 +27,7 @@ java_library(
     srcs = glob(["generated-src/java/**/*.java"]),
     deps = [
         "//support-lib:djinni-support-java",
-        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven_djinni//:com_google_code_findbugs_jsr305",
     ],
 )
 

--- a/src/BUILD
+++ b/src/BUILD
@@ -5,9 +5,9 @@ scala_binary(
     srcs = glob(["source/**/*.scala"]),
     main_class = "djinni.Main",
     deps = [
-        "@maven//:com_github_scopt_scopt_2_11",
-        "@maven//:org_scala_lang_modules_scala_parser_combinators_2_11",
-        "@maven//:org_yaml_snakeyaml",
+        "@maven_djinni//:com_github_scopt_scopt_2_11",
+        "@maven_djinni//:org_scala_lang_modules_scala_parser_combinators_2_11",
+        "@maven_djinni//:org_yaml_snakeyaml",
     ],
     visibility = ["//visibility:public"],
 )

--- a/test-suite/BUILD
+++ b/test-suite/BUILD
@@ -122,8 +122,8 @@ java_test(
     deps = [
         ":djinni-tests-jni",
         "//support-lib:djinni-support-java",
-        "@maven//:com_google_code_findbugs_jsr305",
-        "@maven//:junit_junit",
+        "@maven_djinni//:com_google_code_findbugs_jsr305",
+        "@maven_djinni//:junit_junit",
         "@com_google_protobuf//java/core:core",
     ],
     jvm_flags = ["-Ddjinni.native_libs_dirs=./test-suite/libdjinni-tests-jni.so"],


### PR DESCRIPTION
The bazel rules for maven allow setting a scoped name, and the packages get downloaded in this namespace. This is necessary when using maven across workspaces with different namespaces.

PTAL @bholmes-sc @chancila 