### PR TITLE
Fix JNI enum flags in yaml output

### DIFF
--- a/src/source/JNIMarshal.scala
+++ b/src/source/JNIMarshal.scala
@@ -26,7 +26,10 @@ class JNIMarshal(spec: Spec) extends Marshal(spec) {
 
   // For JNI typename() is always fully qualified and describes the mangled Java type to be used in field/method signatures
   override def typename(tm: MExpr): String = javaTypeSignature(tm)
-  def typename(name: String, ty: TypeDef) = s"L${undecoratedTypename(name, ty)};"
+  def typename(name: String, ty: TypeDef) = ty match {
+    case e: Enum if e.flags => "Ljava/util/EnumSet;"
+    case _ => s"L${undecoratedTypename(name, ty)};"
+  }
 
   override def fqTypename(tm: MExpr): String = typename(tm)
   def fqTypename(name: String, ty: TypeDef): String = typename(name, ty)


### PR DESCRIPTION
Fix the yaml output for enum flags.  flags should produce "Ljava/util/EnumSet;" rather than "LPackage/Class;" in yaml as well as in local codegen.

The bug was found by @delaitre-manfrotto  and was fixed in the cross-language-cpp repo on the yaml consumer side (https://github.com/cross-language-cpp/djinni-generator/pull/90). After examine this problem closely, I believe this is better fixed on the yaml producer side, as the `typeSignature` field in the yaml  file is incorrect in the first place.

Testing: examined `yaml-test.yaml` in `test-suite/djinni-output-temp/yaml`,  and the `typeSignature` fields now have the correct value `Ljava/util/EnumSet;`