### PR TITLE
remove log on start

### DIFF
--- a/support-lib/wasm/djinni_wasm.cpp
+++ b/support-lib/wasm/djinni_wasm.cpp
@@ -116,7 +116,7 @@ static std::string getExceptionMessage(int eptr)
 }
 
 EM_JS(void, djinni_init_wasm, (), {
-        console.log("djinni_init_wasm");
+        // console.log("djinni_init_wasm");
         Module.cppProxyFinalizerRegistry = new FinalizationRegistry(nativeRef => {
             // console.log("finalizing cpp object @" + nativeRef);
             nativeRef.nativeDestroy();


### PR DESCRIPTION
Hi,

The log is commented because not all applications need show it on console. All other logs is commented, but not the startup log message. It is commented now to maintain consistency.

