### PR TITLE
Allow usage of all caps identifiers in Djinni files

### DIFF
--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -111,7 +111,22 @@ package object generatorTools {
     if (s.isEmpty) s else ", " + s
   }
   def q(s: String) = '"' + s + '"'
-  def firstUpper(token: String) = if (token.isEmpty()) token else token.charAt(0).toUpper + token.substring(1)
+
+  def leadingUpper(token: String) = {
+    if (token.isEmpty()) {
+      token
+    } else {
+      val head = token.charAt(0)
+      val tail = token.substring(1)
+      // Preserve mixed case identifiers like 'XXFoo':
+      // Convert tail to lowercase only when it is full uppercase.
+      if (tail.toUpperCase == tail) {
+        head.toUpper + tail.toLowerCase
+      } else {
+        head.toUpper + tail
+      }
+    }
+  }
 
   type IdentConverter = String => String
 
@@ -132,13 +147,13 @@ package object generatorTools {
                           enum: IdentConverter, const: IdentConverter)
 
   object IdentStyle {
-    val camelUpper = (s: String) => s.split("[-_]").map(firstUpper).mkString
+    val camelUpper = (s: String) => s.split("[-_]").map(leadingUpper).mkString
     val camelLower = (s: String) => {
       val parts = s.split('_')
-      parts.head + parts.tail.map(firstUpper).mkString
+      parts.head + parts.tail.map(leadingUpper).mkString
     }
     val underLower = (s: String) => s
-    val underUpper = (s: String) => s.split('_').map(firstUpper).mkString("_")
+    val underUpper = (s: String) => s.split('_').map(leadingUpper).mkString("_")
     val underCaps = (s: String) => s.toUpperCase
     val prefix = (prefix: String, suffix: IdentConverter) => (s: String) => prefix + suffix(s)
 

--- a/test-suite/djinni/constants.djinni
+++ b/test-suite/djinni/constants.djinni
@@ -84,4 +84,10 @@ constants_interface = interface +c {
     # No support for constant binary, list, set, map
 
     dummy();
+
+    # An upper-case constant should be parsed correctly
+    const UPPER_CASE_CONSTANT: string = "upper-case-constant";
+
+    # But we should preserve weirdness in casing
+    const XXXWeird_Case: i32 = 1;
 }

--- a/test-suite/generated-src/cpp/constants_interface.cpp
+++ b/test-suite/generated-src/cpp/constants_interface.cpp
@@ -35,4 +35,7 @@ ConstantRecord const ConstantsInterface::OBJECT_CONSTANT = ConstantRecord(
     ConstantsInterface::I32_CONSTANT /* some_integer */ ,
     ConstantsInterface::STRING_CONSTANT /* some_string */ );
 
+std::string const ConstantsInterface::UPPER_CASE_CONSTANT = {"upper-case-constant"};
+
+
 }  // namespace testsuite

--- a/test-suite/generated-src/cpp/constants_interface.hpp
+++ b/test-suite/generated-src/cpp/constants_interface.hpp
@@ -62,6 +62,12 @@ public:
 
     static ConstantRecord const OBJECT_CONSTANT;
 
+    /** An upper-case constant should be parsed correctly */
+    static std::string const UPPER_CASE_CONSTANT;
+
+    /** But we should preserve weirdness in casing */
+    static constexpr int32_t XXXWEIRD_CASE = 1;
+
     /**
      * No support for null optional constants
      * No support for optional constant records

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantsInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantsInterface.java
@@ -68,6 +68,13 @@ public abstract class ConstantsInterface {
         I32_CONSTANT /* mSomeInteger */ ,
         STRING_CONSTANT /* mSomeString */ );
 
+    /** An upper-case constant should be parsed correctly */
+    @Nonnull
+    public static final String UPPER_CASE_CONSTANT = "upper-case-constant";
+
+    /** But we should preserve weirdness in casing */
+    public static final int XXXWEIRD_CASE = 1;
+
     /**
      * No support for null optional constants
      * No support for optional constant records

--- a/test-suite/generated-src/objc/DBConstantsInterface.h
+++ b/test-suite/generated-src/objc/DBConstantsInterface.h
@@ -19,6 +19,10 @@ extern float const DBConstantsInterfaceF32Constant;
 extern double const DBConstantsInterfaceF64Constant;
 extern NSString * __nonnull const DBConstantsInterfaceStringConstant;
 extern NSString * __nullable const DBConstantsInterfaceOptStringConstant;
+/** An upper-case constant should be parsed correctly */
+extern NSString * __nonnull const DBConstantsInterfaceUpperCaseConstant;
+/** But we should preserve weirdness in casing */
+extern int32_t const DBConstantsInterfaceXXXWeirdCase;
 
 /** Interface containing constants */
 @interface DBConstantsInterface : NSObject

--- a/test-suite/generated-src/objc/DBConstantsInterface.mm
+++ b/test-suite/generated-src/objc/DBConstantsInterface.mm
@@ -21,3 +21,7 @@ double const DBConstantsInterfaceF64Constant = 5.0;
 NSString * __nonnull const DBConstantsInterfaceStringConstant = @"string-constant";
 
 NSString * __nullable const DBConstantsInterfaceOptStringConstant = @"string-constant";
+
+NSString * __nonnull const DBConstantsInterfaceUpperCaseConstant = @"upper-case-constant";
+
+int32_t const DBConstantsInterfaceXXXWeirdCase = 1;

--- a/test-suite/generated-src/ts/test.ts
+++ b/test-suite/generated-src/ts/test.ts
@@ -379,6 +379,10 @@ export namespace ConstantsInterface {
         someString: STRING_CONSTANT
     }
     ;
+    /** An upper-case constant should be parsed correctly */
+    export const UPPER_CASE_CONSTANT = "upper-case-constant";
+    /** But we should preserve weirdness in casing */
+    export const XXXWEIRD_CASE = 1;
 }
 
 export interface /*record*/ AssortedPrimitives {

--- a/test-suite/generated-src/wasm/NativeConstantsInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeConstantsInterface.cpp
@@ -51,6 +51,8 @@ namespace {
             someString: Module.testsuite_ConstantsInterface.STRING_CONSTANT
         }
         ;
+        Module.testsuite_ConstantsInterface.UPPER_CASE_CONSTANT = "upper-case-constant";
+        Module.testsuite_ConstantsInterface.XXXWEIRD_CASE = 1;
     })
 }
 void NativeConstantsInterface::staticInitializeConstants() {


### PR DESCRIPTION
Originally, djinni idl files are meant to be written entirely in `snake_case`, and the ident style of the target would define the final result.

In practice, `CamelCase` identifiers in djinni files are preserved, so people started using them. See [examples](https://github.com/Snapchat/djinni/blob/master/test-suite/djinni/data_ref_view.djinni) [in the](https://github.com/Snapchat/djinni/blob/master/test-suite/djinni/function_prologue.djinni) [test-suite](https://github.com/Snapchat/djinni/blob/master/test-suite/djinni/single_language_interfaces.djinni).

Our own djinni files use the same convention as we use for Java/C++: `FooBar` for types and files, `fooBar` for fields, and `ALL_CAPS` for constants.

```
ExampleInterface = interface {
  exampleMethod();
  const EXAMPLE_CONSTANT: i32 = 0;
}
```

This style is certainly very common and leads to the same identifiers being generated for C++, Java and Objective-C in the general case.

Thus it appeared surprising that in this example, the constant would get translated in Objective-C as:

```
int32_t const ExampleInterfaceEXAMPLECONSTANT= 0;
```
Which is difficult to read, and doesn't adhere to standard Objective-C naming guidelines.


After the change suggested in this PR, the `EXAMPLE_CONSTANT` above gets translated as:

```
int32_t const ExampleInterfaceExampleConstant = 0;
```

Which is consistent with standard objective-c guidelines.

The final result means that for this fairly common style, the C++, Java and Objective-C identifiers are identical, except for Objective-C constants which are adjusted to be consistent with standard Objective-C guidelines.

