### PR TITLE
Add option to mark Obj-C symbols with "default" visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ verify the build and binary from the command line.
  - Option to generate function prologue
  - Option to omit objc helper methods
  - Option to disable exception translation in ObjC
+ - Option to mark ObjC symbols (records and constants) with `default` visibility
  - array<> type support
  - outcome<> type support
  - Protobuf type support
@@ -115,6 +116,18 @@ You can also remove the `description` method in Djinni generated classes by
 defining the `DJINNI_DISABLE_DESCRIPTION_METHODS` preprocessor symbol.
 
 These help reducing the binary size of the app slightly.
+
+### Mark ObjC symbols (records and constants) with `default` visibility
+
+You can use `--objc-default-visibility-annotation true` to mark records and
+constants with the default visibility attribute:
+
+```objc
+__attribute__((visibility("default")))
+```
+
+This ensures that they will have external linkage even when compiled with
+`-fvisibility=hidden`.
 
 ### Disable C++ exception translation in ObjC
 

--- a/src/source/Main.scala
+++ b/src/source/Main.scala
@@ -86,6 +86,7 @@ object Main {
     var objcFileIdentStyleOptional: Option[IdentConverter] = None
     var objcppNamespace: String = "djinni_generated"
     var objcBaseLibIncludePrefix: String = ""
+    var objcDefaultVisibilityAnnotation: Boolean = false
     var wasmOutFolder: Option[File] = None
     var wasmIncludePrefix: String = ""
     var wasmIncludeCppPrefix: String = ""
@@ -225,6 +226,8 @@ object Main {
         .text("Disable generating C++ -> Objective-C exception translation")
       opt[String]("objc-base-lib-include-prefix").valueName("...").foreach(x => objcBaseLibIncludePrefix = x)
         .text("The Objective-C++ base library's include path, relative to the Objective-C++ classes.")
+      opt[Boolean]("objc-default-visibility-annotation").valueName("<true/false>").foreach(x => objcDefaultVisibilityAnnotation = x)
+        .text("Mark Objective-C++ symbols with \"default\" symbol visibility.")
       note("")
       opt[File]("wasm-out").valueName("<out-folder>").foreach(x => wasmOutFolder = Some(x))
         .text("The output for the WASM bridge C++ files (Generator disabled if unspecified).")
@@ -416,6 +419,7 @@ object Main {
       objcGenProtocol,
       objcDisableClassCtor,
       objcClosedEnums,
+      objcDefaultVisibilityAnnotation,
       wasmOutFolder,
       wasmIncludePrefix,
       wasmIncludeCppPrefix,

--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -30,6 +30,8 @@ import scala.collection.parallel.immutable
 
 class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
 
+  val visibilityAnnotation = if (spec.objcDefaultVisibilityAnnotation) "__attribute__((visibility(\"default\"))) " else ""
+
   class ObjcRefs() {
     var body = mutable.TreeSet[String]()
     var header = mutable.TreeSet[String]()
@@ -109,7 +111,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
       if(i.methods.exists(_.static)) {
         val protocolHeader = "#import " + q(spec.objcIncludePrefix + marshal.headerName(ident))
         writeObjcFile(marshal.implHeaderName(ident), origin, List(protocolHeader), w => {
-          w.wl(s"@interface $self : NSObject<$self>")
+          w.wl(s"${visibilityAnnotation}@interface $self : NSObject<$self>")
           for (m <- i.methods) {
             if (m.static && m.lang.objc) {
               w.wl
@@ -128,14 +130,14 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
     writeObjcFile(marshal.headerName(ident), origin, refs.header, w => {
       for (c <- i.consts if marshal.canBeConstVariable(c)) {
         writeDoc(w, c.doc)
-        w.w(s"extern ")
+        w.w(s"${visibilityAnnotation}extern ")
         writeObjcConstVariableDecl(w, c, self)
         w.wl(s";")
       }
 
       w.wl
       writeDoc(w, doc)
-      if (useProtocol(i.ext, spec)) w.wl(s"@protocol $self <NSObject>") else w.wl(s"@interface $self : NSObject")
+      if (useProtocol(i.ext, spec)) w.wl(s"@protocol $self <NSObject>") else w.wl(s"${visibilityAnnotation}@interface $self : NSObject")
 
       for (m <- i.methods) {
         if (!m.static || (!spec.objcGenProtocol && m.lang.objc)) {
@@ -200,9 +202,9 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
       writeDoc(w, doc)
 
       if (r.derivingTypes.contains(DerivingType.NSCopying)) {
-        w.wl(s"@interface $self : NSObject<NSCopying>")
+        w.wl(s"${visibilityAnnotation}@interface $self : NSObject<NSCopying>")
       } else {
-        w.wl(s"@interface $self : NSObject")
+        w.wl(s"${visibilityAnnotation}@interface $self : NSObject")
       }
 
       def writeInitializer(sign: String, prefix: String) {
@@ -249,7 +251,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
         w.wl
         for (c <- r.consts if marshal.canBeConstVariable(c)) {
           writeDoc(w, c.doc)
-          w.w(s"extern ")
+          w.w(s"${visibilityAnnotation}extern ")
           writeObjcConstVariableDecl(w, c, noBaseSelf);
           w.wl(s";")
         }

--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -88,6 +88,7 @@ package object generatorTools {
                    objcGenProtocol: Boolean,
                    objcDisableClassCtor: Boolean,
                    objcClosedEnums: Boolean,
+                   objcDefaultVisibilityAnnotation: Boolean,
                    wasmOutFolder: Option[File],
                    wasmIncludePrefix: String,
                    wasmIncludeCppPrefix: String,


### PR DESCRIPTION
We generate dynamic frameworks from djinni-generated Obj-C code, but we compile our code with `-fvisibility=hidden`, so we need to mark djinni-generated records and constants with "default" visibility.

This PR adds a `--objc-default-visibility-annotation` option to mark records and constants with "default" visibility:

```objc
__attribute__((visibility("default")))
```

This ensures that they will have external linkage even when compiled with `-fvisibility=hidden`.