### PR TITLE
Make generated ObjC protocols conform to NSObject

### DIFF
--- a/examples/generated-src/objc/TXSTextboxListener.h
+++ b/examples/generated-src/objc/TXSTextboxListener.h
@@ -5,7 +5,7 @@
 #import <Foundation/Foundation.h>
 
 
-@protocol TXSTextboxListener
+@protocol TXSTextboxListener <NSObject>
 
 - (void)update:(nonnull TXSItemList *)items;
 

--- a/perftest/generated-src/objc/TXSObjectPlatform.h
+++ b/perftest/generated-src/objc/TXSObjectPlatform.h
@@ -5,7 +5,7 @@
 
 
 /** interfaces for platform Java or Objective-C objects, to be passed to C++ */
-@protocol TXSObjectPlatform
+@protocol TXSObjectPlatform <NSObject>
 
 - (void)onDone;
 

--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -135,7 +135,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
 
       w.wl
       writeDoc(w, doc)
-      if (useProtocol(i.ext, spec)) w.wl(s"@protocol $self") else w.wl(s"@interface $self : NSObject")
+      if (useProtocol(i.ext, spec)) w.wl(s"@protocol $self <NSObject>") else w.wl(s"@interface $self : NSObject")
 
       for (m <- i.methods) {
         if (!m.static || !spec.objcGenProtocol) {

--- a/test-suite/generated-src/objc/DBClientInterface.h
+++ b/test-suite/generated-src/objc/DBClientInterface.h
@@ -7,7 +7,7 @@
 
 
 /** Client interface */
-@protocol DBClientInterface
+@protocol DBClientInterface <NSObject>
 
 /** Returns record of given string */
 - (nonnull DBClientReturnedRecord *)getRecord:(int64_t)recordId

--- a/test-suite/generated-src/objc/DBEnumUsageInterface.h
+++ b/test-suite/generated-src/objc/DBEnumUsageInterface.h
@@ -5,7 +5,7 @@
 #import <Foundation/Foundation.h>
 
 
-@protocol DBEnumUsageInterface
+@protocol DBEnumUsageInterface <NSObject>
 
 - (DBColor)e:(DBColor)e;
 

--- a/test-suite/generated-src/objc/DBExternInterface2.h
+++ b/test-suite/generated-src/objc/DBExternInterface2.h
@@ -6,7 +6,7 @@
 #import <Foundation/Foundation.h>
 
 
-@protocol DBExternInterface2
+@protocol DBExternInterface2 <NSObject>
 
 - (nonnull DBExternRecordWithDerivings *)foo:(nullable DBTestHelpers *)i;
 

--- a/test-suite/generated-src/objc/DBFirstListener.h
+++ b/test-suite/generated-src/objc/DBFirstListener.h
@@ -5,7 +5,7 @@
 
 
 /** Used for ObjC multiple inheritance tests */
-@protocol DBFirstListener
+@protocol DBFirstListener <NSObject>
 
 - (void)first;
 

--- a/test-suite/generated-src/objc/DBObjcOnlyListener.h
+++ b/test-suite/generated-src/objc/DBObjcOnlyListener.h
@@ -4,6 +4,6 @@
 #import <Foundation/Foundation.h>
 
 
-@protocol DBObjcOnlyListener
+@protocol DBObjcOnlyListener <NSObject>
 
 @end

--- a/test-suite/generated-src/objc/DBSecondListener.h
+++ b/test-suite/generated-src/objc/DBSecondListener.h
@@ -5,7 +5,7 @@
 
 
 /** Used for ObjC multiple inheritance tests */
-@protocol DBSecondListener
+@protocol DBSecondListener <NSObject>
 
 - (void)second;
 

--- a/test-suite/generated-src/objc/DBUserToken.h
+++ b/test-suite/generated-src/objc/DBUserToken.h
@@ -4,7 +4,7 @@
 #import <Foundation/Foundation.h>
 
 
-@protocol DBUserToken
+@protocol DBUserToken <NSObject>
 
 - (nonnull NSString *)whoami;
 

--- a/test-suite/generated-src/objc/DBUsesSingleLanguageListeners.h
+++ b/test-suite/generated-src/objc/DBUsesSingleLanguageListeners.h
@@ -10,7 +10,7 @@
  * Generating and compiling this makes sure other languages don't break
  * on references to interfaces they don't need.
  */
-@protocol DBUsesSingleLanguageListeners
+@protocol DBUsesSingleLanguageListeners <NSObject>
 
 - (void)callForObjC:(nullable id<DBObjcOnlyListener>)l;
 


### PR DESCRIPTION
Apple recommends all protocols to conform to NSObject.  And since practically all ObjC objects are directly or indirectly derived from NSObject anyway, there is no reason not to make them conform to NSObject protocol.  This should not break any existing code and will only make certain tasks easier (eg. using NSObject methods without casting)