### PR TITLE
Add static method language annotation

### DIFF
--- a/src/source/JNIGenerator.scala
+++ b/src/source/JNIGenerator.scala
@@ -378,7 +378,7 @@ class JNIGenerator(spec: Spec) extends Generator(spec) {
         nativeHook("nativeDestroy", false, Seq.empty, None, {
           w.wl(s"delete reinterpret_cast<::djinni::CppProxyHandle<$cppSelf>*>(nativeRef);")
         })
-        for (m <- i.methods) {
+        for (m <- i.methods.filter(m => !m.static || m.lang.java)) {
           val nativeAddon = if (m.static) "" else "native_"
           nativeHook(nativeAddon + idJava.method(m.ident), m.static, m.params, m.ret, {
             //w.wl(s"::${spec.jniNamespace}::JniLocalScope jscope(jniEnv, 10);")

--- a/src/source/JavaGenerator.scala
+++ b/src/source/JavaGenerator.scala
@@ -192,7 +192,7 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
           w.wl("public abstract " + ret + " " + idJava.method(m.ident) + params.mkString("(", ", ", ")") + throwException + ";")
         }
 
-        val statics = i.methods.filter(m => m.static)
+        val statics = i.methods.filter(m => m.static && m.lang.java)
 
         if (statics.nonEmpty) {
           writeModuleInitializer(w)

--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -111,7 +111,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
         writeObjcFile(marshal.implHeaderName(ident), origin, List(protocolHeader), w => {
           w.wl(s"@interface $self : NSObject<$self>")
           for (m <- i.methods) {
-            if (m.static) {
+            if (m.static && m.lang.objc) {
               w.wl
               writeMethodDoc(w, m, idObjc.local)
               writeObjcFuncDecl(m, w)
@@ -138,7 +138,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
       if (useProtocol(i.ext, spec)) w.wl(s"@protocol $self <NSObject>") else w.wl(s"@interface $self : NSObject")
 
       for (m <- i.methods) {
-        if (!m.static || !spec.objcGenProtocol) {
+        if (!m.static || (!spec.objcGenProtocol && m.lang.objc)) {
           w.wl
           writeMethodDoc(w, m, idObjc.local)
           writeObjcFuncDecl(m, w)

--- a/src/source/ObjcppGenerator.scala
+++ b/src/source/ObjcppGenerator.scala
@@ -180,7 +180,7 @@ class ObjcppGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
           }
           w.wl("return self;")
         }
-        for (m <- i.methods) {
+        for (m <- i.methods.filter(m => !m.static || m.lang.objc)) {
           w.wl
           writeObjcFuncDecl(m, w)
           w.braced {

--- a/src/source/WasmGenerator.scala
+++ b/src/source/WasmGenerator.scala
@@ -303,7 +303,7 @@ class WasmGenerator(spec: Spec) extends Generator(spec) {
         w.wl
         // stubs
         if (i.ext.cpp) {
-          for (m <- i.methods) {
+          for (m <- i.methods.filter(m => !m.static || m.lang.js)) {
             val selfRef = if (m.static) "" else if (m.params.isEmpty) "const CppType& self" else "const CppType& self, "
             w.w(s"static ${stubRetType(m)} ${idCpp.method(m.ident)}(${selfRef}")
             w.w(m.params.map(p => {
@@ -353,7 +353,7 @@ class WasmGenerator(spec: Spec) extends Generator(spec) {
       w.wl
       // stub methods
       if (i.ext.cpp) {
-        for (m <- i.methods) {
+        for (m <- i.methods.filter(m => !m.static || m.lang.js)) {
           val selfRef = if (m.static) "" else if (m.params.isEmpty) "const CppType& self" else "const CppType& self, "
           w.w(s"${stubRetType(m)} $helper::${idCpp.method(m.ident)}(${selfRef}")
           w.w(m.params.map(p => {
@@ -413,7 +413,7 @@ class WasmGenerator(spec: Spec) extends Generator(spec) {
           w.wl(s""".smart_ptr<std::shared_ptr<$cls>>("${fullyQualifiedJsName}")""")
           w.wl(s""".function("${idJs.method("native_destroy")}", &$helper::nativeDestroy)""")
           if (i.ext.cpp) {
-            for (m <- i.methods) {
+            for (m <- i.methods.filter(m => !m.static || m.lang.js)) {
               val funcType = if (m.static) "class_function" else "function"
               w.wl(s""".$funcType("${idJs.method(m.ident.name)}", $helper::${idCpp.method(m.ident)})""")
             }

--- a/src/source/ast.scala
+++ b/src/source/ast.scala
@@ -85,7 +85,7 @@ object Record {
 
 case class Interface(ext: Ext, methods: Seq[Interface.Method], consts: Seq[Const]) extends TypeDef
 object Interface {
-  case class Method(ident: Ident, params: Seq[Field], ret: Option[TypeRef], doc: Doc, static: Boolean, const: Boolean)
+  case class Method(ident: Ident, params: Seq[Field], ret: Option[TypeRef], doc: Doc, static: Boolean, const: Boolean, lang: Ext)
 }
 
 case class Field(ident: Ident, ty: TypeRef, doc: Doc)

--- a/src/source/parser.scala
+++ b/src/source/parser.scala
@@ -88,6 +88,7 @@ private object IdlParser extends RegexParsers {
   def ext(default: Ext) = (rep1("+" ~> ident) >> checkExts) | success(default)
   def extRecord = ext(Ext(false, false, false, false))
   def extInterface = ext(Ext(true, true, true, true))
+  def supportLang = ext(Ext(true, true, true, true))
 
   def checkExts(parts: List[Ident]): Parser[Ext] = {
     var foundCpp = false
@@ -186,8 +187,8 @@ private object IdlParser extends RegexParsers {
     case "const " => true
     case "" => false
   }
-  def method: Parser[Interface.Method] = doc ~ staticLabel ~ constLabel ~ ident ~ parens(repsepend(field, ",")) ~ opt(ret) ^^ {
-    case doc~staticLabel~constLabel~ ident~params~ret => Interface.Method(ident, params, ret, doc, staticLabel, constLabel)
+  def method: Parser[Interface.Method] = doc ~ staticLabel ~ constLabel ~ ident ~ parens(repsepend(field, ",")) ~ opt(ret) ~ supportLang ^^ {
+    case doc~staticLabel~constLabel~ ident~params~ret~ext => Interface.Method(ident, params, ret, doc, staticLabel, constLabel, ext)
   }
   def ret: Parser[TypeRef] = ":" ~> typeRef
 


### PR DESCRIPTION
Static method declaration can now have `+c +j +o +w` annotations at the end (right before the comma).

If no annotation is present, then Djinni will generate binding for the static method in all languages.  eg. `static foo() +j;` will only generate java binding for `foo()`.

The absent of `+c` does not disable the static method in the generated C++ header file, but if a static method has only `+c` then all other language bindings are disabled.