### PR TITLE
Fix race condition when finalizing weakrefs

### DIFF
--- a/support-lib/wasm/djinni_wasm.cpp
+++ b/support-lib/wasm/djinni_wasm.cpp
@@ -42,7 +42,7 @@ Date::JsType Date::fromCpp(const CppType& c) {
 
 JsProxyId nextId = 0;
 std::unordered_map<JsProxyId, std::weak_ptr<JsProxyBase>> jsProxyCache;
-std::unordered_map<void*, em::val> cppProxyCache;
+std::unordered_map<void*, CppProxyCacheEntry> cppProxyCache;
 std::mutex jsProxyCacheMutex;
 std::mutex cppProxyCacheMutex;
 

--- a/support-lib/wasm/djinni_wasm.hpp
+++ b/support-lib/wasm/djinni_wasm.hpp
@@ -462,9 +462,14 @@ private:
     JsProxyId _id;
 };
 
+struct CppProxyCacheEntry {
+    em::val ref;
+    int count;
+};
+
 extern JsProxyId nextId;
 extern std::unordered_map<JsProxyId, std::weak_ptr<JsProxyBase>> jsProxyCache;
-extern std::unordered_map<void*, em::val> cppProxyCache;
+extern std::unordered_map<void*, CppProxyCacheEntry> cppProxyCache;
 extern std::mutex jsProxyCacheMutex;
 extern std::mutex cppProxyCacheMutex;
 
@@ -472,8 +477,11 @@ template<typename I, typename Self>
 struct JsInterface {
     static void nativeDestroy(const std::shared_ptr<I>& cpp) {
         std::lock_guard lk(cppProxyCacheMutex);
-        assert(cppProxyCache.find(cpp.get()) != cppProxyCache.end());
-        cppProxyCache.erase(cpp.get());
+        auto i = cppProxyCache.find(cpp.get());
+        assert(i != cppProxyCache.end());
+        if (--(i->second.count) == 0) {
+            cppProxyCache.erase(cpp.get());
+        }
     }
     // enable this only when the derived class has `cppProxyMethods` defined
     // (interface +c)
@@ -490,9 +498,11 @@ struct JsInterface {
             // look up in cpp proxy cache
             std::lock_guard lk(cppProxyCacheMutex);
             auto i = cppProxyCache.find(c.get());
+            int jsRefCount = 1;
             if (i != cppProxyCache.end()) {
                 // found existing cpp proxy
-                auto strongRef = i->second.template call<em::val>("deref");
+                jsRefCount += i->second.count;
+                auto strongRef = i->second.ref.template call<em::val>("deref");
                 if (!strongRef.isUndefined()) {
                     // and it's not expired
                     return strongRef;
@@ -504,7 +514,11 @@ struct JsInterface {
             em::val nativeRef(c);
             em::val cppProxy = getCppProxyClass().new_(nativeRef, Self::cppProxyMethods());
             em::val weakRef = weakRefClass.new_(cppProxy);
-            cppProxyCache.emplace(c.get(), weakRef);
+            if (i == cppProxyCache.end()) {
+                cppProxyCache.emplace(c.get(), CppProxyCacheEntry{weakRef, jsRefCount});
+            } else {
+                i->second = CppProxyCacheEntry{weakRef, jsRefCount};
+            }
             getCppProxyFinalizerRegistry().call<void>("register", cppProxy, nativeRef);
             return cppProxy;
         }


### PR DESCRIPTION
When a C++ object's proxy is expired in JS but the finalizer is not yet run,  the same object gets a new proxy when it's passed across the boundary.  Because both proxies are registered with the finalizer, the finalizer `nativeDestroy` will be called twice, and the second time it'll trigger an assertion, as the proxy is no longer in the proxy cache.

The sequence of events are like this:

1. C++ object proxy in JS is expired and becomes garbage
2. The same C++ is passed to JS again
3. The marshalling code sees the weakref to the original proxy is expired, and creates a new proxy
4. The expired proxy object's finalizer is called, and removes the new proxy from proxy cache
5. The new proxy object is expired in JS
6. The new proxy object's finalizer is called, but it can't find itself in the proxy cache and triggers assertion

This PR fixes the problem by keeping a count in the proxy cache.  When an object gets a new proxy but the old proxy's finalizer is not yet run,  we'll bump the count.  We'll only remove the proxy cache entry when the count reaches 0.