### PR TITLE
Unit test doc fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,8 @@ either plain Bazel or [Bazelisk](https://github.com/bazelbuild/bazelisk).
 
 ### Building and running the test suite
 
-`bazel test //test-suite:all` builds and then runs all tests.
-
-Or `bazel test //test-suite:djinni-objc-tests` and `bazel test
-//test-suite:djinni-java-tests` to run Objective-C and Java tests separately.
+Use `bazel test //test-suite:djinni-objc-tests //test-suite:djinni-java-tests`
+to build and run Objective-C and Java tests.
 
 ### Building and running the mobile example apps
 

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -10,7 +10,5 @@ like to be generated. After input files are changed, run `./run_djinni.sh` to re
 
 Testing
 -------
-`bazel test //test-suite:all` builds and then runs all tests.
-
-Or `bazel test //test-suite:djinni-objc-tests` and `bazel test
-//test-suite:djinni-java-tests` to run Objective-C and Java tests separately.
+Use `bazel test //test-suite:djinni-objc-tests //test-suite:djinni-java-tests`
+to build and run Objective-C and Java tests.


### PR DESCRIPTION
`bazel test //test-suite:all` no longer works after adding the experimental wasm support, so fix the README files with correct build instructions.