### PR TITLE
[ObjC] Mark NSObject init / new as unavailable for records with any fields

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,9 @@ jobs:
         - name: Build
           run: bazel build //src:djinni
 
+        - name: Generate examples / check clean output
+          run: ./ci/generate.sh
+
         - name: Test
           run: bazel test //test-suite:djinni-java-tests  //test-suite:djinni-objc-tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ investigated. Bug reports should have:
 Pull requests are the best way to propose code changes:
 
 1. Fork the repo and create your branch from `master`.
-2. Run `./examples/run_djinni.sh` and check in any changes to generated code.
+2. Run `./ci/generate.sh` and check in any changes to generated code.
 3. Add tests, if appropriate.
 4. If you add or change code generator command line options, update the
    documentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,12 +33,13 @@ investigated. Bug reports should have:
 Pull requests are the best way to propose code changes:
 
 1. Fork the repo and create your branch from `master`.
-2. Add tests, if appropriate.
-3. If you add or change code generator command line options, update the
+2. Run `./examples/run_djinni.sh` and check in any changes to generated code.
+3. Add tests, if appropriate.
+4. If you add or change code generator command line options, update the
    documentation.
-4. Ensure the test suite passes with your change.
-5. Test the changes on actual devices if you can.
-6. Issue the pull request.
+5. Ensure the test suite passes with your change.
+6. Test the changes on actual devices if you can.
+7. Issue the pull request.
 
 ## Code style
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ either plain Bazel or [Bazelisk](https://github.com/bazelbuild/bazelisk).
 
 ### Building and running the test suite
 
+`./examples/run_djinni.sh` generates the examples sources.
+
 `bazel test //test-suite:all` builds and then runs all tests.
 
 Or `bazel test //test-suite:djinni-objc-tests` and `bazel test

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ either plain Bazel or [Bazelisk](https://github.com/bazelbuild/bazelisk).
 
 ### Building and running the test suite
 
-`./examples/run_djinni.sh` generates the examples sources.
+`./ci/generate.sh` generates the examples sources.
 
 `bazel test //test-suite:all` builds and then runs all tests.
 

--- a/ci/generate.sh
+++ b/ci/generate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "--- Check Generated files"
+./examples/run_djinni.sh
+./perftest/run_djinni.sh
+./test-suite/run_djinni.sh
+
+if test -z "$(git status --porcelain)"; then
+  echo "--- Success! Generated files are clean."
+else
+  echo "--- Failed! Generated files are dirty after running generator."
+  git status
+  git --no-pager diff --submodule=diff
+  exit 1
+fi

--- a/examples/generated-src/objc/TXSItemList.h
+++ b/examples/generated-src/objc/TXSItemList.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface TXSItemList : NSObject
-- (nonnull instancetype)initWithItems:(nonnull NSArray<NSString *> *)items;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithItems:(nonnull NSArray<NSString *> *)items NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)itemListWithItems:(nonnull NSArray<NSString *> *)items;
 
 @property (nonatomic, readonly, nonnull) NSArray<NSString *> * items;

--- a/perftest/generated-src/objc/TXSRecordSixInt.h
+++ b/perftest/generated-src/objc/TXSRecordSixInt.h
@@ -4,12 +4,14 @@
 #import <Foundation/Foundation.h>
 
 @interface TXSRecordSixInt : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithI1:(int64_t)i1
                                 i2:(int64_t)i2
                                 i3:(int64_t)i3
                                 i4:(int64_t)i4
                                 i5:(int64_t)i5
-                                i6:(int64_t)i6;
+                                i6:(int64_t)i6 NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)RecordSixIntWithI1:(int64_t)i1
                                         i2:(int64_t)i2
                                         i3:(int64_t)i3

--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -209,7 +209,19 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
       def writeInitializer(sign: String, prefix: String) {
         val decl = s"$sign (nonnull instancetype)$prefix$firstInitializerArg"
         writeAlignedObjcCall(w, decl, r.fields, "", f => (idObjc.field(f.ident), s"(${marshal.paramType(f.ty)})${idObjc.local(f.ident)}"))
-        w.wl(";")
+
+        if (prefix == "init") {
+          w.wl(" NS_DESIGNATED_INITIALIZER;")
+        } else {
+          w.wl(";")
+        }
+      }
+
+      if (r.fields.nonEmpty) {
+          // NSObject init / new are marked unavailable. Only allow designated initializer
+          // as records may have non-optional / nonnull fields.
+          w.wl("- (nonnull instancetype)init NS_UNAVAILABLE;")
+          w.wl("+ (nonnull instancetype)new NS_UNAVAILABLE;")
       }
 
       writeInitializer("-", "init")

--- a/test-suite/generated-src/objc/DBAssortedPrimitives.h
+++ b/test-suite/generated-src/objc/DBAssortedPrimitives.h
@@ -4,6 +4,8 @@
 #import <Foundation/Foundation.h>
 
 @interface DBAssortedPrimitives : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithB:(BOOL)b
                             eight:(int8_t)eight
                           sixteen:(int16_t)sixteen
@@ -17,7 +19,7 @@
                        oThirtytwo:(nullable NSNumber *)oThirtytwo
                        oSixtyfour:(nullable NSNumber *)oSixtyfour
                       oFthirtytwo:(nullable NSNumber *)oFthirtytwo
-                      oFsixtyfour:(nullable NSNumber *)oFsixtyfour;
+                      oFsixtyfour:(nullable NSNumber *)oFsixtyfour NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)assortedPrimitivesWithB:(BOOL)b
                                           eight:(int8_t)eight
                                         sixteen:(int16_t)sixteen

--- a/test-suite/generated-src/objc/DBClientReturnedRecord.h
+++ b/test-suite/generated-src/objc/DBClientReturnedRecord.h
@@ -5,9 +5,11 @@
 
 /** Record returned by a client */
 @interface DBClientReturnedRecord : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithRecordId:(int64_t)recordId
                                  content:(nonnull NSString *)content
-                                    misc:(nullable NSString *)misc;
+                                    misc:(nullable NSString *)misc NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)clientReturnedRecordWithRecordId:(int64_t)recordId
                                                  content:(nonnull NSString *)content
                                                     misc:(nullable NSString *)misc;

--- a/test-suite/generated-src/objc/DBConstantRecord.h
+++ b/test-suite/generated-src/objc/DBConstantRecord.h
@@ -5,8 +5,10 @@
 
 /** Record for use in constants */
 @interface DBConstantRecord : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithSomeInteger:(int32_t)someInteger
-                                 someString:(nonnull NSString *)someString;
+                                 someString:(nonnull NSString *)someString NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)constantRecordWithSomeInteger:(int32_t)someInteger
                                            someString:(nonnull NSString *)someString;
 

--- a/test-suite/generated-src/objc/DBConstantWithEnum.h
+++ b/test-suite/generated-src/objc/DBConstantWithEnum.h
@@ -6,7 +6,7 @@
 
 /** Record containing enum constant */
 @interface DBConstantWithEnum : NSObject
-- (nonnull instancetype)init;
+- (nonnull instancetype)init NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)constantWithEnum;
 
 + (DBConstantEnum)constEnum;

--- a/test-suite/generated-src/objc/DBConstants.h
+++ b/test-suite/generated-src/objc/DBConstants.h
@@ -6,7 +6,7 @@
 
 /** Record containing constants */
 @interface DBConstants : NSObject
-- (nonnull instancetype)init;
+- (nonnull instancetype)init NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)constants;
 
 + (NSNumber * __nullable)optBoolConstant;

--- a/test-suite/generated-src/objc/DBDateRecord.h
+++ b/test-suite/generated-src/objc/DBDateRecord.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBDateRecord : NSObject
-- (nonnull instancetype)initWithCreatedAt:(nonnull NSDate *)createdAt;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithCreatedAt:(nonnull NSDate *)createdAt NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)dateRecordWithCreatedAt:(nonnull NSDate *)createdAt;
 
 @property (nonatomic, readonly, nonnull) NSDate * createdAt;

--- a/test-suite/generated-src/objc/DBEmptyRecord.h
+++ b/test-suite/generated-src/objc/DBEmptyRecord.h
@@ -9,7 +9,7 @@
  *   Indented third line of multi-line documentation.)
  */
 @interface DBEmptyRecord : NSObject
-- (nonnull instancetype)init;
+- (nonnull instancetype)init NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)emptyRecord;
 
 @end

--- a/test-suite/generated-src/objc/DBEnumUsageRecord.h
+++ b/test-suite/generated-src/objc/DBEnumUsageRecord.h
@@ -5,11 +5,13 @@
 #import <Foundation/Foundation.h>
 
 @interface DBEnumUsageRecord : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithE:(DBColor)e
                                 o:(nullable NSNumber *)o
                                 l:(nonnull NSArray<NSNumber *> *)l
                                 s:(nonnull NSSet<NSNumber *> *)s
-                                m:(nonnull NSDictionary<NSNumber *, NSNumber *> *)m;
+                                m:(nonnull NSDictionary<NSNumber *, NSNumber *> *)m NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)enumUsageRecordWithE:(DBColor)e
                                            o:(nullable NSNumber *)o
                                            l:(nonnull NSArray<NSNumber *> *)l

--- a/test-suite/generated-src/objc/DBExtendedRecord.h
+++ b/test-suite/generated-src/objc/DBExtendedRecord.h
@@ -6,7 +6,9 @@
 
 /** Extended record */
 @interface DBExtendedRecord : NSObject
-- (nonnull instancetype)initWithFoo:(BOOL)foo;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithFoo:(BOOL)foo NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)extendedRecordWithFoo:(BOOL)foo;
 
 + (DBExtendedRecord * __nonnull)extendedRecordConst;

--- a/test-suite/generated-src/objc/DBExternRecordWithDerivings.h
+++ b/test-suite/generated-src/objc/DBExternRecordWithDerivings.h
@@ -7,8 +7,10 @@
 
 /** This file tests YAML dumped by Djinni can be parsed back in */
 @interface DBExternRecordWithDerivings : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithMember:(nonnull DBRecordWithDerivings *)member
-                                     e:(DBColor)e;
+                                     e:(DBColor)e NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)externRecordWithDerivingsWithMember:(nonnull DBRecordWithDerivings *)member
                                                           e:(DBColor)e;
 

--- a/test-suite/generated-src/objc/DBMapDateRecord.h
+++ b/test-suite/generated-src/objc/DBMapDateRecord.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBMapDateRecord : NSObject
-- (nonnull instancetype)initWithDatesById:(nonnull NSDictionary<NSString *, NSDate *> *)datesById;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithDatesById:(nonnull NSDictionary<NSString *, NSDate *> *)datesById NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)mapDateRecordWithDatesById:(nonnull NSDictionary<NSString *, NSDate *> *)datesById;
 
 @property (nonatomic, readonly, nonnull) NSDictionary<NSString *, NSDate *> * datesById;

--- a/test-suite/generated-src/objc/DBMapListRecord.h
+++ b/test-suite/generated-src/objc/DBMapListRecord.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBMapListRecord : NSObject
-- (nonnull instancetype)initWithMapList:(nonnull NSArray<NSDictionary<NSString *, NSNumber *> *> *)mapList;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithMapList:(nonnull NSArray<NSDictionary<NSString *, NSNumber *> *> *)mapList NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)mapListRecordWithMapList:(nonnull NSArray<NSDictionary<NSString *, NSNumber *> *> *)mapList;
 
 @property (nonatomic, readonly, nonnull) NSArray<NSDictionary<NSString *, NSNumber *> *> * mapList;

--- a/test-suite/generated-src/objc/DBMapRecord.h
+++ b/test-suite/generated-src/objc/DBMapRecord.h
@@ -4,8 +4,10 @@
 #import <Foundation/Foundation.h>
 
 @interface DBMapRecord : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithMap:(nonnull NSDictionary<NSString *, NSNumber *> *)map
-                               imap:(nonnull NSDictionary<NSNumber *, NSNumber *> *)imap;
+                               imap:(nonnull NSDictionary<NSNumber *, NSNumber *> *)imap NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)mapRecordWithMap:(nonnull NSDictionary<NSString *, NSNumber *> *)map
                                     imap:(nonnull NSDictionary<NSNumber *, NSNumber *> *)imap;
 

--- a/test-suite/generated-src/objc/DBNestedCollection.h
+++ b/test-suite/generated-src/objc/DBNestedCollection.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBNestedCollection : NSObject
-- (nonnull instancetype)initWithSetList:(nonnull NSArray<NSSet<NSString *> *> *)setList;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithSetList:(nonnull NSArray<NSSet<NSString *> *> *)setList NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)nestedCollectionWithSetList:(nonnull NSArray<NSSet<NSString *> *> *)setList;
 
 @property (nonatomic, readonly, nonnull) NSArray<NSSet<NSString *> *> * setList;

--- a/test-suite/generated-src/objc/DBNestedOutcome.h
+++ b/test-suite/generated-src/objc/DBNestedOutcome.h
@@ -5,7 +5,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBNestedOutcome : NSObject
-- (nonnull instancetype)initWithO:(nonnull DJOutcome<NSNumber *, NSString *> *)o;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithO:(nonnull DJOutcome<NSNumber *, NSString *> *)o NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)nestedOutcomeWithO:(nonnull DJOutcome<NSNumber *, NSString *> *)o;
 
 @property (nonatomic, readonly, nonnull) DJOutcome<NSNumber *, NSString *> * o;

--- a/test-suite/generated-src/objc/DBPrimitiveList.h
+++ b/test-suite/generated-src/objc/DBPrimitiveList.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBPrimitiveList : NSObject
-- (nonnull instancetype)initWithList:(nonnull NSArray<NSNumber *> *)list;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithList:(nonnull NSArray<NSNumber *> *)list NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)primitiveListWithList:(nonnull NSArray<NSNumber *> *)list;
 
 @property (nonatomic, readonly, nonnull) NSArray<NSNumber *> * list;

--- a/test-suite/generated-src/objc/DBRecordUsingExtendedRecord.h
+++ b/test-suite/generated-src/objc/DBRecordUsingExtendedRecord.h
@@ -6,7 +6,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBRecordUsingExtendedRecord : NSObject
-- (nonnull instancetype)initWithEr:(nonnull DBExtendedRecord *)er;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithEr:(nonnull DBExtendedRecord *)er NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)recordUsingExtendedRecordWithEr:(nonnull DBExtendedRecord *)er;
 
 + (DBRecordUsingExtendedRecord * __nonnull)cr;

--- a/test-suite/generated-src/objc/DBRecordWithDerivings.h
+++ b/test-suite/generated-src/objc/DBRecordWithDerivings.h
@@ -4,6 +4,8 @@
 #import <Foundation/Foundation.h>
 
 @interface DBRecordWithDerivings : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithEight:(int8_t)eight
                               sixteen:(int16_t)sixteen
                             thirtytwo:(int32_t)thirtytwo
@@ -11,7 +13,7 @@
                            fthirtytwo:(float)fthirtytwo
                            fsixtyfour:(double)fsixtyfour
                                     d:(nonnull NSDate *)d
-                                    s:(nonnull NSString *)s;
+                                    s:(nonnull NSString *)s NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)recordWithDerivingsWithEight:(int8_t)eight
                                              sixteen:(int16_t)sixteen
                                            thirtytwo:(int32_t)thirtytwo

--- a/test-suite/generated-src/objc/DBRecordWithDurationAndDerivings.h
+++ b/test-suite/generated-src/objc/DBRecordWithDurationAndDerivings.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBRecordWithDurationAndDerivings : NSObject
-- (nonnull instancetype)initWithDt:(NSTimeInterval)dt;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithDt:(NSTimeInterval)dt NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)recordWithDurationAndDerivingsWithDt:(NSTimeInterval)dt;
 
 @property (nonatomic, readonly) NSTimeInterval dt;

--- a/test-suite/generated-src/objc/DBRecordWithEmbeddedCppProto.h
+++ b/test-suite/generated-src/objc/DBRecordWithEmbeddedCppProto.h
@@ -5,7 +5,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBRecordWithEmbeddedCppProto : NSObject
-- (nonnull instancetype)initWithState:(const djinni::test2::PersistingState & )state;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithState:(const djinni::test2::PersistingState & )state NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)RecordWithEmbeddedCppProtoWithState:(const djinni::test2::PersistingState & )state;
 
 @property (nonatomic, readonly) djinni::test2::PersistingState state;

--- a/test-suite/generated-src/objc/DBRecordWithEmbeddedProto.h
+++ b/test-suite/generated-src/objc/DBRecordWithEmbeddedProto.h
@@ -5,7 +5,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBRecordWithEmbeddedProto : NSObject
-- (nonnull instancetype)initWithPerson:(nonnull DJTestPerson *)person;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithPerson:(nonnull DJTestPerson *)person NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)RecordWithEmbeddedProtoWithPerson:(nonnull DJTestPerson *)person;
 
 @property (nonatomic, readonly, nonnull) DJTestPerson * person;

--- a/test-suite/generated-src/objc/DBRecordWithFlags.h
+++ b/test-suite/generated-src/objc/DBRecordWithFlags.h
@@ -5,7 +5,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBRecordWithFlags : NSObject
-- (nonnull instancetype)initWithAccess:(DBAccessFlags)access;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithAccess:(DBAccessFlags)access NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)recordWithFlagsWithAccess:(DBAccessFlags)access;
 
 @property (nonatomic, readonly) DBAccessFlags access;

--- a/test-suite/generated-src/objc/DBRecordWithNestedDerivings.h
+++ b/test-suite/generated-src/objc/DBRecordWithNestedDerivings.h
@@ -5,8 +5,10 @@
 #import <Foundation/Foundation.h>
 
 @interface DBRecordWithNestedDerivings : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithKey:(int32_t)key
-                                rec:(nonnull DBRecordWithDerivings *)rec;
+                                rec:(nonnull DBRecordWithDerivings *)rec NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)recordWithNestedDerivingsWithKey:(int32_t)key
                                                      rec:(nonnull DBRecordWithDerivings *)rec;
 

--- a/test-suite/generated-src/objc/DBSetRecord.h
+++ b/test-suite/generated-src/objc/DBSetRecord.h
@@ -4,8 +4,10 @@
 #import <Foundation/Foundation.h>
 
 @interface DBSetRecord : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithSet:(nonnull NSSet<NSString *> *)set
-                               iset:(nonnull NSSet<NSNumber *> *)iset;
+                               iset:(nonnull NSSet<NSNumber *> *)iset NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)setRecordWithSet:(nonnull NSSet<NSString *> *)set
                                     iset:(nonnull NSSet<NSNumber *> *)iset;
 

--- a/test-suite/generated-src/objc/DBSupportCopying.h
+++ b/test-suite/generated-src/objc/DBSupportCopying.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBSupportCopying : NSObject<NSCopying>
-- (nonnull instancetype)initWithX:(int32_t)x;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithX:(int32_t)x NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)supportCopyingWithX:(int32_t)x;
 
 @property (nonatomic, readonly) int32_t x;

--- a/test-suite/generated-src/objc/DBTestOptionalExternInterfaceRecord.h
+++ b/test-suite/generated-src/objc/DBTestOptionalExternInterfaceRecord.h
@@ -5,7 +5,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBTestOptionalExternInterfaceRecord : NSObject
-- (nonnull instancetype)initWithSampleInterface:(nullable DBSampleInterface *)sampleInterface;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithSampleInterface:(nullable DBSampleInterface *)sampleInterface NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)testOptionalExternInterfaceRecordWithSampleInterface:(nullable DBSampleInterface *)sampleInterface;
 
 @property (nonatomic, readonly, nullable) DBSampleInterface * sampleInterface;

--- a/test-suite/generated-src/objc/DBVarnameRecord.h
+++ b/test-suite/generated-src/objc/DBVarnameRecord.h
@@ -9,7 +9,9 @@
  * badly when it is.  However this test case ensures we at least don't crash.
  */
 @interface DBVarnameRecord : NSObject
-- (nonnull instancetype)initWithField:(int8_t)Field;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithField:(int8_t)Field NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)VarnameRecordWithField:(int8_t)Field;
 
 @property (nonatomic, readonly) int8_t Field;

--- a/test-suite/generated-src/objc/DBVec2.h
+++ b/test-suite/generated-src/objc/DBVec2.h
@@ -4,8 +4,10 @@
 #import <Foundation/Foundation.h>
 
 @interface DBVec2 : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithX:(int32_t)x
-                                y:(int32_t)y;
+                                y:(int32_t)y NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)vec2WithX:(int32_t)x
                                 y:(int32_t)y;
 

--- a/test-suite/generated-src/objc/DBWcharTestRec.h
+++ b/test-suite/generated-src/objc/DBWcharTestRec.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBWcharTestRec : NSObject
-- (nonnull instancetype)initWithS:(nonnull NSString *)s;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithS:(nonnull NSString *)s NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)wcharTestRecWithS:(nonnull NSString *)s;
 
 @property (nonatomic, readonly, nonnull) NSString * s;


### PR DESCRIPTION
Blocked by https://github.com/Snapchat/djinni/issues/27 for full test suite, but passes.

```sh
jgavris in ~/code/djinni on objc-record-initializers
λ bazel test //test-suite:djinni-java-tests  //test-suite:djinni-objc-tests
INFO: Analyzed 2 targets (0 packages loaded, 0 targets configured).
INFO: Found 2 test targets...
INFO: Elapsed time: 0.371s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//test-suite:djinni-java-tests                                  (cached) PASSED in 2.7s
//test-suite:djinni-objc-tests                                  (cached) PASSED in 14.9s

Executed 0 out of 2 tests: 2 tests pass.
INFO: Build completed successfully, 1 total action
```

- Records with non-null fields will be improperly constructed if a default initializer (`[NSObject init]` or `[NSObject new]`) is called (on any record with `optional` fields), which can cause an unexpectedly unwrapped optional `nil` in Swift code. Mark these as unavailable to hide them from Swift. 
- Adds `./ci/generate.sh` step as an intermediate check to make sure that all the example test files are 'clean' before running the test suite.