### PR TITLE
Make the `ts` key optional in protobuf yaml

### DIFF
--- a/src/source/TsGenerator.scala
+++ b/src/source/TsGenerator.scala
@@ -104,7 +104,7 @@ class TsGenerator(spec: Spec) extends Generator(spec) {
   case class TsSymbolRef(sym: String, module: String)
   def references(m: Meta): Seq[TsSymbolRef] = m match {
     case e: MExtern => List(TsSymbolRef(idJs.ty(e.name), e.ts.module))
-    case p: MProtobuf => List(TsSymbolRef(p.name, p.body.ts.module))
+    case MProtobuf(name, _, ProtobufMessage(_,_,_,Some(ts))) => List(TsSymbolRef(name, ts.module))
     case MOutcome => List(TsSymbolRef("Outcome", "@djinni_support/Outcome"))
     case _ => List()
   }

--- a/src/source/WasmGenerator.scala
+++ b/src/source/WasmGenerator.scala
@@ -78,10 +78,10 @@ class WasmGenerator(spec: Spec) extends Generator(spec) {
       case MMap | MOutcome =>
         assert(tm.args.size == 2)
         f
-      case p: MProtobuf =>
+      case MProtobuf(name, _, ProtobufMessage(cpp,_,_,Some(ts))) =>
         assert(tm.args.size == 0)
-        val tsname = if (p.body.ts.ns.isEmpty) p.name else p.body.ts.ns + "." + p.name
-        s"""<${withNs(Some(p.body.cpp.ns), p.name)}, ${jsClassNameAsCppType(tsname)}>"""
+        val tsname = if (ts.ns.isEmpty) name else ts.ns + "." + name
+        s"""<${withNs(Some(cpp.ns), name)}, ${jsClassNameAsCppType(tsname)}>"""
       case MArray =>
         assert(tm.args.size == 1)
         s"""<${helperClass(tm.args.head)}>"""

--- a/src/source/ast.scala
+++ b/src/source/ast.scala
@@ -90,7 +90,7 @@ object Interface {
 
 case class Field(ident: Ident, ty: TypeRef, doc: Doc)
 
-case class ProtobufMessage(cpp: ProtobufMessage.Cpp, java: ProtobufMessage.Java, objc: Option[ProtobufMessage.Objc], ts: ProtobufMessage.Ts) extends TypeDef
+case class ProtobufMessage(cpp: ProtobufMessage.Cpp, java: ProtobufMessage.Java, objc: Option[ProtobufMessage.Objc], ts: Option[ProtobufMessage.Ts]) extends TypeDef
 object ProtobufMessage {
   case class Cpp(header: String, ns: String)
   case class Java(pkg: String)


### PR DESCRIPTION
Allow the`ts` section to be omitted if the user is not interested in using typescript.