### PR TITLE
Revert "Allow usage of all caps identifiers in Djinni files (#58)"

### DIFF
--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -111,22 +111,7 @@ package object generatorTools {
     if (s.isEmpty) s else ", " + s
   }
   def q(s: String) = '"' + s + '"'
-
-  def leadingUpper(token: String) = {
-    if (token.isEmpty()) {
-      token
-    } else {
-      val head = token.charAt(0)
-      val tail = token.substring(1)
-      // Preserve mixed case identifiers like 'XXFoo':
-      // Convert tail to lowercase only when it is full uppercase.
-      if (tail.toUpperCase == tail) {
-        head.toUpper + tail.toLowerCase
-      } else {
-        head.toUpper + tail
-      }
-    }
-  }
+  def firstUpper(token: String) = if (token.isEmpty()) token else token.charAt(0).toUpper + token.substring(1)
 
   type IdentConverter = String => String
 
@@ -147,13 +132,13 @@ package object generatorTools {
                           enum: IdentConverter, const: IdentConverter)
 
   object IdentStyle {
-    val camelUpper = (s: String) => s.split("[-_]").map(leadingUpper).mkString
+    val camelUpper = (s: String) => s.split("[-_]").map(firstUpper).mkString
     val camelLower = (s: String) => {
       val parts = s.split('_')
-      parts.head + parts.tail.map(leadingUpper).mkString
+      parts.head + parts.tail.map(firstUpper).mkString
     }
     val underLower = (s: String) => s
-    val underUpper = (s: String) => s.split('_').map(leadingUpper).mkString("_")
+    val underUpper = (s: String) => s.split('_').map(firstUpper).mkString("_")
     val underCaps = (s: String) => s.toUpperCase
     val prefix = (prefix: String, suffix: IdentConverter) => (s: String) => prefix + suffix(s)
 

--- a/test-suite/djinni/constants.djinni
+++ b/test-suite/djinni/constants.djinni
@@ -84,10 +84,4 @@ constants_interface = interface +c {
     # No support for constant binary, list, set, map
 
     dummy();
-
-    # An upper-case constant should be parsed correctly
-    const UPPER_CASE_CONSTANT: string = "upper-case-constant";
-
-    # But we should preserve weirdness in casing
-    const XXXWeird_Case: i32 = 1;
 }

--- a/test-suite/generated-src/cpp/constants_interface.cpp
+++ b/test-suite/generated-src/cpp/constants_interface.cpp
@@ -35,7 +35,4 @@ ConstantRecord const ConstantsInterface::OBJECT_CONSTANT = ConstantRecord(
     ConstantsInterface::I32_CONSTANT /* some_integer */ ,
     ConstantsInterface::STRING_CONSTANT /* some_string */ );
 
-std::string const ConstantsInterface::UPPER_CASE_CONSTANT = {"upper-case-constant"};
-
-
 }  // namespace testsuite

--- a/test-suite/generated-src/cpp/constants_interface.hpp
+++ b/test-suite/generated-src/cpp/constants_interface.hpp
@@ -62,12 +62,6 @@ public:
 
     static ConstantRecord const OBJECT_CONSTANT;
 
-    /** An upper-case constant should be parsed correctly */
-    static std::string const UPPER_CASE_CONSTANT;
-
-    /** But we should preserve weirdness in casing */
-    static constexpr int32_t XXXWEIRD_CASE = 1;
-
     /**
      * No support for null optional constants
      * No support for optional constant records

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantsInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantsInterface.java
@@ -68,13 +68,6 @@ public abstract class ConstantsInterface {
         I32_CONSTANT /* mSomeInteger */ ,
         STRING_CONSTANT /* mSomeString */ );
 
-    /** An upper-case constant should be parsed correctly */
-    @Nonnull
-    public static final String UPPER_CASE_CONSTANT = "upper-case-constant";
-
-    /** But we should preserve weirdness in casing */
-    public static final int XXXWEIRD_CASE = 1;
-
     /**
      * No support for null optional constants
      * No support for optional constant records

--- a/test-suite/generated-src/objc/DBConstantsInterface.h
+++ b/test-suite/generated-src/objc/DBConstantsInterface.h
@@ -19,10 +19,6 @@ extern float const DBConstantsInterfaceF32Constant;
 extern double const DBConstantsInterfaceF64Constant;
 extern NSString * __nonnull const DBConstantsInterfaceStringConstant;
 extern NSString * __nullable const DBConstantsInterfaceOptStringConstant;
-/** An upper-case constant should be parsed correctly */
-extern NSString * __nonnull const DBConstantsInterfaceUpperCaseConstant;
-/** But we should preserve weirdness in casing */
-extern int32_t const DBConstantsInterfaceXXXWeirdCase;
 
 /** Interface containing constants */
 @interface DBConstantsInterface : NSObject

--- a/test-suite/generated-src/objc/DBConstantsInterface.mm
+++ b/test-suite/generated-src/objc/DBConstantsInterface.mm
@@ -21,7 +21,3 @@ double const DBConstantsInterfaceF64Constant = 5.0;
 NSString * __nonnull const DBConstantsInterfaceStringConstant = @"string-constant";
 
 NSString * __nullable const DBConstantsInterfaceOptStringConstant = @"string-constant";
-
-NSString * __nonnull const DBConstantsInterfaceUpperCaseConstant = @"upper-case-constant";
-
-int32_t const DBConstantsInterfaceXXXWeirdCase = 1;

--- a/test-suite/generated-src/ts/test.ts
+++ b/test-suite/generated-src/ts/test.ts
@@ -379,10 +379,6 @@ export namespace ConstantsInterface {
         someString: STRING_CONSTANT
     }
     ;
-    /** An upper-case constant should be parsed correctly */
-    export const UPPER_CASE_CONSTANT = "upper-case-constant";
-    /** But we should preserve weirdness in casing */
-    export const XXXWEIRD_CASE = 1;
 }
 
 export interface /*record*/ AssortedPrimitives {

--- a/test-suite/generated-src/wasm/NativeConstantsInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeConstantsInterface.cpp
@@ -51,8 +51,6 @@ namespace {
             someString: Module.testsuite_ConstantsInterface.STRING_CONSTANT
         }
         ;
-        Module.testsuite_ConstantsInterface.UPPER_CASE_CONSTANT = "upper-case-constant";
-        Module.testsuite_ConstantsInterface.XXXWEIRD_CASE = 1;
     })
 }
 void NativeConstantsInterface::staticInitializeConstants() {


### PR DESCRIPTION
This reverts commit 2ec96d39ca9768e1d5c69295f15545d7e5e6c4a2.

Revert because of side effects affecting C++ codegen. eg.

`SSL` => `Ssl`