### PR TITLE
Add whenAll() and whenAny() function for C++ futures

### DIFF
--- a/test-suite/djinni/test.djinni
+++ b/test-suite/djinni/test.djinni
@@ -52,6 +52,7 @@ test_helpers = interface +c {
     static future_roundtrip(f: future<i32>): future<string>;
 
     static check_async_interface(i: async_interface): future<string>;
+    static check_async_composition(i: async_interface): future<string>;
 }
 
 # Empty record

--- a/test-suite/generated-src/cpp/test_helpers.hpp
+++ b/test-suite/generated-src/cpp/test_helpers.hpp
@@ -94,6 +94,8 @@ public:
     static ::djinni::Future<std::string> future_roundtrip(::djinni::Future<int32_t> f);
 
     static ::djinni::Future<std::string> check_async_interface(const /*not-null*/ std::shared_ptr<AsyncInterface> & i);
+
+    static ::djinni::Future<std::string> check_async_composition(const /*not-null*/ std::shared_ptr<AsyncInterface> & i);
 };
 
 }  // namespace testsuite

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
@@ -92,6 +92,9 @@ public abstract class TestHelpers {
     @Nonnull
     public static native com.snapchat.djinni.Future<String> checkAsyncInterface(@CheckForNull AsyncInterface i);
 
+    @Nonnull
+    public static native com.snapchat.djinni.Future<String> checkAsyncComposition(@CheckForNull AsyncInterface i);
+
     public static final class CppProxy extends TestHelpers
     {
         private final long nativeRef;

--- a/test-suite/generated-src/jni/NativeTestHelpers.cpp
+++ b/test-suite/generated-src/jni/NativeTestHelpers.cpp
@@ -246,4 +246,12 @@ CJNIEXPORT ::djinni::FutureAdaptor<::djinni::String>::JniType JNICALL Java_com_d
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT ::djinni::FutureAdaptor<::djinni::String>::JniType JNICALL Java_com_dropbox_djinni_test_TestHelpers_checkAsyncComposition(JNIEnv* jniEnv, jobject /*this*/, jobject j_i)
+{
+    try {
+        auto r = ::testsuite::TestHelpers::check_async_composition(::djinni_generated::NativeAsyncInterface::toCpp(jniEnv, j_i));
+        return ::djinni::release(::djinni::FutureAdaptor<::djinni::String>::fromCpp(jniEnv, std::move(r)));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 }  // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBTestHelpers+Private.mm
+++ b/test-suite/generated-src/objc/DBTestHelpers+Private.mm
@@ -231,6 +231,13 @@ static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for th
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }
 
++ (nonnull DJFuture<NSString *> *)checkAsyncComposition:(nullable id<DBAsyncInterface>)i {
+    try {
+        auto objcpp_result_ = ::testsuite::TestHelpers::check_async_composition(::djinni_generated::AsyncInterface::toCpp(i));
+        return ::djinni::FutureAdaptor<::djinni::String>::fromCpp(std::move(objcpp_result_));
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
 namespace djinni_generated {
 
 auto TestHelpers::toCpp(ObjcType objc) -> CppType

--- a/test-suite/generated-src/objc/DBTestHelpers.h
+++ b/test-suite/generated-src/objc/DBTestHelpers.h
@@ -85,4 +85,6 @@
 
 + (nonnull DJFuture<NSString *> *)checkAsyncInterface:(nullable id<DBAsyncInterface>)i;
 
++ (nonnull DJFuture<NSString *> *)checkAsyncComposition:(nullable id<DBAsyncInterface>)i;
+
 @end

--- a/test-suite/generated-src/ts/test.ts
+++ b/test-suite/generated-src/ts/test.ts
@@ -450,6 +450,7 @@ export interface TestHelpers_statics {
     getAsyncResult(): Promise<number>;
     futureRoundtrip(f: Promise<number>): Promise<string>;
     checkAsyncInterface(i: AsyncInterface): Promise<string>;
+    checkAsyncComposition(i: AsyncInterface): Promise<string>;
 }
 
 /**

--- a/test-suite/generated-src/wasm/NativeTestHelpers.cpp
+++ b/test-suite/generated-src/wasm/NativeTestHelpers.cpp
@@ -295,6 +295,16 @@ em::val NativeTestHelpers::check_async_interface(const em::val& w_i) {
         throw;
     }
 }
+em::val NativeTestHelpers::check_async_composition(const em::val& w_i) {
+    try {
+        auto r = ::testsuite::TestHelpers::check_async_composition(::djinni_generated::NativeAsyncInterface::toCpp(w_i));
+        return ::djinni::FutureAdaptor<::djinni::String>::fromCpp(std::move(r));
+    }
+    catch(const std::exception& e) {
+        djinni::djinni_throw_native_exception(e);
+        throw;
+    }
+}
 
 EMSCRIPTEN_BINDINGS(testsuite_test_helpers) {
     ::djinni::DjinniClass_<::testsuite::TestHelpers>("testsuite_TestHelpers", "testsuite.TestHelpers")
@@ -328,6 +338,7 @@ EMSCRIPTEN_BINDINGS(testsuite_test_helpers) {
         .class_function("getAsyncResult", NativeTestHelpers::get_async_result)
         .class_function("futureRoundtrip", NativeTestHelpers::future_roundtrip)
         .class_function("checkAsyncInterface", NativeTestHelpers::check_async_interface)
+        .class_function("checkAsyncComposition", NativeTestHelpers::check_async_composition)
         ;
 }
 

--- a/test-suite/generated-src/wasm/NativeTestHelpers.hpp
+++ b/test-suite/generated-src/wasm/NativeTestHelpers.hpp
@@ -51,6 +51,7 @@ struct NativeTestHelpers : ::djinni::JsInterface<::testsuite::TestHelpers, Nativ
     static em::val get_async_result();
     static em::val future_roundtrip(const em::val& w_f);
     static em::val check_async_interface(const em::val& w_i);
+    static em::val check_async_composition(const em::val& w_i);
 
 };
 

--- a/test-suite/handwritten-src/java/com/dropbox/djinni/test/AsyncTest.java
+++ b/test-suite/handwritten-src/java/com/dropbox/djinni/test/AsyncTest.java
@@ -61,6 +61,11 @@ public class AsyncTest extends TestCase {
         assertEquals(s.get(), "36");
     }
 
+    public void testFutureComposition() throws Throwable {
+        Future<String> s = TestHelpers.checkAsyncComposition(new AsyncInterfaceImpl());
+        assertEquals(s.get(), "42");
+    }
+
     public void testRx() throws Throwable {
         Future<Integer> f = TestHelpers.getAsyncResult();
         Single<Integer> s = Single.create(o -> f.then((i) -> {

--- a/test-suite/handwritten-src/js/AsyncTest.js
+++ b/test-suite/handwritten-src/js/AsyncTest.js
@@ -55,6 +55,11 @@ class AsyncTest {
         const s = await this.module.testsuite.TestHelpers.checkAsyncInterface(new AsyncInterfaceImpl());
         assertEq(s, "36");
     }
+
+    async testFutureComposition() {
+        const s = await this.module.testsuite.TestHelpers.checkAsyncComposition(new AsyncInterfaceImpl());
+        assertEq(s, "42");
+    }
 }
 
 allTests.push(AsyncTest);

--- a/test-suite/handwritten-src/objc/tests/DBAsyncTest.m
+++ b/test-suite/handwritten-src/objc/tests/DBAsyncTest.m
@@ -76,4 +76,9 @@
     XCTAssertEqualObjects([s get], @"36");
 }
 
+- (void) testFutureComposition {
+    DJFuture<NSString *> *s = [DBTestHelpers checkAsyncComposition: [[AsyncInterfaceImpl alloc] init]];
+    XCTAssertEqualObjects([s get], @"42");
+}
+
 @end

--- a/test-suite/handwritten-src/ts/AsyncTest.ts
+++ b/test-suite/handwritten-src/ts/AsyncTest.ts
@@ -61,6 +61,10 @@ class AsyncTest extends TestCase {
         const s = await this.m.testsuite.TestHelpers.checkAsyncInterface(new AsyncInterfaceImpl());
         assertEq(s, "36");
     }
+    async testFutureComposition() {
+        const s = await this.m.testsuite.TestHelpers.checkAsyncComposition(new AsyncInterfaceImpl());
+        assertEq(s, "42");
+    }
 }
 
 allTests.push(AsyncTest);


### PR DESCRIPTION
Add a few utility functions to make handling a group of futures together easier in C++

`whenAll()` returns a new future that becomes ready when all of the supplied futures are ready.
`whenAny()` returns a new future that becomes ready when the first future in the supplied futures becomes ready.