### PR TITLE
Support optional<> in ObjC containers

### DIFF
--- a/support-lib/objc/DJIMarshal+Private.h
+++ b/support-lib/objc/DJIMarshal+Private.h
@@ -233,7 +233,7 @@ public:
     using Boxed = Optional;
 
     static CppType toCpp(ObjcType obj) {
-        if (obj/* && (id)obj != [NSNull null]*/) {
+        if (obj) {
             return T::Boxed::toCpp(obj);
         } else {
             return CppType();

--- a/support-lib/objc/DJIMarshal+Private.h
+++ b/support-lib/objc/DJIMarshal+Private.h
@@ -277,7 +277,11 @@ public:
         assert(v.size() <= std::numeric_limits<NSUInteger>::max());
         auto array = [NSMutableArray arrayWithCapacity:static_cast<NSUInteger>(v.size())];
         for(const auto& value : v) {
-            [array addObject:T::Boxed::fromCpp(value)];
+            id elem = T::Boxed::fromCpp(value);
+            if (elem == nil) {
+                elem = [NSNull null];
+            }
+            [array addObject:elem];
         }
         return [array copy];
     }

--- a/support-lib/objc/DJIMarshal+Private.h
+++ b/support-lib/objc/DJIMarshal+Private.h
@@ -233,7 +233,9 @@ public:
     using Boxed = Optional;
 
     static CppType toCpp(ObjcType obj) {
-        if (obj) {
+        // In addition to nil, detect NSNull objects and convert to empty
+        // optional, too.
+        if (obj && obj != [NSNull null]) {
             return T::Boxed::toCpp(obj);
         } else {
             return CppType();
@@ -278,6 +280,8 @@ public:
         auto array = [NSMutableArray arrayWithCapacity:static_cast<NSUInteger>(v.size())];
         for(const auto& value : v) {
             id elem = T::Boxed::fromCpp(value);
+            // NSArray does not allow nil elements, so convert Nil to NSNull
+            // before adding to array.
             if (elem == nil) {
                 elem = [NSNull null];
             }

--- a/support-lib/objc/DJIMarshal+Private.h
+++ b/support-lib/objc/DJIMarshal+Private.h
@@ -267,11 +267,11 @@ template<template<class> class OptionalType, class T>
 struct ContainerElem<Optional<OptionalType, T>> {
     // check for empty optional and convert to NSNull
     static id fromCpp(const typename Optional<OptionalType, T>::CppType& opt) {
-        return opt ? Optional<OptionalType, T>::fromCpp(opt) : [NSNull null];
+        return opt ? Optional<OptionalType, T>::fromCpp(opt) : (__bridge NSNull *)kCFNull;
     }
     // check for NSNull and convert to empty optional
     static typename Optional<OptionalType, T>::CppType toCpp(typename Optional<OptionalType, T>::ObjcType obj) {
-        return (id)obj != [NSNull null] ?
+        return (id)obj != (__bridge NSNull *)kCFNull ?
             Optional<OptionalType, T>::toCpp(obj) :
             typename Optional<OptionalType, T>::CppType();
     }

--- a/test-suite/djinni/test.djinni
+++ b/test-suite/djinni/test.djinni
@@ -53,6 +53,13 @@ test_helpers = interface +c {
 
     static check_async_interface(i: async_interface): future<string>;
     static check_async_composition(i: async_interface): future<string>;
+
+    static get_optional_list(): list<optional<string>>;
+    static check_optional_list(ol: list<optional<string>>): bool;
+    static get_optional_set(): set<optional<string>>;
+    static check_optional_set(os: set<optional<string>>): bool;
+    static get_optional_map(): map<optional<string>, optional<string>>;
+    static check_optional_map(om: map<optional<string>, optional<string>>): bool;
 }
 
 # Empty record

--- a/test-suite/generated-src/cpp/test_helpers.hpp
+++ b/test-suite/generated-src/cpp/test_helpers.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace testsuite {
@@ -96,6 +97,18 @@ public:
     static ::djinni::Future<std::string> check_async_interface(const /*not-null*/ std::shared_ptr<AsyncInterface> & i);
 
     static ::djinni::Future<std::string> check_async_composition(const /*not-null*/ std::shared_ptr<AsyncInterface> & i);
+
+    static std::vector<std::experimental::optional<std::string>> get_optional_list();
+
+    static bool check_optional_list(const std::vector<std::experimental::optional<std::string>> & ol);
+
+    static std::unordered_set<std::experimental::optional<std::string>> get_optional_set();
+
+    static bool check_optional_set(const std::unordered_set<std::experimental::optional<std::string>> & os);
+
+    static std::unordered_map<std::experimental::optional<std::string>, std::experimental::optional<std::string>> get_optional_map();
+
+    static bool check_optional_map(const std::unordered_map<std::experimental::optional<std::string>, std::experimental::optional<std::string>> & om);
 };
 
 }  // namespace testsuite

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
@@ -4,7 +4,9 @@
 package com.dropbox.djinni.test;
 
 import com.snapchat.djinni.NativeObjectManager;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -94,6 +96,21 @@ public abstract class TestHelpers {
 
     @Nonnull
     public static native com.snapchat.djinni.Future<String> checkAsyncComposition(@CheckForNull AsyncInterface i);
+
+    @Nonnull
+    public static native ArrayList<String> getOptionalList();
+
+    public static native boolean checkOptionalList(@Nonnull ArrayList<String> ol);
+
+    @Nonnull
+    public static native HashSet<String> getOptionalSet();
+
+    public static native boolean checkOptionalSet(@Nonnull HashSet<String> os);
+
+    @Nonnull
+    public static native HashMap<String, String> getOptionalMap();
+
+    public static native boolean checkOptionalMap(@Nonnull HashMap<String, String> om);
 
     public static final class CppProxy extends TestHelpers
     {

--- a/test-suite/generated-src/jni/NativeTestHelpers.cpp
+++ b/test-suite/generated-src/jni/NativeTestHelpers.cpp
@@ -254,4 +254,52 @@ CJNIEXPORT ::djinni::FutureAdaptor<::djinni::String>::JniType JNICALL Java_com_d
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT jobject JNICALL Java_com_dropbox_djinni_test_TestHelpers_getOptionalList(JNIEnv* jniEnv, jobject /*this*/)
+{
+    try {
+        auto r = ::testsuite::TestHelpers::get_optional_list();
+        return ::djinni::release(::djinni::List<::djinni::Optional<std::experimental::optional, ::djinni::String>>::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
+CJNIEXPORT jboolean JNICALL Java_com_dropbox_djinni_test_TestHelpers_checkOptionalList(JNIEnv* jniEnv, jobject /*this*/, jobject j_ol)
+{
+    try {
+        auto r = ::testsuite::TestHelpers::check_optional_list(::djinni::List<::djinni::Optional<std::experimental::optional, ::djinni::String>>::toCpp(jniEnv, j_ol));
+        return ::djinni::release(::djinni::Bool::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
+CJNIEXPORT jobject JNICALL Java_com_dropbox_djinni_test_TestHelpers_getOptionalSet(JNIEnv* jniEnv, jobject /*this*/)
+{
+    try {
+        auto r = ::testsuite::TestHelpers::get_optional_set();
+        return ::djinni::release(::djinni::Set<::djinni::Optional<std::experimental::optional, ::djinni::String>>::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
+CJNIEXPORT jboolean JNICALL Java_com_dropbox_djinni_test_TestHelpers_checkOptionalSet(JNIEnv* jniEnv, jobject /*this*/, jobject j_os)
+{
+    try {
+        auto r = ::testsuite::TestHelpers::check_optional_set(::djinni::Set<::djinni::Optional<std::experimental::optional, ::djinni::String>>::toCpp(jniEnv, j_os));
+        return ::djinni::release(::djinni::Bool::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
+CJNIEXPORT jobject JNICALL Java_com_dropbox_djinni_test_TestHelpers_getOptionalMap(JNIEnv* jniEnv, jobject /*this*/)
+{
+    try {
+        auto r = ::testsuite::TestHelpers::get_optional_map();
+        return ::djinni::release(::djinni::Map<::djinni::Optional<std::experimental::optional, ::djinni::String>, ::djinni::Optional<std::experimental::optional, ::djinni::String>>::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
+CJNIEXPORT jboolean JNICALL Java_com_dropbox_djinni_test_TestHelpers_checkOptionalMap(JNIEnv* jniEnv, jobject /*this*/, jobject j_om)
+{
+    try {
+        auto r = ::testsuite::TestHelpers::check_optional_map(::djinni::Map<::djinni::Optional<std::experimental::optional, ::djinni::String>, ::djinni::Optional<std::experimental::optional, ::djinni::String>>::toCpp(jniEnv, j_om));
+        return ::djinni::release(::djinni::Bool::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 }  // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBTestHelpers+Private.mm
+++ b/test-suite/generated-src/objc/DBTestHelpers+Private.mm
@@ -238,6 +238,48 @@ static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for th
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }
 
++ (nonnull NSArray<NSString *> *)getOptionalList {
+    try {
+        auto objcpp_result_ = ::testsuite::TestHelpers::get_optional_list();
+        return ::djinni::List<::djinni::Optional<std::experimental::optional, ::djinni::String>>::fromCpp(objcpp_result_);
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
++ (BOOL)checkOptionalList:(nonnull NSArray<NSString *> *)ol {
+    try {
+        auto objcpp_result_ = ::testsuite::TestHelpers::check_optional_list(::djinni::List<::djinni::Optional<std::experimental::optional, ::djinni::String>>::toCpp(ol));
+        return ::djinni::Bool::fromCpp(objcpp_result_);
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
++ (nonnull NSSet<NSString *> *)getOptionalSet {
+    try {
+        auto objcpp_result_ = ::testsuite::TestHelpers::get_optional_set();
+        return ::djinni::Set<::djinni::Optional<std::experimental::optional, ::djinni::String>>::fromCpp(objcpp_result_);
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
++ (BOOL)checkOptionalSet:(nonnull NSSet<NSString *> *)os {
+    try {
+        auto objcpp_result_ = ::testsuite::TestHelpers::check_optional_set(::djinni::Set<::djinni::Optional<std::experimental::optional, ::djinni::String>>::toCpp(os));
+        return ::djinni::Bool::fromCpp(objcpp_result_);
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
++ (nonnull NSDictionary<NSString *, NSString *> *)getOptionalMap {
+    try {
+        auto objcpp_result_ = ::testsuite::TestHelpers::get_optional_map();
+        return ::djinni::Map<::djinni::Optional<std::experimental::optional, ::djinni::String>, ::djinni::Optional<std::experimental::optional, ::djinni::String>>::fromCpp(objcpp_result_);
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
++ (BOOL)checkOptionalMap:(nonnull NSDictionary<NSString *, NSString *> *)om {
+    try {
+        auto objcpp_result_ = ::testsuite::TestHelpers::check_optional_map(::djinni::Map<::djinni::Optional<std::experimental::optional, ::djinni::String>, ::djinni::Optional<std::experimental::optional, ::djinni::String>>::toCpp(om));
+        return ::djinni::Bool::fromCpp(objcpp_result_);
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
 namespace djinni_generated {
 
 auto TestHelpers::toCpp(ObjcType objc) -> CppType

--- a/test-suite/generated-src/objc/DBTestHelpers.h
+++ b/test-suite/generated-src/objc/DBTestHelpers.h
@@ -87,4 +87,16 @@
 
 + (nonnull DJFuture<NSString *> *)checkAsyncComposition:(nullable id<DBAsyncInterface>)i;
 
++ (nonnull NSArray<NSString *> *)getOptionalList;
+
++ (BOOL)checkOptionalList:(nonnull NSArray<NSString *> *)ol;
+
++ (nonnull NSSet<NSString *> *)getOptionalSet;
+
++ (BOOL)checkOptionalSet:(nonnull NSSet<NSString *> *)os;
+
++ (nonnull NSDictionary<NSString *, NSString *> *)getOptionalMap;
+
++ (BOOL)checkOptionalMap:(nonnull NSDictionary<NSString *, NSString *> *)om;
+
 @end

--- a/test-suite/generated-src/ts/test.ts
+++ b/test-suite/generated-src/ts/test.ts
@@ -451,6 +451,12 @@ export interface TestHelpers_statics {
     futureRoundtrip(f: Promise<number>): Promise<string>;
     checkAsyncInterface(i: AsyncInterface): Promise<string>;
     checkAsyncComposition(i: AsyncInterface): Promise<string>;
+    getOptionalList(): Array<string>;
+    checkOptionalList(ol: Array<string>): boolean;
+    getOptionalSet(): Set<string>;
+    checkOptionalSet(os: Set<string>): boolean;
+    getOptionalMap(): Map<string, string>;
+    checkOptionalMap(om: Map<string, string>): boolean;
 }
 
 /**

--- a/test-suite/generated-src/wasm/NativeTestHelpers.cpp
+++ b/test-suite/generated-src/wasm/NativeTestHelpers.cpp
@@ -305,6 +305,66 @@ em::val NativeTestHelpers::check_async_composition(const em::val& w_i) {
         throw;
     }
 }
+em::val NativeTestHelpers::get_optional_list() {
+    try {
+        auto r = ::testsuite::TestHelpers::get_optional_list();
+        return ::djinni::List<::djinni::Optional<std::experimental::optional, ::djinni::String>>::fromCpp(r);
+    }
+    catch(const std::exception& e) {
+        djinni::djinni_throw_native_exception(e);
+        throw;
+    }
+}
+bool NativeTestHelpers::check_optional_list(const em::val& w_ol) {
+    try {
+        auto r = ::testsuite::TestHelpers::check_optional_list(::djinni::List<::djinni::Optional<std::experimental::optional, ::djinni::String>>::toCpp(w_ol));
+        return ::djinni::Bool::fromCpp(r);
+    }
+    catch(const std::exception& e) {
+        djinni::djinni_throw_native_exception(e);
+        throw;
+    }
+}
+em::val NativeTestHelpers::get_optional_set() {
+    try {
+        auto r = ::testsuite::TestHelpers::get_optional_set();
+        return ::djinni::Set<::djinni::Optional<std::experimental::optional, ::djinni::String>>::fromCpp(r);
+    }
+    catch(const std::exception& e) {
+        djinni::djinni_throw_native_exception(e);
+        throw;
+    }
+}
+bool NativeTestHelpers::check_optional_set(const em::val& w_os) {
+    try {
+        auto r = ::testsuite::TestHelpers::check_optional_set(::djinni::Set<::djinni::Optional<std::experimental::optional, ::djinni::String>>::toCpp(w_os));
+        return ::djinni::Bool::fromCpp(r);
+    }
+    catch(const std::exception& e) {
+        djinni::djinni_throw_native_exception(e);
+        throw;
+    }
+}
+em::val NativeTestHelpers::get_optional_map() {
+    try {
+        auto r = ::testsuite::TestHelpers::get_optional_map();
+        return ::djinni::Map<::djinni::Optional<std::experimental::optional, ::djinni::String>, ::djinni::Optional<std::experimental::optional, ::djinni::String>>::fromCpp(r);
+    }
+    catch(const std::exception& e) {
+        djinni::djinni_throw_native_exception(e);
+        throw;
+    }
+}
+bool NativeTestHelpers::check_optional_map(const em::val& w_om) {
+    try {
+        auto r = ::testsuite::TestHelpers::check_optional_map(::djinni::Map<::djinni::Optional<std::experimental::optional, ::djinni::String>, ::djinni::Optional<std::experimental::optional, ::djinni::String>>::toCpp(w_om));
+        return ::djinni::Bool::fromCpp(r);
+    }
+    catch(const std::exception& e) {
+        djinni::djinni_throw_native_exception(e);
+        throw;
+    }
+}
 
 EMSCRIPTEN_BINDINGS(testsuite_test_helpers) {
     ::djinni::DjinniClass_<::testsuite::TestHelpers>("testsuite_TestHelpers", "testsuite.TestHelpers")
@@ -339,6 +399,12 @@ EMSCRIPTEN_BINDINGS(testsuite_test_helpers) {
         .class_function("futureRoundtrip", NativeTestHelpers::future_roundtrip)
         .class_function("checkAsyncInterface", NativeTestHelpers::check_async_interface)
         .class_function("checkAsyncComposition", NativeTestHelpers::check_async_composition)
+        .class_function("getOptionalList", NativeTestHelpers::get_optional_list)
+        .class_function("checkOptionalList", NativeTestHelpers::check_optional_list)
+        .class_function("getOptionalSet", NativeTestHelpers::get_optional_set)
+        .class_function("checkOptionalSet", NativeTestHelpers::check_optional_set)
+        .class_function("getOptionalMap", NativeTestHelpers::get_optional_map)
+        .class_function("checkOptionalMap", NativeTestHelpers::check_optional_map)
         ;
 }
 

--- a/test-suite/generated-src/wasm/NativeTestHelpers.hpp
+++ b/test-suite/generated-src/wasm/NativeTestHelpers.hpp
@@ -52,6 +52,12 @@ struct NativeTestHelpers : ::djinni::JsInterface<::testsuite::TestHelpers, Nativ
     static em::val future_roundtrip(const em::val& w_f);
     static em::val check_async_interface(const em::val& w_i);
     static em::val check_async_composition(const em::val& w_i);
+    static em::val get_optional_list();
+    static bool check_optional_list(const em::val& w_ol);
+    static em::val get_optional_set();
+    static bool check_optional_set(const em::val& w_os);
+    static em::val get_optional_map();
+    static bool check_optional_map(const em::val& w_om);
 
 };
 

--- a/test-suite/handwritten-src/cpp/test_helpers.cpp
+++ b/test-suite/handwritten-src/cpp/test_helpers.cpp
@@ -231,4 +231,36 @@ djinni::Future<std::string> TestHelpers::check_async_composition(const std::shar
     });
 }
 
+std::vector<std::experimental::optional<std::string>> TestHelpers::get_optional_list() {
+    return {std::experimental::nullopt, std::string("hello")};
+}
+
+bool TestHelpers::check_optional_list(const std::vector<std::experimental::optional<std::string>> & ol) {
+    return ol.size() == 2 &&
+        ol[0] == std::experimental::nullopt &&
+        ol[1] == std::string("hello");
+}
+
+std::unordered_set<std::experimental::optional<std::string>> TestHelpers::get_optional_set() {
+    return {std::experimental::nullopt, std::string("hello")};
+}
+
+bool TestHelpers::check_optional_set(const std::unordered_set<std::experimental::optional<std::string>> & os) {
+    return os.size() == 2 &&
+        os.find(std::experimental::nullopt) != os.end() &&
+        os.find(std::string("hello")) != os.end();
+}
+
+std::unordered_map<std::experimental::optional<std::string>, std::experimental::optional<std::string>> TestHelpers::get_optional_map() {
+    return {{std::experimental::nullopt, std::string("hello")}, {std::string("hello"), std::experimental::nullopt}};
+}
+
+bool TestHelpers::check_optional_map(const std::unordered_map<std::experimental::optional<std::string>, std::experimental::optional<std::string>> & om) {
+    auto i1 = om.find(std::experimental::nullopt);
+    auto i2 = om.find(std::string("hello"));
+    return om.size() == 2 &&
+        i1->second == std::string("hello") &&
+        i2->second == std::experimental::nullopt;
+}
+
 } // namespace testsuite

--- a/test-suite/handwritten-src/objc/tests/DBOptionalContainerTests.mm
+++ b/test-suite/handwritten-src/objc/tests/DBOptionalContainerTests.mm
@@ -1,0 +1,58 @@
+#import "DBTestHelpers.h"
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+// using namespace testsuite;
+
+@interface DBOptionalContainerTests : XCTestCase
+
+@end
+
+@implementation DBOptionalContainerTests
+
+- (void)setUp
+{
+    [super setUp];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+}
+
+- (void)testOptionalList
+{
+    NSArray<NSString *> * ol = [DBTestHelpers getOptionalList];
+    XCTAssertEqual([ol count], 2);
+    XCTAssertEqualObjects(ol[0], [NSNull null]);
+    XCTAssertEqualObjects(ol[1], @"hello");
+
+    BOOL ret = [DBTestHelpers checkOptionalList:ol];
+    XCTAssertTrue(ret);
+}
+
+- (void)testOptionalSet
+{
+    NSSet<NSString *> * os = [DBTestHelpers getOptionalSet];
+    // NSArray's interface doesn't allow us to directly check for NSNull, but we
+    // can see the count is 2
+    XCTAssertEqual([os count], 2);
+    XCTAssertTrue([os containsObject:@"hello"]);
+
+    BOOL ret = [DBTestHelpers checkOptionalSet:os];
+    XCTAssertTrue(ret);
+}
+
+- (void)testOptionalMap
+{
+    NSDictionary<NSString *, NSString *> * om = [DBTestHelpers getOptionalMap];
+    // Can't directly check for NSNull, but we will pass the same dictionary
+    // into C++ and check there.
+    XCTAssertEqual([om count], 2);
+
+    BOOL ret = [DBTestHelpers checkOptionalMap:om];
+    XCTAssertTrue(ret);
+}
+
+@end


### PR DESCRIPTION
ObjC containers (NSArray, NSSet, NSDictionary) do not allow `nil` as elements.  However, the codegen does not prevent this, so if C++ puts empty optionals in the container, it will raise as a runtime error in ObjC.

This PR detects empty optional<> in C++ containers, and converts them into `NSNull` objects before returning to ObjC. And converts `NSNull` objects back to empty optionals when they are passed from ObjC to C++.

The check is only performed in containers with optional elements, so the performance of normal containers with non-null elements are unaffected.