### PR TITLE
Add runtime check for calling get()/wait() in wasm code

### DIFF
--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -224,7 +224,7 @@ public:
         assert(sharedState);    // call on invalid future will trigger assertion
         std::unique_lock lk(sharedState->mutex);
 #if defined(__EMSCRIPTEN__)
-        assert(state->isReady()); // in wasm we must not block and wait
+        assert(sharedState->isReady()); // in wasm we must not block and wait
 #else
         sharedState->cv.wait(lk, [state = sharedState] {return state->isReady();});
 #endif
@@ -237,7 +237,7 @@ public:
         assert(sharedState);    // call on invalid future will trigger assertion
         std::unique_lock lk(sharedState->mutex);
 #if defined(__EMSCRIPTEN__)
-        assert(state->isReady()); // in wasm we must not block and wait
+        assert(sharedState->isReady()); // in wasm we must not block and wait
 #else
         sharedState->cv.wait(lk, [state = sharedState] {return state->isReady();});
 #endif


### PR DESCRIPTION
Wasm code cannot block and wait because it has only one thread.  This adds a runtime check to make sure when calling `get()` or `wait()` in wasm, the future is already in a ready state.