### PR TITLE
Optimize exception check

### DIFF
--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -230,8 +230,8 @@ void jniExceptionCheck(JNIEnv * env) {
     if (!env) {
         abort();
     }
-    const LocalRef<jthrowable> e(env->ExceptionOccurred());
-    if (e) {
+    if (env->ExceptionCheck()) {
+        const LocalRef<jthrowable> e(env->ExceptionOccurred());
         env->ExceptionClear();
         jniThrowCppFromJavaException(env, e.get());
     }


### PR DESCRIPTION
Use `ExceptionCheck()` for the initial check (which doesn't need to create a local reference) and only call `ExceptionOccurred()` to retrieve the `jthrowable` when we already know there is a pending exception.

https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/functions.html#exception_check
https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/functions.html#wp16124

No user code is broken. This change is a pure optimization. 