### PR TITLE
support for executable

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
         run: bazel build //generator:generator
 
       - name: Test generator
-        run: bazel run //generator:generator
+        run: bazel run //generator:generator -- --help
 
       - name: Creating bat
         run: cp bazel-bin/generator/djinni bazel-bin/generator/djinni.bat

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,10 @@ jobs:
         run: bazel build //src:djinni_deploy.jar
 
       - name: Generator
-        run: bazel build //generator
+        run: bazel build //generator:generator
+
+      - name: Test generator
+        run: bazel run //generator:generator
 
       - name: Creating bat
         run: cp bazel-bin/generator/djinni bazel-bin/generator/djinni.bat

--- a/generator/BUILD
+++ b/generator/BUILD
@@ -3,5 +3,5 @@ genrule(
     srcs = ["stub.sh", "//src:djinni_deploy.jar"],
     outs = ["djinni"],
     cmd = "cat $(location :stub.sh) $(location //src:djinni_deploy.jar) > $@ && chmod +x $@",
-    tools = [],
+    executable = True
 )


### PR DESCRIPTION
This pull-request:

1. add runnable capability to the generator package
2. now you can execute generator direct from bazel with bazel run //generator:generator -- --help
3. a simple test is executed in generator after create it
