### PR TITLE
revert <NSObject> in generated protocols

### DIFF
--- a/examples/generated-src/objc/TXSTextboxListener.h
+++ b/examples/generated-src/objc/TXSTextboxListener.h
@@ -5,7 +5,7 @@
 #import <Foundation/Foundation.h>
 
 
-@protocol TXSTextboxListener <NSObject>
+@protocol TXSTextboxListener
 
 - (void)update:(nonnull TXSItemList *)items;
 

--- a/perftest/generated-src/objc/TXSObjectPlatform.h
+++ b/perftest/generated-src/objc/TXSObjectPlatform.h
@@ -5,7 +5,7 @@
 
 
 /** interfaces for platform Java or Objective-C objects, to be passed to C++ */
-@protocol TXSObjectPlatform <NSObject>
+@protocol TXSObjectPlatform
 
 - (void)onDone;
 

--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -135,7 +135,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
 
       w.wl
       writeDoc(w, doc)
-      if (useProtocol(i.ext, spec)) w.wl(s"@protocol $self <NSObject>") else w.wl(s"@interface $self : NSObject")
+      if (useProtocol(i.ext, spec)) w.wl(s"@protocol $self") else w.wl(s"@interface $self : NSObject")
 
       for (m <- i.methods) {
         if (!m.static || (!spec.objcGenProtocol && m.lang.objc)) {

--- a/test-suite/generated-src/objc/DBAsyncInterface.h
+++ b/test-suite/generated-src/objc/DBAsyncInterface.h
@@ -5,7 +5,7 @@
 #import <Foundation/Foundation.h>
 
 
-@protocol DBAsyncInterface <NSObject>
+@protocol DBAsyncInterface
 
 - (nonnull DJFuture<NSString *> *)futureRoundtrip:(nonnull DJFuture<NSNumber *> *)f;
 

--- a/test-suite/generated-src/objc/DBClientInterface.h
+++ b/test-suite/generated-src/objc/DBClientInterface.h
@@ -7,7 +7,7 @@
 
 
 /** Client interface */
-@protocol DBClientInterface <NSObject>
+@protocol DBClientInterface
 
 /** Returns record of given string */
 - (nonnull DBClientReturnedRecord *)getRecord:(int64_t)recordId

--- a/test-suite/generated-src/objc/DBEnumUsageInterface.h
+++ b/test-suite/generated-src/objc/DBEnumUsageInterface.h
@@ -5,7 +5,7 @@
 #import <Foundation/Foundation.h>
 
 
-@protocol DBEnumUsageInterface <NSObject>
+@protocol DBEnumUsageInterface
 
 - (DBColor)e:(DBColor)e;
 

--- a/test-suite/generated-src/objc/DBExternInterface2.h
+++ b/test-suite/generated-src/objc/DBExternInterface2.h
@@ -6,7 +6,7 @@
 #import <Foundation/Foundation.h>
 
 
-@protocol DBExternInterface2 <NSObject>
+@protocol DBExternInterface2
 
 - (nonnull DBExternRecordWithDerivings *)foo:(nullable DBTestHelpers *)i;
 

--- a/test-suite/generated-src/objc/DBFirstListener.h
+++ b/test-suite/generated-src/objc/DBFirstListener.h
@@ -5,7 +5,7 @@
 
 
 /** Used for ObjC multiple inheritance tests */
-@protocol DBFirstListener <NSObject>
+@protocol DBFirstListener
 
 - (void)first;
 

--- a/test-suite/generated-src/objc/DBObjcOnlyListener.h
+++ b/test-suite/generated-src/objc/DBObjcOnlyListener.h
@@ -4,6 +4,6 @@
 #import <Foundation/Foundation.h>
 
 
-@protocol DBObjcOnlyListener <NSObject>
+@protocol DBObjcOnlyListener
 
 @end

--- a/test-suite/generated-src/objc/DBSecondListener.h
+++ b/test-suite/generated-src/objc/DBSecondListener.h
@@ -5,7 +5,7 @@
 
 
 /** Used for ObjC multiple inheritance tests */
-@protocol DBSecondListener <NSObject>
+@protocol DBSecondListener
 
 - (void)second;
 

--- a/test-suite/generated-src/objc/DBUserToken.h
+++ b/test-suite/generated-src/objc/DBUserToken.h
@@ -4,7 +4,7 @@
 #import <Foundation/Foundation.h>
 
 
-@protocol DBUserToken <NSObject>
+@protocol DBUserToken
 
 - (nonnull NSString *)whoami;
 

--- a/test-suite/generated-src/objc/DBUsesSingleLanguageListeners.h
+++ b/test-suite/generated-src/objc/DBUsesSingleLanguageListeners.h
@@ -10,7 +10,7 @@
  * Generating and compiling this makes sure other languages don't break
  * on references to interfaces they don't need.
  */
-@protocol DBUsesSingleLanguageListeners <NSObject>
+@protocol DBUsesSingleLanguageListeners
 
 - (void)callForObjC:(nullable id<DBObjcOnlyListener>)l;
 


### PR DESCRIPTION
Revert the <NSObjet> requirement on Djinni generated ObjC protocols, based on the discussion in [this thread](https://github.com/cross-language-cpp/djinni-generator/issues/133) and consulting with iOS developers.

Basically, the lack of <NSObject> does not prevent us from achieving anything in ObjC (it just makes the user code slightly more verbose in the worst case). However, it does make the generated code considerably more difficult to consume in Swift code.