### PR TITLE
Assert with an error message instead of silently return empty object

### DIFF
--- a/support-lib/wasm/djinni_wasm.hpp
+++ b/support-lib/wasm/djinni_wasm.hpp
@@ -458,7 +458,10 @@ struct JsInterface {
     // (interface +c)
     template <typename, typename>
     struct GetOrCreateCppProxy {
-        em::val operator() (const std::shared_ptr<I>& c) { return em::val::undefined(); }
+        em::val operator() (const std::shared_ptr<I>& c) {
+            assert(false && "Attempting to pass C++ object but interface lacks +c");
+            return em::val::undefined();
+        }
     };
     template <typename T>
     struct GetOrCreateCppProxy<T, std::void_t<decltype(T::cppProxyMethods)>> {
@@ -501,7 +504,10 @@ struct JsInterface {
     // (interface +w)
     template <typename, typename>
     struct GetOrCreateJsProxy {
-        std::shared_ptr<I> operator() (em::val js) { return {}; }
+        std::shared_ptr<I> operator() (em::val js) {
+            assert(false && "Attempting to pass JS object but interface lacks +w");
+            return {};
+        }
     };
     template <typename T>
     struct GetOrCreateJsProxy<T, std::void_t<typename T::JsProxy>> {


### PR DESCRIPTION
When passing JS interface objects but the interfaces lacks "+w",  we currently pass an empty object into C++.  This causes downstream code to fail silently and it confuses developers.

This change will trigger an assertion in this case with a clear error message about what happened.  Also fix the case of passing C++ interface objects without "+c".