### PR TITLE
Fix warnings in support-lib/java

### DIFF
--- a/support-lib/java/com/snapchat/djinni/Future.java
+++ b/support-lib/java/com/snapchat/djinni/Future.java
@@ -57,10 +57,12 @@ public class Future<T> implements java.util.concurrent.Future<T> {
     }
     
     // Handler routine for type U that does not return a value
+    @FunctionalInterface
     public interface FutureHandler<U> {
         public void handleResult(Future<U> res) throws Throwable;
     }
     // Handler routine for type U that returns a value of type R
+    @FunctionalInterface
     public interface FutureHandlerWithReturn<U, R> {
         public R handleResult(Future<U> res) throws Throwable;
     }
@@ -68,7 +70,7 @@ public class Future<T> implements java.util.concurrent.Future<T> {
     private AtomicReference<SharedState<T>> _sharedState;
 
     Future(SharedState<T> state) {
-        _sharedState = new AtomicReference(state);
+        _sharedState = new AtomicReference<>(state);
     }
     // If the future is ready, then calling its `get()` method will not block.
     public boolean isReady() {
@@ -80,6 +82,10 @@ public class Future<T> implements java.util.concurrent.Future<T> {
     // Tell the future to Call the specified handler routine when it becomes
     // ready. Returns a new void future. The current future becomes invalid
     // after this call.
+    // If a class were to implement both FutureHandler and FutureHandlerWithReturn, the overload
+    // selected at runtime would be ambiguous. In practice these objects are always created using
+    // a lambda so suppress the warning.
+    @SuppressWarnings("overloads")
     public Future<Void> then (FutureHandler<T> handler) {
         final Promise<Void> nextPromise = new Promise<Void>();
         final Future<Void> nextFuture = nextPromise.getFuture();
@@ -108,6 +114,7 @@ public class Future<T> implements java.util.concurrent.Future<T> {
     // Tell the future to Call the specified handler routine when it becomes
     // ready. Returns a new future that wraps the return value of the handler
     // routine. The current future becomes invalid after this call.
+    @SuppressWarnings("overloads")
     public <R> Future<R> then (final FutureHandlerWithReturn<T, R> handler) {
         final Promise<R> nextPromise = new Promise<R>();
         final Future<R> nextFuture = nextPromise.getFuture();

--- a/support-lib/java/com/snapchat/djinni/NativeFutureHandler.java
+++ b/support-lib/java/com/snapchat/djinni/NativeFutureHandler.java
@@ -16,7 +16,7 @@
 
 package com.snapchat.djinni;
 
-public class NativeFutureHandler implements Future.FutureHandler {
+public class NativeFutureHandler<T> implements Future.FutureHandler<T> {
     private final long mNativeFunc;
     private final long mNativePromise;
     
@@ -26,8 +26,8 @@ public class NativeFutureHandler implements Future.FutureHandler {
     }
 
     @Override
-    public void handleResult(Future future) {
-        Object res = null;
+    public void handleResult(Future<T> future) {
+        T res = null;
         Throwable ex = null;
         try {
             res = future.get();

--- a/support-lib/java/com/snapchat/djinni/Outcome.java
+++ b/support-lib/java/com/snapchat/djinni/Outcome.java
@@ -35,15 +35,15 @@ public abstract class Outcome<Result, Error> {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null) return false;
-        if (!(o instanceof Outcome)) return false;
-        Outcome other = (Outcome) o;
+        if (!(o instanceof Outcome<?, ?>)) return false;
+        Outcome<?, ?> other = (Outcome<?, ?>) o;
         return match(x -> x.equals(other.resultOr(null)),
                      x -> x.equals(other.errorOrNull()));
     }
 
     @Override
     public int hashCode() {
-        Class cls = getClass();
+        Class<?> cls = getClass();
         return match(x -> Objects.hash(cls, 1, x),
                      x -> Objects.hash(cls, 0, x));
     }

--- a/support-lib/java/com/snapchat/djinni/Promise.java
+++ b/support-lib/java/com/snapchat/djinni/Promise.java
@@ -23,7 +23,7 @@ public class Promise<T> {
     private AtomicReference<SharedState<T>> _sharedState;
 
     public Promise() {
-        _sharedState = new AtomicReference(new SharedState<T>());
+        _sharedState = new AtomicReference<>(new SharedState<T>());
     }
 
     // Get a future object associated with this promise


### PR DESCRIPTION
* Future.java:83: warning: [overloads] then(FutureHandler<T>) in Future
  is potentially ambiguous with <R>then(FutureHandlerWithReturn<T,R>) in
  Future

  Since both of these are interfaces, a class could implement both and
  then the overload of `then()` to call would be ambiguous. In practice
  this would not happen as these objects are created via lambdas and the
  functional interface, so suppressed the warning.

* Future.java:71: warning: [rawtypes] found raw type: AtomicReference

  Fixed these by changing `new AtomicReference(...)` to `new
  AtomicReference<>(...)`

* NativeFutureHandler.java:19: warning: [rawtypes] found raw type:
  FutureHandler

  Added type arguments

* Outcome.java:39: warning: [rawtypes] found raw type: Outcome

  Added wildcard type arguments

* Outcome.java:46: warning: [rawtypes] found raw type: Class

  Added wildcard type argument