### PR TITLE
[build] set build tools version in bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,7 +9,8 @@ djinni_setup_deps()
 
 # --- Everything below is only used for examples and tests
 
-android_sdk_repository(name = "androidsdk")
+# android_sdk_repository fails to find build_tools if we don't explicitly set a version.
+android_sdk_repository(name = "androidsdk", build_tools_version = "32.0.0")
 android_ndk_repository(name = "androidndk", api_level = 21)
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")


### PR DESCRIPTION
We've had a few people hit errors locally because sometimes android_sdk_repository won't find build-tools unless you explicitly set a version.