### PR TITLE
Fix calling `whenAll/whenAny` on empty future set

### DIFF
--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -330,6 +330,10 @@ Future<void> combine(U&& futures, size_t c) {
     };
     auto context = std::make_shared<Context>(c);
     auto future = context->promise.getFuture();
+    if (futures.empty()) {
+        context->promise.setValue();
+        return future;
+    }
     for (auto& f: futures) {
         f.then([context] (auto f) {
             if (--(context->counter) == 0) {


### PR DESCRIPTION
Calling `whenAll/whenAny` on empty future set causes the result future to stuck in pending state.
Fix by detecting empty future set and immediately makes the result future ready.