### PR TITLE
Fix assertion

### DIFF
--- a/support-lib/jni/djinni_support.hpp
+++ b/support-lib/jni/djinni_support.hpp
@@ -325,7 +325,7 @@ template <class T> using CppProxyHandle = JniCppProxyCache::Handle<std::shared_p
 template <class T>
 static const std::shared_ptr<T> & objectFromHandleAddress(jlong handle) {
     assert(handle);
-    assert(handle > 4096);
+    assert(static_cast<uintptr_t>(handle) > 4096);
     // Below line segfaults gcc-4.8. Using a temporary variable hides the bug.
     //const auto & ret = reinterpret_cast<const CppProxyHandle<T> *>(handle)->get();
     const CppProxyHandle<T> *proxy_handle =


### PR DESCRIPTION
`jlong` is signed in C++.  We need to convert it to unsigned before comparing it with an address.
Otherwise it sometimes triggers false positives on 64bit Android systems.