### PR TITLE
Use the user supplied TS module name to name module level statics

### DIFF
--- a/examples/generated-src/ts/example.ts
+++ b/examples/generated-src/ts/example.ts
@@ -26,6 +26,6 @@ export interface TextboxListener {
     update(items: ItemList): void;
 }
 
-export interface Module_statics {
+export interface Example_statics {
     SortItems: SortItems_statics;
 }

--- a/examples/ts/demo.ts
+++ b/examples/ts/demo.ts
@@ -1,6 +1,6 @@
 import * as example from "../generated-src/ts/example";
 
-declare function Module(): Promise<example.Module_statics>;
+declare function Module(): Promise<example.Example_statics>;
 
 var sorter: example.SortItems;
 

--- a/perftest/generated-src/cpp/EnumSixValue.hpp
+++ b/perftest/generated-src/cpp/EnumSixValue.hpp
@@ -16,6 +16,18 @@ enum class EnumSixValue : int {
     SIXTH = 5,
 };
 
+constexpr const char* to_string(EnumSixValue e) noexcept {
+    constexpr const char* names[] = {
+        "First",
+        "Second",
+        "Third",
+        "Fourth",
+        "Fifth",
+        "Sixth",
+    };
+    return names[static_cast<int>(e)];
+}
+
 } } }  // namespace snapchat::djinni::benchmark
 
 namespace std {

--- a/perftest/generated-src/ts/perftest.ts
+++ b/perftest/generated-src/ts/perftest.ts
@@ -61,6 +61,6 @@ export interface DjinniPerfBenchmark_statics {
     getInstance(): DjinniPerfBenchmark;
 }
 
-export interface Module_statics {
+export interface Perftest_statics {
     DjinniPerfBenchmark: DjinniPerfBenchmark_statics;
 }

--- a/perftest/run_djinni.sh
+++ b/perftest/run_djinni.sh
@@ -75,7 +75,7 @@ fi
     \
     --wasm-out "$temp_out/wasm" \
     --ts-out "$temp_out/ts" \
-    --ts-module "perftest_d" \
+    --ts-module "perftest" \
     \
     --idl "$in"
 

--- a/perftest/ts/perftest.ts
+++ b/perftest/ts/perftest.ts
@@ -1,6 +1,6 @@
-import * as perftest from "../generated-src/ts/perftest_d";
+import * as perftest from "../generated-src/ts/perftest";
 import {DjinniModule} from "@djinni_support/DjinniModule"
-declare function Module(): Promise<perftest.Module_statics & DjinniModule>;
+declare function Module(): Promise<perftest.Perftest_statics & DjinniModule>;
 
 Module().then(module => {
     main(module);
@@ -55,7 +55,7 @@ class ObjectPlatformImpl {
     onDone() {}
 }
 
-function main (module: perftest.Module_statics & DjinniModule) {
+function main (module: perftest.Perftest_statics & DjinniModule) {
     var minCount = 16;
     var lowCount = 128;
     var highCount = 4096;

--- a/src/source/TsGenerator.scala
+++ b/src/source/TsGenerator.scala
@@ -243,7 +243,7 @@ class TsGenerator(spec: Spec) extends Generator(spec) {
       }
       // add static factories
       w.wl
-      w.w("export interface Module_statics").braced {
+      w.w(s"export interface ${idJs.ty(spec.tsModule)}_statics").braced {
         for (i <- interfacesWithStatics.toList) {
           w.wl(i + ": " + i + "_statics;")
         }

--- a/test-suite/generated-src/ts/test.ts
+++ b/test-suite/generated-src/ts/test.ts
@@ -570,7 +570,7 @@ export interface /*record*/ SetRecord {
     iset: Set<number>;
 }
 
-export interface Module_statics {
+export interface Test_statics {
     ProtoTests: ProtoTests_statics;
     TestOutcome: TestOutcome_statics;
     TestDuration: TestDuration_statics;

--- a/test-suite/generated-src/ts/test_wchar.ts
+++ b/test-suite/generated-src/ts/test_wchar.ts
@@ -15,6 +15,6 @@ export interface WcharTestHelpers_statics {
     checkRecord(rec: WcharTestRec): boolean;
 }
 
-export interface Module_statics {
+export interface TestWchar_statics {
     WcharTestHelpers: WcharTestHelpers_statics;
 }

--- a/test-suite/generated-src/ts/test_yaml.ts
+++ b/test-suite/generated-src/ts/test_yaml.ts
@@ -22,5 +22,5 @@ export interface /*record*/ TestOptionalExternInterfaceRecord {
     sampleInterface: SampleInterface;
 }
 
-export interface Module_statics {
+export interface TestYaml_statics {
 }

--- a/test-suite/handwritten-src/ts/ArrayTest.ts
+++ b/test-suite/handwritten-src/ts/ArrayTest.ts
@@ -2,10 +2,10 @@ import {TestCase, allTests, assertArrayEq} from "./testutils"
 import * as test from "../../generated-src/ts/test";
 
 export class ArrayTest extends TestCase {
-    m: test.Module_statics;
+    m: test.Test_statics;
     constructor(module: any) {
         super(module);
-        this.m = <test.Module_statics>module;
+        this.m = <test.Test_statics>module;
     }
     testStringArray() {
         var inputStrings = ['1', '2', '3'];

--- a/test-suite/handwritten-src/ts/ClientInterfaceTest.ts
+++ b/test-suite/handwritten-src/ts/ClientInterfaceTest.ts
@@ -25,11 +25,11 @@ class ClientInterfaceImpl implements test.ClientInterface {
 }
 
 class ClientInterfaceTest extends TestCase {
-    m: test.Module_statics;
+    m: test.Test_statics;
     jsClientInterface: test.ClientInterface;
     constructor(module) {
         super(module);
-        this.m = <test.Module_statics>module;
+        this.m = <test.Test_statics>module;
     }
     setUp() {
         this.jsClientInterface = new ClientInterfaceImpl();

--- a/test-suite/handwritten-src/ts/CppExceptionTest.ts
+++ b/test-suite/handwritten-src/ts/CppExceptionTest.ts
@@ -3,10 +3,10 @@ import * as test from "../../generated-src/ts/test";
 import {DjinniModule} from "@djinni_support/DjinniModule"
 
 class CppExceptionTest extends TestCase  {
-    m: test.Module_statics & DjinniModule;
+    m: test.Test_statics & DjinniModule;
     cppInterface: test.CppException;
 
-    constructor(module: test.Module_statics & DjinniModule) {
+    constructor(module: test.Test_statics & DjinniModule) {
         super(module);
         this.m = module;
     }

--- a/test-suite/handwritten-src/ts/DataTest.ts
+++ b/test-suite/handwritten-src/ts/DataTest.ts
@@ -3,10 +3,10 @@ import * as test from "../../generated-src/ts/test";
 import {DjinniModule} from "@djinni_support/DjinniModule"
 
 class DataTest extends TestCase {
-    m: test.Module_statics & DjinniModule;
+    m: test.Test_statics & DjinniModule;
     test: test.DataRefTest;
 
-    constructor(module: test.Module_statics & DjinniModule) {
+    constructor(module: test.Test_statics & DjinniModule) {
         super(module);
         this.m = module;
     }

--- a/test-suite/handwritten-src/ts/DurationTest.ts
+++ b/test-suite/handwritten-src/ts/DurationTest.ts
@@ -9,10 +9,10 @@ function minutes(x: number) { return x * 1000 * 60; }
 function hours(x: number) { return x * 1000 * 3600; }
 
 class DurationTest extends TestCase {
-    m: test.Module_statics;
+    m: test.Test_statics;
     constructor(module: any) {
         super(module);
-        this.m = <test.Module_statics>module;
+        this.m = <test.Test_statics>module;
     }
     test() {
         assertEq(this.m.TestDuration.hoursString(hours(1)), "1");

--- a/test-suite/handwritten-src/ts/EnumTest.ts
+++ b/test-suite/handwritten-src/ts/EnumTest.ts
@@ -2,10 +2,10 @@ import {TestCase, allTests, assertEq, assertNull} from "./testutils"
 import * as test from "../../generated-src/ts/test";
 
 class EnumTest extends TestCase {
-    m: test.Module_statics;
+    m: test.Test_statics;
     constructor(module: any) {
         super(module);
-        this.m = <test.Module_statics>module;
+        this.m = <test.Test_statics>module;
     }
 
     enumToString(v: test.Color) {

--- a/test-suite/handwritten-src/ts/MapRecordTest.ts
+++ b/test-suite/handwritten-src/ts/MapRecordTest.ts
@@ -2,10 +2,10 @@ import {TestCase, allTests, assertEq, assertTrue} from "./testutils"
 import * as test from "../../generated-src/ts/test";
 
 class MapRecordTest extends TestCase {
-    m: test.Module_statics;
+    m: test.Test_statics;
     constructor(module: any) {
         super(module);
-        this.m = <test.Module_statics>module;
+        this.m = <test.Test_statics>module;
     }
 
     testCppMapToJavaMap() {

--- a/test-suite/handwritten-src/ts/NestedCollectionTest.ts
+++ b/test-suite/handwritten-src/ts/NestedCollectionTest.ts
@@ -2,12 +2,12 @@ import {TestCase, allTests, assertEq, assertTrue} from "./testutils"
 import * as test from "../../generated-src/ts/test";
 
 class NestedCollectionTest extends TestCase {
-    m: test.Module_statics;
+    m: test.Test_statics;
     jsNestedCollection: test.NestedCollection;
 
     constructor(module: any) {
         super(module);
-        this.m = <test.Module_statics>module;
+        this.m = <test.Test_statics>module;
     }
     setUp() {
         var jsSet1 = new Set();

--- a/test-suite/handwritten-src/ts/OutcomeTest.ts
+++ b/test-suite/handwritten-src/ts/OutcomeTest.ts
@@ -2,10 +2,10 @@ import {TestCase, allTests, assertEq, assertNe} from "./testutils"
 import * as test from "../../generated-src/ts/test";
 
 class OutcomeTest extends TestCase {
-    m: test.Module_statics;
+    m: test.Test_statics;
     constructor(module: any) {
         super(module);
-        this.m = <test.Module_statics>module;
+        this.m = <test.Test_statics>module;
     }
     test() {
         // construct result outcome in native and pass to js

--- a/test-suite/handwritten-src/ts/PrimitiveListTest.ts
+++ b/test-suite/handwritten-src/ts/PrimitiveListTest.ts
@@ -2,11 +2,11 @@ import {TestCase, allTests, assertArrayEq, assertTrue} from "./testutils"
 import * as test from "../../generated-src/ts/test";
 
 class PrimitiveListTest extends TestCase {
-    m: test.Module_statics;
+    m: test.Test_statics;
     jsPrimitiveList: test.PrimitiveList;
     constructor(module: any) {
         super(module);
-        this.m = <test.Module_statics>module;
+        this.m = <test.Test_statics>module;
     }
     setUp() {
         var list = [BigInt(1), BigInt(2), BigInt(3)];

--- a/test-suite/handwritten-src/ts/PrimitivesTest.ts
+++ b/test-suite/handwritten-src/ts/PrimitivesTest.ts
@@ -2,10 +2,10 @@ import {TestCase, allTests, assertEq} from "./testutils"
 import * as test from "../../generated-src/ts/test";
 
 class PrimitivesTest extends TestCase {
-    m: test.Module_statics;
+    m: test.Test_statics;
     constructor(module: any) {
         super(module);
-        this.m = <test.Module_statics>module;
+        this.m = <test.Test_statics>module;
     }
     testPrimitives() {
         var p = {

--- a/test-suite/handwritten-src/ts/ProtoTest.ts
+++ b/test-suite/handwritten-src/ts/ProtoTest.ts
@@ -5,8 +5,8 @@ import {DjinniModule} from "@djinni_support/DjinniModule"
 import { Writer } from "protobufjs/minimal";
 
 export class ProtoTest extends TestCase {
-    m: test.Module_statics;
-    constructor(module: test.Module_statics & DjinniModule) {
+    m: test.Test_statics;
+    constructor(module: test.Test_statics & DjinniModule) {
         super(module);
         this.m = module;
         // register protobuf types with wasm module

--- a/test-suite/handwritten-src/ts/SetRecordTest.ts
+++ b/test-suite/handwritten-src/ts/SetRecordTest.ts
@@ -2,11 +2,11 @@ import {TestCase, allTests, assertEq, assertTrue} from "./testutils"
 import * as test from "../../generated-src/ts/test";
 
 class SetRecordTest extends TestCase {
-    m: test.Module_statics;
+    m: test.Test_statics;
 
     constructor(module: any) {
         super(module);
-        this.m = <test.Module_statics>module;
+        this.m = <test.Test_statics>module;
     }
     testCppSetToJavaSet() {
         var jsSetRecord = this.m.TestHelpers.getSetRecord();

--- a/test-suite/handwritten-src/ts/TokenTest.ts
+++ b/test-suite/handwritten-src/ts/TokenTest.ts
@@ -8,11 +8,11 @@ class JsToken {
 }
 
 export class TokenTest extends TestCase {
-    m: test.Module_statics;
+    m: test.Test_statics;
 
     constructor(module) {
         super(module);
-        this.m = <test.Module_statics>module;
+        this.m = <test.Test_statics>module;
     }
     
     testTokens() {

--- a/test-suite/handwritten-src/ts/WcharTest.ts
+++ b/test-suite/handwritten-src/ts/WcharTest.ts
@@ -2,10 +2,10 @@ import {TestCase, allTests, assertEq} from "./testutils"
 import * as test from "../../generated-src/ts/test_wchar";
 
 class WcharTest extends TestCase {
-    m: test.Module_statics;
+    m: test.TestWchar_statics;
     constructor(module: any) {
         super(module);
-        this.m = <test.Module_statics>module;
+        this.m = <test.TestWchar_statics>module;
     }
 
     static STR1 = "some string with unicode \u{0000}, \u{263A}, \u{D83D}\u{DCA9} symbols";


### PR DESCRIPTION
Instead of naming them all as `Module_statics`,  use the ts-module-name command line option to name them.