### PR TITLE
Translate C++ exceptions to async Errors in async functions

### DIFF
--- a/examples/generated-src/wasm/NativeSortItems.cpp
+++ b/examples/generated-src/wasm/NativeSortItems.cpp
@@ -21,8 +21,7 @@ void NativeSortItems::sort(const CppType& self, int32_t w_order,const em::val& w
              ::djinni_generated::NativeItemList::toCpp(w_items));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 em::val NativeSortItems::create_with_listener(const em::val& w_listener) {
@@ -31,8 +30,7 @@ em::val NativeSortItems::create_with_listener(const em::val& w_listener) {
         return ::djinni_generated::NativeSortItems::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeSortItems>::handleNativeException(e);
     }
 }
 em::val NativeSortItems::run_sort(const em::val& w_items) {
@@ -41,8 +39,7 @@ em::val NativeSortItems::run_sort(const em::val& w_items) {
         return ::djinni_generated::NativeItemList::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeItemList>::handleNativeException(e);
     }
 }
 

--- a/perftest/generated-src/wasm/NativeDjinniPerfBenchmark.cpp
+++ b/perftest/generated-src/wasm/NativeDjinniPerfBenchmark.cpp
@@ -47,8 +47,7 @@ em::val NativeDjinniPerfBenchmark::getInstance() {
         return ::djinni_generated::NativeDjinniPerfBenchmark::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeDjinniPerfBenchmark>::handleNativeException(e);
     }
 }
 int64_t NativeDjinniPerfBenchmark::cppTests(const CppType& self) {
@@ -57,8 +56,7 @@ int64_t NativeDjinniPerfBenchmark::cppTests(const CppType& self) {
         return ::djinni::I64::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::I64>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::baseline(const CppType& self) {
@@ -66,8 +64,7 @@ void NativeDjinniPerfBenchmark::baseline(const CppType& self) {
         self->baseline();
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argString(const CppType& self, const std::string& w_s) {
@@ -75,8 +72,7 @@ void NativeDjinniPerfBenchmark::argString(const CppType& self, const std::string
         self->argString(::djinni::String::toCpp(w_s));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argBinary(const CppType& self, const em::val& w_b) {
@@ -84,8 +80,7 @@ void NativeDjinniPerfBenchmark::argBinary(const CppType& self, const em::val& w_
         self->argBinary(::djinni::Binary::toCpp(w_b));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argDataRef(const CppType& self, const em::val& w_r) {
@@ -93,8 +88,7 @@ void NativeDjinniPerfBenchmark::argDataRef(const CppType& self, const em::val& w
         self->argDataRef(::djinni::NativeDataRef::toCpp(w_r));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argDataView(const CppType& self, const em::val& w_d) {
@@ -102,8 +96,7 @@ void NativeDjinniPerfBenchmark::argDataView(const CppType& self, const em::val& 
         self->argDataView(::djinni::NativeDataView::toCpp(w_d));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argEnumSixValue(const CppType& self, int32_t w_e) {
@@ -111,8 +104,7 @@ void NativeDjinniPerfBenchmark::argEnumSixValue(const CppType& self, int32_t w_e
         self->argEnumSixValue(::djinni_generated::NativeEnumSixValue::toCpp(w_e));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argRecordSixInt(const CppType& self, const em::val& w_r) {
@@ -120,8 +112,7 @@ void NativeDjinniPerfBenchmark::argRecordSixInt(const CppType& self, const em::v
         self->argRecordSixInt(::djinni_generated::NativeRecordSixInt::toCpp(w_r));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argListInt(const CppType& self, const em::val& w_v) {
@@ -129,8 +120,7 @@ void NativeDjinniPerfBenchmark::argListInt(const CppType& self, const em::val& w
         self->argListInt(::djinni::List<::djinni::I64>::toCpp(w_v));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argArrayInt(const CppType& self, const em::val& w_v) {
@@ -138,8 +128,7 @@ void NativeDjinniPerfBenchmark::argArrayInt(const CppType& self, const em::val& 
         self->argArrayInt(::djinni::Array<::djinni::I64>::toCpp(w_v));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argObject(const CppType& self, const em::val& w_c) {
@@ -147,8 +136,7 @@ void NativeDjinniPerfBenchmark::argObject(const CppType& self, const em::val& w_
         self->argObject(::djinni_generated::NativeObjectPlatform::toCpp(w_c));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argListObject(const CppType& self, const em::val& w_l) {
@@ -156,8 +144,7 @@ void NativeDjinniPerfBenchmark::argListObject(const CppType& self, const em::val
         self->argListObject(::djinni::List<::djinni_generated::NativeObjectPlatform>::toCpp(w_l));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argListRecord(const CppType& self, const em::val& w_l) {
@@ -165,8 +152,7 @@ void NativeDjinniPerfBenchmark::argListRecord(const CppType& self, const em::val
         self->argListRecord(::djinni::List<::djinni_generated::NativeRecordSixInt>::toCpp(w_l));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argArrayRecord(const CppType& self, const em::val& w_a) {
@@ -174,8 +160,7 @@ void NativeDjinniPerfBenchmark::argArrayRecord(const CppType& self, const em::va
         self->argArrayRecord(::djinni::List<::djinni_generated::NativeRecordSixInt>::toCpp(w_a));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 int64_t NativeDjinniPerfBenchmark::returnInt(const CppType& self, int64_t w_i) {
@@ -184,8 +169,7 @@ int64_t NativeDjinniPerfBenchmark::returnInt(const CppType& self, int64_t w_i) {
         return ::djinni::I64::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::I64>::handleNativeException(e);
     }
 }
 std::string NativeDjinniPerfBenchmark::returnString(const CppType& self, int32_t w_size) {
@@ -194,8 +178,7 @@ std::string NativeDjinniPerfBenchmark::returnString(const CppType& self, int32_t
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 em::val NativeDjinniPerfBenchmark::returnBinary(const CppType& self, int32_t w_size) {
@@ -204,8 +187,7 @@ em::val NativeDjinniPerfBenchmark::returnBinary(const CppType& self, int32_t w_s
         return ::djinni::Binary::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Binary>::handleNativeException(e);
     }
 }
 em::val NativeDjinniPerfBenchmark::returnObject(const CppType& self) {
@@ -214,8 +196,7 @@ em::val NativeDjinniPerfBenchmark::returnObject(const CppType& self) {
         return ::djinni_generated::NativeObjectNative::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeObjectNative>::handleNativeException(e);
     }
 }
 em::val NativeDjinniPerfBenchmark::returnListInt(const CppType& self, int32_t w_size) {
@@ -224,8 +205,7 @@ em::val NativeDjinniPerfBenchmark::returnListInt(const CppType& self, int32_t w_
         return ::djinni::List<::djinni::I64>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni::I64>>::handleNativeException(e);
     }
 }
 em::val NativeDjinniPerfBenchmark::returnArrayInt(const CppType& self, int32_t w_size) {
@@ -234,8 +214,7 @@ em::val NativeDjinniPerfBenchmark::returnArrayInt(const CppType& self, int32_t w
         return ::djinni::Array<::djinni::I64>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Array<::djinni::I64>>::handleNativeException(e);
     }
 }
 em::val NativeDjinniPerfBenchmark::returnListObject(const CppType& self, int32_t w_size) {
@@ -244,8 +223,7 @@ em::val NativeDjinniPerfBenchmark::returnListObject(const CppType& self, int32_t
         return ::djinni::List<::djinni_generated::NativeObjectNative>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni_generated::NativeObjectNative>>::handleNativeException(e);
     }
 }
 em::val NativeDjinniPerfBenchmark::returnListRecord(const CppType& self, int32_t w_size) {
@@ -254,8 +232,7 @@ em::val NativeDjinniPerfBenchmark::returnListRecord(const CppType& self, int32_t
         return ::djinni::List<::djinni_generated::NativeRecordSixInt>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni_generated::NativeRecordSixInt>>::handleNativeException(e);
     }
 }
 em::val NativeDjinniPerfBenchmark::returnArrayRecord(const CppType& self, int32_t w_size) {
@@ -264,8 +241,7 @@ em::val NativeDjinniPerfBenchmark::returnArrayRecord(const CppType& self, int32_
         return ::djinni::List<::djinni_generated::NativeRecordSixInt>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni_generated::NativeRecordSixInt>>::handleNativeException(e);
     }
 }
 std::string NativeDjinniPerfBenchmark::roundTripString(const CppType& self, const std::string& w_s) {
@@ -274,8 +250,7 @@ std::string NativeDjinniPerfBenchmark::roundTripString(const CppType& self, cons
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 

--- a/perftest/generated-src/wasm/NativeObjectNative.cpp
+++ b/perftest/generated-src/wasm/NativeObjectNative.cpp
@@ -17,8 +17,7 @@ void NativeObjectNative::baseline(const CppType& self) {
         self->baseline();
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 

--- a/src/source/WasmGenerator.scala
+++ b/src/source/WasmGenerator.scala
@@ -375,11 +375,8 @@ class WasmGenerator(spec: Spec) extends Generator(spec) {
               m.ret.fold()(r => w.wl(s"return ${helperClass(r.resolved)}::fromCpp(${cppMarshal.maybeMove("r", r)});"))
             }
             w.w("catch(const std::exception& e)").braced {
-              w.wl("djinni::djinni_throw_native_exception(e);");
-              // The throw line is just to let the C++ compiler know that this
-              // branch won't return a value. Execution will never reach this
-              // line as the previous line already throws in JS code.
-              w.wl("throw;");
+              val helper = if (!m.ret.isEmpty) helperClass(m.ret.get.resolved) else "void"
+              w.wl(s"return djinni::ExceptionHandlingTraits<${helper}>::handleNativeException(e);");
             }
           }
         }

--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -179,6 +179,7 @@ protected:
     }
 private:
     detail::SharedStatePtr<T> _sharedState = std::make_shared<SharedState<T>>();
+    detail::SharedStatePtr<T> _sharedStateReadOnly = _sharedState; // allow calling getFuture() after setValue()
 
     template <typename UpdateFunc>
     void updateAndCallResultHandler(UpdateFunc&& updater) {
@@ -362,7 +363,7 @@ private:
 
 template <typename T>
 Future<T> detail::PromiseBase<T>::getFuture() {
-    return Future<T>(std::atomic_load(&_sharedState));
+    return Future<T>(_sharedStateReadOnly);
 }
 
 template <typename U>

--- a/support-lib/wasm/Future_wasm.hpp
+++ b/support-lib/wasm/Future_wasm.hpp
@@ -105,4 +105,12 @@ public:
     }
 };
 
+template<typename U>
+struct ExceptionHandlingTraits<FutureAdaptor<U>> {
+    static em::val handleNativeException(const std::exception& e) {
+        auto r = FutureAdaptor<U>::NativePromiseType::reject(std::current_exception());
+        return FutureAdaptor<U>::fromCpp(std::move(r));
+    }
+};
+
 } // namespace djinni

--- a/support-lib/wasm/djinni_wasm.hpp
+++ b/support-lib/wasm/djinni_wasm.hpp
@@ -602,6 +602,30 @@ private:
 extern "C" void djinni_register_name_in_ns(const char* prefixedName, const char* namespacedName);
 extern "C" void djinni_throw_native_exception(const std::exception& e);
 
+template<typename U>
+struct DefaultInit {
+    static U get() { return U{}; }
+};
+template<>
+struct DefaultInit<em::val> {
+    static em::val get() { return em::val::undefined(); }
+};
+
+template<typename T>
+struct ExceptionHandlingTraits {
+    using R = typename T::JsType;
+    static R handleNativeException(const std::exception& e) {
+        djinni_throw_native_exception(e);
+        return DefaultInit<R>::get();
+    }
+};
+template<>
+struct ExceptionHandlingTraits<void> {
+    static void handleNativeException(const std::exception& e) {
+        djinni_throw_native_exception(e);
+    }
+};
+
 template<typename ClassType>
 class DjinniClass_ : public em::class_<ClassType> {
 public:

--- a/test-suite/djinni/test.djinni
+++ b/test-suite/djinni/test.djinni
@@ -50,6 +50,7 @@ test_helpers = interface +c {
 
     static get_async_result(): future<i32>;
     static future_roundtrip(f: future<i32>): future<string>;
+    static async_early_throw(): future<i32>;
 
     static check_async_interface(i: async_interface): future<string>;
     static check_async_composition(i: async_interface): future<string>;

--- a/test-suite/generated-src/cpp/test_helpers.hpp
+++ b/test-suite/generated-src/cpp/test_helpers.hpp
@@ -94,6 +94,8 @@ public:
 
     static ::djinni::Future<std::string> future_roundtrip(::djinni::Future<int32_t> f);
 
+    static ::djinni::Future<int32_t> async_early_throw();
+
     static ::djinni::Future<std::string> check_async_interface(const /*not-null*/ std::shared_ptr<AsyncInterface> & i);
 
     static ::djinni::Future<std::string> check_async_composition(const /*not-null*/ std::shared_ptr<AsyncInterface> & i);

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
@@ -92,6 +92,9 @@ public abstract class TestHelpers {
     public static native com.snapchat.djinni.Future<String> futureRoundtrip(@Nonnull com.snapchat.djinni.Future<Integer> f);
 
     @Nonnull
+    public static native com.snapchat.djinni.Future<Integer> asyncEarlyThrow();
+
+    @Nonnull
     public static native com.snapchat.djinni.Future<String> checkAsyncInterface(@CheckForNull AsyncInterface i);
 
     @Nonnull

--- a/test-suite/generated-src/jni/NativeTestHelpers.cpp
+++ b/test-suite/generated-src/jni/NativeTestHelpers.cpp
@@ -238,6 +238,14 @@ CJNIEXPORT ::djinni::FutureAdaptor<::djinni::String>::JniType JNICALL Java_com_d
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT ::djinni::FutureAdaptor<::djinni::I32>::JniType JNICALL Java_com_dropbox_djinni_test_TestHelpers_asyncEarlyThrow(JNIEnv* jniEnv, jobject /*this*/)
+{
+    try {
+        auto r = ::testsuite::TestHelpers::async_early_throw();
+        return ::djinni::release(::djinni::FutureAdaptor<::djinni::I32>::fromCpp(jniEnv, std::move(r)));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 CJNIEXPORT ::djinni::FutureAdaptor<::djinni::String>::JniType JNICALL Java_com_dropbox_djinni_test_TestHelpers_checkAsyncInterface(JNIEnv* jniEnv, jobject /*this*/, jobject j_i)
 {
     try {

--- a/test-suite/generated-src/objc/DBTestHelpers+Private.mm
+++ b/test-suite/generated-src/objc/DBTestHelpers+Private.mm
@@ -224,6 +224,13 @@ static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for th
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }
 
++ (nonnull DJFuture<NSNumber *> *)asyncEarlyThrow {
+    try {
+        auto objcpp_result_ = ::testsuite::TestHelpers::async_early_throw();
+        return ::djinni::FutureAdaptor<::djinni::I32>::fromCpp(std::move(objcpp_result_));
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
 + (nonnull DJFuture<NSString *> *)checkAsyncInterface:(nullable id<DBAsyncInterface>)i {
     try {
         auto objcpp_result_ = ::testsuite::TestHelpers::check_async_interface(::djinni_generated::AsyncInterface::toCpp(i));

--- a/test-suite/generated-src/objc/DBTestHelpers.h
+++ b/test-suite/generated-src/objc/DBTestHelpers.h
@@ -83,6 +83,8 @@
 
 + (nonnull DJFuture<NSString *> *)futureRoundtrip:(nonnull DJFuture<NSNumber *> *)f;
 
++ (nonnull DJFuture<NSNumber *> *)asyncEarlyThrow;
+
 + (nonnull DJFuture<NSString *> *)checkAsyncInterface:(nullable id<DBAsyncInterface>)i;
 
 + (nonnull DJFuture<NSString *> *)checkAsyncComposition:(nullable id<DBAsyncInterface>)i;

--- a/test-suite/generated-src/ts/test.ts
+++ b/test-suite/generated-src/ts/test.ts
@@ -449,6 +449,7 @@ export interface TestHelpers_statics {
     idBinary(b: Uint8Array): Uint8Array;
     getAsyncResult(): Promise<number>;
     futureRoundtrip(f: Promise<number>): Promise<string>;
+    asyncEarlyThrow(): Promise<number>;
     checkAsyncInterface(i: AsyncInterface): Promise<string>;
     checkAsyncComposition(i: AsyncInterface): Promise<string>;
     getOptionalList(): Array<string>;

--- a/test-suite/generated-src/wasm/NativeConflictUser.cpp
+++ b/test-suite/generated-src/wasm/NativeConflictUser.cpp
@@ -20,8 +20,7 @@ em::val NativeConflictUser::Conflict(const CppType& self) {
         return ::djinni_generated::NativeConflict::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeConflict>::handleNativeException(e);
     }
 }
 bool NativeConflictUser::conflict_arg(const CppType& self, const em::val& w_cs) {
@@ -30,8 +29,7 @@ bool NativeConflictUser::conflict_arg(const CppType& self, const em::val& w_cs) 
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeConstantsInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeConstantsInterface.cpp
@@ -18,8 +18,7 @@ void NativeConstantsInterface::dummy(const CppType& self) {
         self->dummy();
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeCppException.cpp
+++ b/test-suite/generated-src/wasm/NativeCppException.cpp
@@ -21,8 +21,7 @@ int32_t NativeCppException::throw_an_exception(const CppType& self) {
         return ::djinni::I32::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::I32>::handleNativeException(e);
     }
 }
 int32_t NativeCppException::call_throwing_interface(const CppType& self, const em::val& w_cb) {
@@ -31,8 +30,7 @@ int32_t NativeCppException::call_throwing_interface(const CppType& self, const e
         return ::djinni::I32::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::I32>::handleNativeException(e);
     }
 }
 std::string NativeCppException::call_throwing_and_catch(const CppType& self, const em::val& w_cb) {
@@ -41,8 +39,7 @@ std::string NativeCppException::call_throwing_and_catch(const CppType& self, con
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 em::val NativeCppException::get() {
@@ -51,8 +48,7 @@ em::val NativeCppException::get() {
         return ::djinni_generated::NativeCppException::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeCppException>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeDataRefTest.cpp
+++ b/test-suite/generated-src/wasm/NativeDataRefTest.cpp
@@ -26,8 +26,7 @@ void NativeDataRefTest::sendData(const CppType& self, const em::val& w_data) {
         self->sendData(::djinni::NativeDataRef::toCpp(w_data));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 em::val NativeDataRefTest::retriveAsBin(const CppType& self) {
@@ -36,8 +35,7 @@ em::val NativeDataRefTest::retriveAsBin(const CppType& self) {
         return ::djinni::Binary::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Binary>::handleNativeException(e);
     }
 }
 void NativeDataRefTest::sendMutableData(const CppType& self, const em::val& w_data) {
@@ -45,8 +43,7 @@ void NativeDataRefTest::sendMutableData(const CppType& self, const em::val& w_da
         self->sendMutableData(::djinni::NativeDataRef::toCpp(w_data));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 em::val NativeDataRefTest::generateData(const CppType& self) {
@@ -55,8 +52,7 @@ em::val NativeDataRefTest::generateData(const CppType& self) {
         return ::djinni::NativeDataRef::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::NativeDataRef>::handleNativeException(e);
     }
 }
 em::val NativeDataRefTest::dataFromVec(const CppType& self) {
@@ -65,8 +61,7 @@ em::val NativeDataRefTest::dataFromVec(const CppType& self) {
         return ::djinni::NativeDataRef::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::NativeDataRef>::handleNativeException(e);
     }
 }
 em::val NativeDataRefTest::dataFromStr(const CppType& self) {
@@ -75,8 +70,7 @@ em::val NativeDataRefTest::dataFromStr(const CppType& self) {
         return ::djinni::NativeDataRef::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::NativeDataRef>::handleNativeException(e);
     }
 }
 em::val NativeDataRefTest::sendDataView(const CppType& self, const em::val& w_data) {
@@ -85,8 +79,7 @@ em::val NativeDataRefTest::sendDataView(const CppType& self, const em::val& w_da
         return ::djinni::Binary::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Binary>::handleNativeException(e);
     }
 }
 em::val NativeDataRefTest::recvDataView(const CppType& self) {
@@ -95,8 +88,7 @@ em::val NativeDataRefTest::recvDataView(const CppType& self) {
         return ::djinni::NativeDataView::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::NativeDataView>::handleNativeException(e);
     }
 }
 em::val NativeDataRefTest::create() {
@@ -105,8 +97,7 @@ em::val NativeDataRefTest::create() {
         return ::djinni_generated::NativeDataRefTest::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeDataRefTest>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeEnumUsageInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeEnumUsageInterface.cpp
@@ -23,8 +23,7 @@ int32_t NativeEnumUsageInterface::e(const CppType& self, int32_t w_e) {
         return ::djinni_generated::NativeColor::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeColor>::handleNativeException(e);
     }
 }
 em::val NativeEnumUsageInterface::o(const CppType& self, const em::val& w_o) {
@@ -33,8 +32,7 @@ em::val NativeEnumUsageInterface::o(const CppType& self, const em::val& w_o) {
         return ::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeColor>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeColor>>::handleNativeException(e);
     }
 }
 em::val NativeEnumUsageInterface::l(const CppType& self, const em::val& w_l) {
@@ -43,8 +41,7 @@ em::val NativeEnumUsageInterface::l(const CppType& self, const em::val& w_l) {
         return ::djinni::List<::djinni_generated::NativeColor>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni_generated::NativeColor>>::handleNativeException(e);
     }
 }
 em::val NativeEnumUsageInterface::s(const CppType& self, const em::val& w_s) {
@@ -53,8 +50,7 @@ em::val NativeEnumUsageInterface::s(const CppType& self, const em::val& w_s) {
         return ::djinni::Set<::djinni_generated::NativeColor>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Set<::djinni_generated::NativeColor>>::handleNativeException(e);
     }
 }
 em::val NativeEnumUsageInterface::m(const CppType& self, const em::val& w_m) {
@@ -63,8 +59,7 @@ em::val NativeEnumUsageInterface::m(const CppType& self, const em::val& w_m) {
         return ::djinni::Map<::djinni_generated::NativeColor, ::djinni_generated::NativeColor>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Map<::djinni_generated::NativeColor, ::djinni_generated::NativeColor>>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeExternInterface1.cpp
+++ b/test-suite/generated-src/wasm/NativeExternInterface1.cpp
@@ -22,8 +22,7 @@ em::val NativeExternInterface1::foo(const CppType& self, const em::val& w_i) {
         return ::djinni_generated::NativeClientReturnedRecord::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeClientReturnedRecord>::handleNativeException(e);
     }
 }
 int32_t NativeExternInterface1::bar(const CppType& self, int32_t w_e) {
@@ -32,8 +31,7 @@ int32_t NativeExternInterface1::bar(const CppType& self, int32_t w_e) {
         return ::djinni_generated::NativeColor::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeColor>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeFlagRoundtrip.cpp
+++ b/test-suite/generated-src/wasm/NativeFlagRoundtrip.cpp
@@ -19,8 +19,7 @@ int32_t NativeFlagRoundtrip::roundtrip_access(int32_t w_flag) {
         return ::djinni_generated::NativeAccessFlags::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeAccessFlags>::handleNativeException(e);
     }
 }
 int32_t NativeFlagRoundtrip::roundtrip_empty(int32_t w_flag) {
@@ -29,8 +28,7 @@ int32_t NativeFlagRoundtrip::roundtrip_empty(int32_t w_flag) {
         return ::djinni_generated::NativeEmptyFlags::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeEmptyFlags>::handleNativeException(e);
     }
 }
 em::val NativeFlagRoundtrip::roundtrip_access_boxed(const em::val& w_flag) {
@@ -39,8 +37,7 @@ em::val NativeFlagRoundtrip::roundtrip_access_boxed(const em::val& w_flag) {
         return ::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeAccessFlags>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeAccessFlags>>::handleNativeException(e);
     }
 }
 em::val NativeFlagRoundtrip::roundtrip_empty_boxed(const em::val& w_flag) {
@@ -49,8 +46,7 @@ em::val NativeFlagRoundtrip::roundtrip_empty_boxed(const em::val& w_flag) {
         return ::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeEmptyFlags>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeEmptyFlags>>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeInterfaceUsingExtendedRecord.cpp
+++ b/test-suite/generated-src/wasm/NativeInterfaceUsingExtendedRecord.cpp
@@ -20,8 +20,7 @@ em::val NativeInterfaceUsingExtendedRecord::meth(const CppType& self, const em::
         return ::djinni_generated::NativeExtendedRecord::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeExtendedRecord>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeListenerCaller.cpp
+++ b/test-suite/generated-src/wasm/NativeListenerCaller.cpp
@@ -22,8 +22,7 @@ em::val NativeListenerCaller::init(const em::val& w_first_l,const em::val& w_sec
         return ::djinni_generated::NativeListenerCaller::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeListenerCaller>::handleNativeException(e);
     }
 }
 void NativeListenerCaller::callFirst(const CppType& self) {
@@ -31,8 +30,7 @@ void NativeListenerCaller::callFirst(const CppType& self) {
         self->callFirst();
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeListenerCaller::callSecond(const CppType& self) {
@@ -40,8 +38,7 @@ void NativeListenerCaller::callSecond(const CppType& self) {
         self->callSecond();
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeProtoTests.cpp
+++ b/test-suite/generated-src/wasm/NativeProtoTests.cpp
@@ -20,8 +20,7 @@ em::val NativeProtoTests::protoToStrings(const em::val& w_x) {
         return ::djinni::List<::djinni::String>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni::String>>::handleNativeException(e);
     }
 }
 em::val NativeProtoTests::stringsToProto(const em::val& w_x) {
@@ -30,8 +29,7 @@ em::val NativeProtoTests::stringsToProto(const em::val& w_x) {
         return ::djinni::Protobuf<::djinni::test::AddressBook, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','A','d','d','r','e','s','s','B','o','o','k'>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Protobuf<::djinni::test::AddressBook, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','A','d','d','r','e','s','s','B','o','o','k'>>>::handleNativeException(e);
     }
 }
 std::string NativeProtoTests::embeddedProtoToString(const em::val& w_x) {
@@ -40,8 +38,7 @@ std::string NativeProtoTests::embeddedProtoToString(const em::val& w_x) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 em::val NativeProtoTests::stringToEmbeddedProto(const std::string& w_x) {
@@ -50,8 +47,7 @@ em::val NativeProtoTests::stringToEmbeddedProto(const std::string& w_x) {
         return ::djinni_generated::NativeRecordWithEmbeddedProto::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeRecordWithEmbeddedProto>::handleNativeException(e);
     }
 }
 std::string NativeProtoTests::cppProtoToString(const em::val& w_x) {
@@ -60,8 +56,7 @@ std::string NativeProtoTests::cppProtoToString(const em::val& w_x) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 em::val NativeProtoTests::stringToCppProto(const std::string& w_x) {
@@ -70,8 +65,7 @@ em::val NativeProtoTests::stringToCppProto(const std::string& w_x) {
         return ::djinni::Protobuf<::djinni::test2::PersistingState, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','2','.','P','e','r','s','i','s','t','i','n','g','S','t','a','t','e'>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Protobuf<::djinni::test2::PersistingState, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','2','.','P','e','r','s','i','s','t','i','n','g','S','t','a','t','e'>>>::handleNativeException(e);
     }
 }
 std::string NativeProtoTests::embeddedCppProtoToString(const em::val& w_x) {
@@ -80,8 +74,7 @@ std::string NativeProtoTests::embeddedCppProtoToString(const em::val& w_x) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 em::val NativeProtoTests::stringToEmbeddedCppProto(const std::string& w_x) {
@@ -90,8 +83,7 @@ em::val NativeProtoTests::stringToEmbeddedCppProto(const std::string& w_x) {
         return ::djinni_generated::NativeRecordWithEmbeddedCppProto::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeRecordWithEmbeddedCppProto>::handleNativeException(e);
     }
 }
 em::val NativeProtoTests::protoListToStrings(const em::val& w_x) {
@@ -100,8 +92,7 @@ em::val NativeProtoTests::protoListToStrings(const em::val& w_x) {
         return ::djinni::List<::djinni::String>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni::String>>::handleNativeException(e);
     }
 }
 em::val NativeProtoTests::stringsToProtoList(const em::val& w_x) {
@@ -110,8 +101,7 @@ em::val NativeProtoTests::stringsToProtoList(const em::val& w_x) {
         return ::djinni::List<::djinni::Protobuf<::djinni::test::Person, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','P','e','r','s','o','n'>>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni::Protobuf<::djinni::test::Person, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','P','e','r','s','o','n'>>>>::handleNativeException(e);
     }
 }
 std::string NativeProtoTests::optionalProtoToString(const em::val& w_x) {
@@ -120,8 +110,7 @@ std::string NativeProtoTests::optionalProtoToString(const em::val& w_x) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 em::val NativeProtoTests::stringToOptionalProto(const std::string& w_x) {
@@ -130,8 +119,7 @@ em::val NativeProtoTests::stringToOptionalProto(const std::string& w_x) {
         return ::djinni::Optional<std::experimental::optional, ::djinni::Protobuf<::djinni::test::Person, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','P','e','r','s','o','n'>>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni::Protobuf<::djinni::test::Person, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','P','e','r','s','o','n'>>>>::handleNativeException(e);
     }
 }
 em::val NativeProtoTests::stringToProtoOutcome(const std::string& w_x) {
@@ -140,8 +128,7 @@ em::val NativeProtoTests::stringToProtoOutcome(const std::string& w_x) {
         return ::djinni::Outcome<::djinni::Protobuf<::djinni::test::Person, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','P','e','r','s','o','n'>>, ::djinni::I32>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Outcome<::djinni::Protobuf<::djinni::test::Person, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','P','e','r','s','o','n'>>, ::djinni::I32>>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeReturnOne.cpp
+++ b/test-suite/generated-src/wasm/NativeReturnOne.cpp
@@ -18,8 +18,7 @@ em::val NativeReturnOne::get_instance() {
         return ::djinni_generated::NativeReturnOne::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeReturnOne>::handleNativeException(e);
     }
 }
 int8_t NativeReturnOne::return_one(const CppType& self) {
@@ -28,8 +27,7 @@ int8_t NativeReturnOne::return_one(const CppType& self) {
         return ::djinni::I8::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::I8>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeReturnTwo.cpp
+++ b/test-suite/generated-src/wasm/NativeReturnTwo.cpp
@@ -18,8 +18,7 @@ em::val NativeReturnTwo::get_instance() {
         return ::djinni_generated::NativeReturnTwo::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeReturnTwo>::handleNativeException(e);
     }
 }
 int8_t NativeReturnTwo::return_two(const CppType& self) {
@@ -28,8 +27,7 @@ int8_t NativeReturnTwo::return_two(const CppType& self) {
         return ::djinni::I8::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::I8>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeReverseClientInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeReverseClientInterface.cpp
@@ -20,8 +20,7 @@ std::string NativeReverseClientInterface::return_str(const CppType& self) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 std::string NativeReverseClientInterface::meth_taking_interface(const CppType& self, const em::val& w_i) {
@@ -30,8 +29,7 @@ std::string NativeReverseClientInterface::meth_taking_interface(const CppType& s
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 std::string NativeReverseClientInterface::meth_taking_optional_interface(const CppType& self, const em::val& w_i) {
@@ -40,8 +38,7 @@ std::string NativeReverseClientInterface::meth_taking_optional_interface(const C
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 em::val NativeReverseClientInterface::create() {
@@ -50,8 +47,7 @@ em::val NativeReverseClientInterface::create() {
         return ::djinni_generated::NativeReverseClientInterface::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeReverseClientInterface>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeTestArray.cpp
+++ b/test-suite/generated-src/wasm/NativeTestArray.cpp
@@ -18,8 +18,7 @@ em::val NativeTestArray::testStringArray(const em::val& w_a) {
         return ::djinni::Array<::djinni::String>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Array<::djinni::String>>::handleNativeException(e);
     }
 }
 em::val NativeTestArray::testIntArray(const em::val& w_a) {
@@ -28,8 +27,7 @@ em::val NativeTestArray::testIntArray(const em::val& w_a) {
         return ::djinni::Array<::djinni::I32>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Array<::djinni::I32>>::handleNativeException(e);
     }
 }
 em::val NativeTestArray::testRecordArray(const em::val& w_a) {
@@ -38,8 +36,7 @@ em::val NativeTestArray::testRecordArray(const em::val& w_a) {
         return ::djinni::Array<::djinni_generated::NativeVec2>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Array<::djinni_generated::NativeVec2>>::handleNativeException(e);
     }
 }
 em::val NativeTestArray::testArrayOfArray(const em::val& w_a) {
@@ -48,8 +45,7 @@ em::val NativeTestArray::testArrayOfArray(const em::val& w_a) {
         return ::djinni::Array<::djinni::Array<::djinni::I32>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Array<::djinni::Array<::djinni::I32>>>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeTestDuration.cpp
+++ b/test-suite/generated-src/wasm/NativeTestDuration.cpp
@@ -18,8 +18,7 @@ std::string NativeTestDuration::hoursString(const em::val& w_dt) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 std::string NativeTestDuration::minutesString(const em::val& w_dt) {
@@ -28,8 +27,7 @@ std::string NativeTestDuration::minutesString(const em::val& w_dt) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 std::string NativeTestDuration::secondsString(const em::val& w_dt) {
@@ -38,8 +36,7 @@ std::string NativeTestDuration::secondsString(const em::val& w_dt) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 std::string NativeTestDuration::millisString(const em::val& w_dt) {
@@ -48,8 +45,7 @@ std::string NativeTestDuration::millisString(const em::val& w_dt) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 std::string NativeTestDuration::microsString(const em::val& w_dt) {
@@ -58,8 +54,7 @@ std::string NativeTestDuration::microsString(const em::val& w_dt) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 std::string NativeTestDuration::nanosString(const em::val& w_dt) {
@@ -68,8 +63,7 @@ std::string NativeTestDuration::nanosString(const em::val& w_dt) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::hours(int32_t w_count) {
@@ -78,8 +72,7 @@ em::val NativeTestDuration::hours(int32_t w_count) {
         return ::djinni::Duration<::djinni::I32, ::djinni::Duration_h>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_h>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::minutes(int32_t w_count) {
@@ -88,8 +81,7 @@ em::val NativeTestDuration::minutes(int32_t w_count) {
         return ::djinni::Duration<::djinni::I32, ::djinni::Duration_min>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_min>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::seconds(int32_t w_count) {
@@ -98,8 +90,7 @@ em::val NativeTestDuration::seconds(int32_t w_count) {
         return ::djinni::Duration<::djinni::I32, ::djinni::Duration_s>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_s>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::millis(int32_t w_count) {
@@ -108,8 +99,7 @@ em::val NativeTestDuration::millis(int32_t w_count) {
         return ::djinni::Duration<::djinni::I32, ::djinni::Duration_ms>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_ms>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::micros(int32_t w_count) {
@@ -118,8 +108,7 @@ em::val NativeTestDuration::micros(int32_t w_count) {
         return ::djinni::Duration<::djinni::I32, ::djinni::Duration_us>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_us>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::nanos(int32_t w_count) {
@@ -128,8 +117,7 @@ em::val NativeTestDuration::nanos(int32_t w_count) {
         return ::djinni::Duration<::djinni::I32, ::djinni::Duration_ns>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_ns>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::hoursf(double w_count) {
@@ -138,8 +126,7 @@ em::val NativeTestDuration::hoursf(double w_count) {
         return ::djinni::Duration<::djinni::F64, ::djinni::Duration_h>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_h>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::minutesf(double w_count) {
@@ -148,8 +135,7 @@ em::val NativeTestDuration::minutesf(double w_count) {
         return ::djinni::Duration<::djinni::F64, ::djinni::Duration_min>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_min>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::secondsf(double w_count) {
@@ -158,8 +144,7 @@ em::val NativeTestDuration::secondsf(double w_count) {
         return ::djinni::Duration<::djinni::F64, ::djinni::Duration_s>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_s>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::millisf(double w_count) {
@@ -168,8 +153,7 @@ em::val NativeTestDuration::millisf(double w_count) {
         return ::djinni::Duration<::djinni::F64, ::djinni::Duration_ms>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_ms>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::microsf(double w_count) {
@@ -178,8 +162,7 @@ em::val NativeTestDuration::microsf(double w_count) {
         return ::djinni::Duration<::djinni::F64, ::djinni::Duration_us>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_us>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::nanosf(double w_count) {
@@ -188,8 +171,7 @@ em::val NativeTestDuration::nanosf(double w_count) {
         return ::djinni::Duration<::djinni::F64, ::djinni::Duration_ns>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_ns>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::box(int64_t w_count) {
@@ -198,8 +180,7 @@ em::val NativeTestDuration::box(int64_t w_count) {
         return ::djinni::Optional<std::experimental::optional, ::djinni::Duration<::djinni::I64, ::djinni::Duration_s>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni::Duration<::djinni::I64, ::djinni::Duration_s>>>::handleNativeException(e);
     }
 }
 int64_t NativeTestDuration::unbox(const em::val& w_dt) {
@@ -208,8 +189,7 @@ int64_t NativeTestDuration::unbox(const em::val& w_dt) {
         return ::djinni::I64::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::I64>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeTestHelpers.cpp
+++ b/test-suite/generated-src/wasm/NativeTestHelpers.cpp
@@ -27,8 +27,7 @@ em::val NativeTestHelpers::get_set_record() {
         return ::djinni_generated::NativeSetRecord::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeSetRecord>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_set_record(const em::val& w_rec) {
@@ -37,8 +36,7 @@ bool NativeTestHelpers::check_set_record(const em::val& w_rec) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_primitive_list() {
@@ -47,8 +45,7 @@ em::val NativeTestHelpers::get_primitive_list() {
         return ::djinni_generated::NativePrimitiveList::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativePrimitiveList>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_primitive_list(const em::val& w_pl) {
@@ -57,8 +54,7 @@ bool NativeTestHelpers::check_primitive_list(const em::val& w_pl) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_nested_collection() {
@@ -67,8 +63,7 @@ em::val NativeTestHelpers::get_nested_collection() {
         return ::djinni_generated::NativeNestedCollection::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeNestedCollection>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_nested_collection(const em::val& w_nc) {
@@ -77,8 +72,7 @@ bool NativeTestHelpers::check_nested_collection(const em::val& w_nc) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_map() {
@@ -87,8 +81,7 @@ em::val NativeTestHelpers::get_map() {
         return ::djinni::Map<::djinni::String, ::djinni::I64>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Map<::djinni::String, ::djinni::I64>>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_map(const em::val& w_m) {
@@ -97,8 +90,7 @@ bool NativeTestHelpers::check_map(const em::val& w_m) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_empty_map() {
@@ -107,8 +99,7 @@ em::val NativeTestHelpers::get_empty_map() {
         return ::djinni::Map<::djinni::String, ::djinni::I64>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Map<::djinni::String, ::djinni::I64>>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_empty_map(const em::val& w_m) {
@@ -117,8 +108,7 @@ bool NativeTestHelpers::check_empty_map(const em::val& w_m) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_map_list_record() {
@@ -127,8 +117,7 @@ em::val NativeTestHelpers::get_map_list_record() {
         return ::djinni_generated::NativeMapListRecord::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeMapListRecord>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_map_list_record(const em::val& w_m) {
@@ -137,8 +126,7 @@ bool NativeTestHelpers::check_map_list_record(const em::val& w_m) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 void NativeTestHelpers::check_client_interface_ascii(const em::val& w_i) {
@@ -146,8 +134,7 @@ void NativeTestHelpers::check_client_interface_ascii(const em::val& w_i) {
         ::testsuite::TestHelpers::check_client_interface_ascii(::djinni_generated::NativeClientInterface::toCpp(w_i));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeTestHelpers::check_client_interface_nonascii(const em::val& w_i) {
@@ -155,8 +142,7 @@ void NativeTestHelpers::check_client_interface_nonascii(const em::val& w_i) {
         ::testsuite::TestHelpers::check_client_interface_nonascii(::djinni_generated::NativeClientInterface::toCpp(w_i));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeTestHelpers::check_client_interface_args(const em::val& w_i) {
@@ -164,8 +150,7 @@ void NativeTestHelpers::check_client_interface_args(const em::val& w_i) {
         ::testsuite::TestHelpers::check_client_interface_args(::djinni_generated::NativeClientInterface::toCpp(w_i));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeTestHelpers::check_enum_map(const em::val& w_m) {
@@ -173,8 +158,7 @@ void NativeTestHelpers::check_enum_map(const em::val& w_m) {
         ::testsuite::TestHelpers::check_enum_map(::djinni::Map<::djinni_generated::NativeColor, ::djinni::String>::toCpp(w_m));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeTestHelpers::check_enum(int32_t w_c) {
@@ -182,8 +166,7 @@ void NativeTestHelpers::check_enum(int32_t w_c) {
         ::testsuite::TestHelpers::check_enum(::djinni_generated::NativeColor::toCpp(w_c));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::token_id(const em::val& w_t) {
@@ -192,8 +175,7 @@ em::val NativeTestHelpers::token_id(const em::val& w_t) {
         return ::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeUserToken>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeUserToken>>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::create_cpp_token() {
@@ -202,8 +184,7 @@ em::val NativeTestHelpers::create_cpp_token() {
         return ::djinni_generated::NativeUserToken::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeUserToken>::handleNativeException(e);
     }
 }
 void NativeTestHelpers::check_cpp_token(const em::val& w_t) {
@@ -211,8 +192,7 @@ void NativeTestHelpers::check_cpp_token(const em::val& w_t) {
         ::testsuite::TestHelpers::check_cpp_token(::djinni_generated::NativeUserToken::toCpp(w_t));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 int64_t NativeTestHelpers::cpp_token_id(const em::val& w_t) {
@@ -221,8 +201,7 @@ int64_t NativeTestHelpers::cpp_token_id(const em::val& w_t) {
         return ::djinni::I64::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::I64>::handleNativeException(e);
     }
 }
 void NativeTestHelpers::check_token_type(const em::val& w_t,const std::string& w_type) {
@@ -231,8 +210,7 @@ void NativeTestHelpers::check_token_type(const em::val& w_t,const std::string& w
                          ::djinni::String::toCpp(w_type));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::return_none() {
@@ -241,8 +219,7 @@ em::val NativeTestHelpers::return_none() {
         return ::djinni::Optional<std::experimental::optional, ::djinni::I32>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni::I32>>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::assorted_primitives_id(const em::val& w_i) {
@@ -251,8 +228,7 @@ em::val NativeTestHelpers::assorted_primitives_id(const em::val& w_i) {
         return ::djinni_generated::NativeAssortedPrimitives::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeAssortedPrimitives>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::id_binary(const em::val& w_b) {
@@ -261,8 +237,7 @@ em::val NativeTestHelpers::id_binary(const em::val& w_b) {
         return ::djinni::Binary::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Binary>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_async_result() {
@@ -271,8 +246,7 @@ em::val NativeTestHelpers::get_async_result() {
         return ::djinni::FutureAdaptor<::djinni::I32>::fromCpp(std::move(r));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::I32>>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::future_roundtrip(const em::val& w_f) {
@@ -281,8 +255,16 @@ em::val NativeTestHelpers::future_roundtrip(const em::val& w_f) {
         return ::djinni::FutureAdaptor<::djinni::String>::fromCpp(std::move(r));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::String>>::handleNativeException(e);
+    }
+}
+em::val NativeTestHelpers::async_early_throw() {
+    try {
+        auto r = ::testsuite::TestHelpers::async_early_throw();
+        return ::djinni::FutureAdaptor<::djinni::I32>::fromCpp(std::move(r));
+    }
+    catch(const std::exception& e) {
+        return djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::I32>>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::check_async_interface(const em::val& w_i) {
@@ -291,8 +273,7 @@ em::val NativeTestHelpers::check_async_interface(const em::val& w_i) {
         return ::djinni::FutureAdaptor<::djinni::String>::fromCpp(std::move(r));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::String>>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::check_async_composition(const em::val& w_i) {
@@ -301,8 +282,7 @@ em::val NativeTestHelpers::check_async_composition(const em::val& w_i) {
         return ::djinni::FutureAdaptor<::djinni::String>::fromCpp(std::move(r));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::String>>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_optional_list() {
@@ -311,8 +291,7 @@ em::val NativeTestHelpers::get_optional_list() {
         return ::djinni::List<::djinni::Optional<std::experimental::optional, ::djinni::String>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni::Optional<std::experimental::optional, ::djinni::String>>>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_optional_list(const em::val& w_ol) {
@@ -321,8 +300,7 @@ bool NativeTestHelpers::check_optional_list(const em::val& w_ol) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_optional_set() {
@@ -331,8 +309,7 @@ em::val NativeTestHelpers::get_optional_set() {
         return ::djinni::Set<::djinni::Optional<std::experimental::optional, ::djinni::String>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Set<::djinni::Optional<std::experimental::optional, ::djinni::String>>>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_optional_set(const em::val& w_os) {
@@ -341,8 +318,7 @@ bool NativeTestHelpers::check_optional_set(const em::val& w_os) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_optional_map() {
@@ -351,8 +327,7 @@ em::val NativeTestHelpers::get_optional_map() {
         return ::djinni::Map<::djinni::Optional<std::experimental::optional, ::djinni::String>, ::djinni::Optional<std::experimental::optional, ::djinni::String>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Map<::djinni::Optional<std::experimental::optional, ::djinni::String>, ::djinni::Optional<std::experimental::optional, ::djinni::String>>>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_optional_map(const em::val& w_om) {
@@ -361,8 +336,7 @@ bool NativeTestHelpers::check_optional_map(const em::val& w_om) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 
@@ -397,6 +371,7 @@ EMSCRIPTEN_BINDINGS(testsuite_test_helpers) {
         .class_function("idBinary", NativeTestHelpers::id_binary)
         .class_function("getAsyncResult", NativeTestHelpers::get_async_result)
         .class_function("futureRoundtrip", NativeTestHelpers::future_roundtrip)
+        .class_function("asyncEarlyThrow", NativeTestHelpers::async_early_throw)
         .class_function("checkAsyncInterface", NativeTestHelpers::check_async_interface)
         .class_function("checkAsyncComposition", NativeTestHelpers::check_async_composition)
         .class_function("getOptionalList", NativeTestHelpers::get_optional_list)

--- a/test-suite/generated-src/wasm/NativeTestHelpers.hpp
+++ b/test-suite/generated-src/wasm/NativeTestHelpers.hpp
@@ -50,6 +50,7 @@ struct NativeTestHelpers : ::djinni::JsInterface<::testsuite::TestHelpers, Nativ
     static em::val id_binary(const em::val& w_b);
     static em::val get_async_result();
     static em::val future_roundtrip(const em::val& w_f);
+    static em::val async_early_throw();
     static em::val check_async_interface(const em::val& w_i);
     static em::val check_async_composition(const em::val& w_i);
     static em::val get_optional_list();

--- a/test-suite/generated-src/wasm/NativeTestOutcome.cpp
+++ b/test-suite/generated-src/wasm/NativeTestOutcome.cpp
@@ -19,8 +19,7 @@ em::val NativeTestOutcome::getSuccessOutcome() {
         return ::djinni::Outcome<::djinni::String, ::djinni::I32>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Outcome<::djinni::String, ::djinni::I32>>::handleNativeException(e);
     }
 }
 em::val NativeTestOutcome::getErrorOutcome() {
@@ -29,8 +28,7 @@ em::val NativeTestOutcome::getErrorOutcome() {
         return ::djinni::Outcome<::djinni::String, ::djinni::I32>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Outcome<::djinni::String, ::djinni::I32>>::handleNativeException(e);
     }
 }
 std::string NativeTestOutcome::putSuccessOutcome(const em::val& w_x) {
@@ -39,8 +37,7 @@ std::string NativeTestOutcome::putSuccessOutcome(const em::val& w_x) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 int32_t NativeTestOutcome::putErrorOutcome(const em::val& w_x) {
@@ -49,8 +46,7 @@ int32_t NativeTestOutcome::putErrorOutcome(const em::val& w_x) {
         return ::djinni::I32::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::I32>::handleNativeException(e);
     }
 }
 em::val NativeTestOutcome::getNestedSuccessOutcome() {
@@ -59,8 +55,7 @@ em::val NativeTestOutcome::getNestedSuccessOutcome() {
         return ::djinni_generated::NativeNestedOutcome::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeNestedOutcome>::handleNativeException(e);
     }
 }
 em::val NativeTestOutcome::getNestedErrorOutcome() {
@@ -69,8 +64,7 @@ em::val NativeTestOutcome::getNestedErrorOutcome() {
         return ::djinni_generated::NativeNestedOutcome::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeNestedOutcome>::handleNativeException(e);
     }
 }
 int32_t NativeTestOutcome::putNestedSuccessOutcome(const em::val& w_x) {
@@ -79,8 +73,7 @@ int32_t NativeTestOutcome::putNestedSuccessOutcome(const em::val& w_x) {
         return ::djinni::I32::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::I32>::handleNativeException(e);
     }
 }
 std::string NativeTestOutcome::putNestedErrorOutcome(const em::val& w_x) {
@@ -89,8 +82,7 @@ std::string NativeTestOutcome::putNestedErrorOutcome(const em::val& w_x) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeUserToken.cpp
+++ b/test-suite/generated-src/wasm/NativeUserToken.cpp
@@ -18,8 +18,7 @@ std::string NativeUserToken::whoami(const CppType& self) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeUsesSingleLanguageListeners.cpp
+++ b/test-suite/generated-src/wasm/NativeUsesSingleLanguageListeners.cpp
@@ -22,8 +22,7 @@ void NativeUsesSingleLanguageListeners::callForObjC(const CppType& self, const e
         self->callForObjC(::djinni_generated::NativeObjcOnlyListener::toCpp(w_l));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 em::val NativeUsesSingleLanguageListeners::returnForObjC(const CppType& self) {
@@ -32,8 +31,7 @@ em::val NativeUsesSingleLanguageListeners::returnForObjC(const CppType& self) {
         return ::djinni_generated::NativeObjcOnlyListener::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeObjcOnlyListener>::handleNativeException(e);
     }
 }
 void NativeUsesSingleLanguageListeners::callForJava(const CppType& self, const em::val& w_l) {
@@ -41,8 +39,7 @@ void NativeUsesSingleLanguageListeners::callForJava(const CppType& self, const e
         self->callForJava(::djinni_generated::NativeJavaOnlyListener::toCpp(w_l));
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 em::val NativeUsesSingleLanguageListeners::returnForJava(const CppType& self) {
@@ -51,8 +48,7 @@ em::val NativeUsesSingleLanguageListeners::returnForJava(const CppType& self) {
         return ::djinni_generated::NativeJavaOnlyListener::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeJavaOnlyListener>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeVarnameInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeVarnameInterface.cpp
@@ -20,8 +20,7 @@ em::val NativeVarnameInterface::_rmethod_(const CppType& self, const em::val& w_
         return ::djinni_generated::NativeVarnameRecord::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeVarnameRecord>::handleNativeException(e);
     }
 }
 em::val NativeVarnameInterface::_imethod_(const CppType& self, const em::val& w__i_arg_) {
@@ -30,8 +29,7 @@ em::val NativeVarnameInterface::_imethod_(const CppType& self, const em::val& w_
         return ::djinni_generated::NativeVarnameInterface::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeVarnameInterface>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeWcharTestHelpers.cpp
+++ b/test-suite/generated-src/wasm/NativeWcharTestHelpers.cpp
@@ -18,8 +18,7 @@ em::val NativeWcharTestHelpers::get_record() {
         return ::djinni_generated::NativeWcharTestRec::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeWcharTestRec>::handleNativeException(e);
     }
 }
 std::wstring NativeWcharTestHelpers::get_string() {
@@ -28,8 +27,7 @@ std::wstring NativeWcharTestHelpers::get_string() {
         return ::djinni::WString::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::WString>::handleNativeException(e);
     }
 }
 bool NativeWcharTestHelpers::check_string(const std::wstring& w_str) {
@@ -38,8 +36,7 @@ bool NativeWcharTestHelpers::check_string(const std::wstring& w_str) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 bool NativeWcharTestHelpers::check_record(const em::val& w_rec) {
@@ -48,8 +45,7 @@ bool NativeWcharTestHelpers::check_record(const em::val& w_rec) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        djinni::djinni_throw_native_exception(e);
-        throw;
+        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 

--- a/test-suite/handwritten-src/cpp/test_helpers.cpp
+++ b/test-suite/handwritten-src/cpp/test_helpers.cpp
@@ -189,6 +189,10 @@ djinni::Future<int32_t> TestHelpers::get_async_result() {
     return f;
 }
 
+djinni::Future<int32_t> TestHelpers::async_early_throw() {
+    throw std::runtime_error("error");
+}
+
 djinni::Future<std::string> TestHelpers::future_roundtrip(djinni::Future<int32_t> f) {
     return f.then([] (djinni::Future<int32_t> f) {
         return std::to_string(f.get());

--- a/test-suite/handwritten-src/js/AsyncTest.js
+++ b/test-suite/handwritten-src/js/AsyncTest.js
@@ -60,6 +60,17 @@ class AsyncTest {
         const s = await this.module.testsuite.TestHelpers.checkAsyncComposition(new AsyncInterfaceImpl());
         assertEq(s, "42");
     }
+
+    async testEarlyThrow() {
+        const r = this.module.testsuite.TestHelpers.asyncEarlyThrow();
+        let s = null;
+        try {
+            await r;
+        } catch (e) {
+            s = e.message;
+        }
+        assertEq(s, "error");
+    }
 }
 
 allTests.push(AsyncTest);

--- a/test-suite/handwritten-src/ts/AsyncTest.ts
+++ b/test-suite/handwritten-src/ts/AsyncTest.ts
@@ -65,6 +65,17 @@ class AsyncTest extends TestCase {
         const s = await this.m.testsuite.TestHelpers.checkAsyncComposition(new AsyncInterfaceImpl());
         assertEq(s, "42");
     }
+
+    async testEarlyThrow() {
+        const r = this.m.testsuite.TestHelpers.asyncEarlyThrow();
+        let s = null;
+        try {
+            await r;
+        } catch (e: any) {
+            s = e.message;
+        }
+        assertEq(s, "error");
+    }
 }
 
 allTests.push(AsyncTest);


### PR DESCRIPTION
Change the codegen for wasm function stubs from:
```
    try {
        auto r = call_into_wasm_implementation_method(...);
        return ::djinni::TranslatorClass<...>::fromCpp(std::move(r));
    }
    catch(const std::exception& e) {
        djinni::djinni_throw_native_exception(e);
        throw;
    }
```
to
```
    try {
        auto r = call_into_wasm_implementation_method(...);
        return ::djinni::TranslatorClass<...>::fromCpp(std::move(r));
    }
    catch(const std::exception& e) {
        return djinni::ExceptionHandlingTraits<::djinni::TranslatorClass<...>>::handleNativeException(e);
    }
```

Add new type `ExceptionHandlingTraits` in wasm support library.  The default implementation is calling `djinni_throw_native_exception(e)` like before.

Specialize `ExceptionHandlingTraits` in the Future translator to return the error as a rejected JS promise:
```
        auto r = FutureAdaptor<U>::NativePromiseType::reject(std::current_exception());
        return FutureAdaptor<U>::fromCpp(std::move(r));
```

This addresses https://github.com/Snapchat/djinni/issues/101

New test cases are added to verify this works as expected.