### PR TITLE
Allow user to customize the java protobuf serializer 

### DIFF
--- a/src/source/ast.scala
+++ b/src/source/ast.scala
@@ -93,7 +93,7 @@ case class Field(ident: Ident, ty: TypeRef, doc: Doc)
 case class ProtobufMessage(cpp: ProtobufMessage.Cpp, java: ProtobufMessage.Java, objc: Option[ProtobufMessage.Objc], ts: Option[ProtobufMessage.Ts]) extends TypeDef
 object ProtobufMessage {
   case class Cpp(header: String, ns: String)
-  case class Java(pkg: String)
+  case class Java(pkg: String, jniClass: Option[String], jniHeader: Option[String])
   case class Objc(header: String, prefix: String)
   case class Ts(module: String, ns: String)
 }

--- a/src/source/parser.scala
+++ b/src/source/parser.scala
@@ -322,6 +322,8 @@ def parseProtobufManifest(origin: String, in: java.io.Reader): Either[Error, Seq
   //   - `cpp.namespace` key must be present
   // - `java` key must be present
   //   - `java.class` key must be present
+  //   - `jni_class` is optional
+  //   - `jni_header` is optional
   // - `ts` key must be present
   //   - `ts.module` key must be present
   // - `objc` key is optional
@@ -341,7 +343,7 @@ def parseProtobufManifest(origin: String, in: java.io.Reader): Either[Error, Seq
   }
   val proto = ProtobufMessage(
     ProtobufMessage.Cpp(c("header"), c("namespace")),
-    ProtobufMessage.Java(j("class")),
+    ProtobufMessage.Java(j("class"), j.get("jni_class"), j.get("jni_header")),
     // ObjC is optional, if it's not present, then ObjC will use C++ protos
     Option(doc.get("objc")) match {
       case Some(properties) => {

--- a/support-lib/jni/Marshal.hpp
+++ b/support-lib/jni/Marshal.hpp
@@ -598,11 +598,11 @@ namespace djinni
         const GlobalRef<jclass> clazz { jniFindClass("com/google/protobuf/MessageLite") };
         const jmethodID method_to_byte_array { jniGetMethodID(clazz.get(), "toByteArray", "()[B") };
 
-        jbyteArray serialzeJavaProto(JNIEnv* jniEnv, jobject jproto) const {
+        jbyteArray serializeJavaProto(JNIEnv* jniEnv, jobject jproto) const {
             return static_cast<jbyteArray>(jniEnv->CallObjectMethod(jproto, method_to_byte_array));
         }
 
-        jobject deserialzeJavaProto(JNIEnv* jniEnv, jobject javaBuf, const char* javaClassName) const {
+        jobject deserializeJavaProto(JNIEnv* jniEnv, jobject javaBuf, const char* javaClassName) const {
             auto cls = jniFindClass(javaClassName);
             auto sig = std::string("(Ljava/nio/ByteBuffer;)L") + javaClassName + ";";
             auto mid = jniGetStaticMethodID(cls.get(), "parseFrom", sig.c_str());
@@ -636,7 +636,7 @@ namespace djinni
 
             // Call message.toByteArray() through JNI
             const auto& msgcls = JniClass<JAVA_SERIALIZER>::get();
-            auto bytes = LocalRef<jbyteArray>(jniEnv, msgcls.serialzeJavaProto(jniEnv, j));
+            auto bytes = LocalRef<jbyteArray>(jniEnv, msgcls.serializeJavaProto(jniEnv, j));
             jniExceptionCheck(jniEnv);
 
             // Get the length of byte array
@@ -672,7 +672,7 @@ namespace djinni
             auto javaBuf = LocalRef<jobject>(jniEnv, jniEnv->NewDirectByteBuffer(cppBuf.data(), cppBuf.size()));
             // Then deserialize from ByteBuffer
             const auto& msgcls = JniClass<JAVA_SERIALIZER>::get();
-            auto ret = msgcls.deserialzeJavaProto(jniEnv, javaBuf.get(), JAVA_PROTO::name());
+            auto ret = msgcls.deserializeJavaProto(jniEnv, javaBuf.get(), JAVA_PROTO::name());
             jniExceptionCheck(jniEnv);
             return {jniEnv, ret};
         }


### PR DESCRIPTION
in case they want to use a different protobuf library.

This introduces 2 new optional fields in the protobuf yaml:
```
java:
    class: 'djinni.test.Test'
    jni_class: 'MyJavaProtoSerializer'
    jni_header: '"MyJavaProtoSerializer.hpp"'
```
If these 2 fields are present, then the code generate will delegate the Java side of protobuf serializing/deserializing to that class.

The custom serializer class should implement the `serializeJavaProto()` and `deserializeJavaProto()` methods.

```
struct MyJavaProtoSerializer {
    // Turn a Java protobuf object into byte[]
    jbyteArray serialzeJavaProto(JNIEnv* jniEnv, jobject jproto) const {
    }
    // Turn a java.nio.ByteBuffer object into the Java protobuf class object (class name passed in javaClassName)
    jobject deserialzeJavaProto(JNIEnv* jniEnv, jobject javaBuf, const char* javaClassName) const {
    }
};
```

If these 2 fields are absent, then the codegen will use the default implementation, which uses `com.google.protobuf.MessageLite`.
