### PR TITLE
Propagate stack from JS Error into C++ exception

### DIFF
--- a/support-lib/wasm/djinni_wasm.cpp
+++ b/support-lib/wasm/djinni_wasm.cpp
@@ -60,7 +60,20 @@ const em::val& JsProxyBase::_jsRef() const {
 
 void JsProxyBase::checkError(const em::val& v) {
     if (v.instanceof(em::val::global("Error"))) {
-        throw JsException(v["message"].as<std::string>());
+         // The stack property is non-standard, but well supported in browsers
+         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack#browser_compatibility
+         // It also seems to include the name and message properties, so no need to access them separately
+         //
+         // >>> function doThrow() { throw new Error("foo")}
+         // >>> try { doThrow() } catch (e) { console.log(e.stack) }
+         // Error: foo
+         //     at doThrow (<anonymous>:1:25)
+         //     at <anonymous>:1:7
+         // >>> try { doThrow() } catch (e) { console.log(e.name) }
+         // Error
+         // >>> try { brad() } catch (e) {console.log(e.message)}
+         // foo
+        throw JsException(v["stack"].as<std::string>());
     }
 }
 

--- a/support-lib/wasm/djinni_wasm.cpp
+++ b/support-lib/wasm/djinni_wasm.cpp
@@ -71,7 +71,7 @@ void JsProxyBase::checkError(const em::val& v) {
          //     at <anonymous>:1:7
          // >>> try { doThrow() } catch (e) { console.log(e.name) }
          // Error
-         // >>> try { brad() } catch (e) {console.log(e.message)}
+         // >>> try { doThrow() } catch (e) { console.log(e.message) }
          // foo
         throw JsException(v["stack"].as<std::string>());
     }


### PR DESCRIPTION
Pivot from https://github.com/Snapchat/djinni/pull/35/.

This solves the problem of information loss, by taking all of the useful info out of the JS error before turning it into a c++ exception.