### PR TITLE
Simplify nested namespaces codegen

### DIFF
--- a/examples/generated-src/cpp/item_list.hpp
+++ b/examples/generated-src/cpp/item_list.hpp
@@ -18,4 +18,4 @@ struct ItemList final {
     {}
 };
 
-}  // namespace textsort
+} // namespace textsort

--- a/examples/generated-src/cpp/sort_items.hpp
+++ b/examples/generated-src/cpp/sort_items.hpp
@@ -24,4 +24,4 @@ public:
     static ItemList run_sort(const ItemList & items);
 };
 
-}  // namespace textsort
+} // namespace textsort

--- a/examples/generated-src/cpp/sort_order.hpp
+++ b/examples/generated-src/cpp/sort_order.hpp
@@ -22,7 +22,7 @@ constexpr const char* to_string(sort_order e) noexcept {
     return names[static_cast<int>(e)];
 }
 
-}  // namespace textsort
+} // namespace textsort
 
 namespace std {
 
@@ -33,4 +33,4 @@ struct hash<::textsort::sort_order> {
     }
 };
 
-}  // namespace std
+} // namespace std

--- a/examples/generated-src/cpp/textbox_listener.hpp
+++ b/examples/generated-src/cpp/textbox_listener.hpp
@@ -14,4 +14,4 @@ public:
     virtual void update(const ItemList & items) = 0;
 };
 
-}  // namespace textsort
+} // namespace textsort

--- a/examples/generated-src/jni/NativeItemList.cpp
+++ b/examples/generated-src/jni/NativeItemList.cpp
@@ -25,4 +25,4 @@ auto NativeItemList::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
     return {::djinni::List<::djinni::String>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mItems))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/examples/generated-src/jni/NativeItemList.hpp
+++ b/examples/generated-src/jni/NativeItemList.hpp
@@ -29,4 +29,4 @@ private:
     const jfieldID field_mItems { ::djinni::jniGetFieldID(clazz.get(), "mItems", "Ljava/util/ArrayList;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/examples/generated-src/jni/NativeSortItems.cpp
+++ b/examples/generated-src/jni/NativeSortItems.cpp
@@ -45,4 +45,4 @@ CJNIEXPORT jobject JNICALL Java_com_dropbox_textsort_SortItems_runSort(JNIEnv* j
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/examples/generated-src/jni/NativeSortItems.hpp
+++ b/examples/generated-src/jni/NativeSortItems.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/examples/generated-src/jni/NativeSortOrder.hpp
+++ b/examples/generated-src/jni/NativeSortOrder.hpp
@@ -23,4 +23,4 @@ private:
     friend ::djinni::JniClass<NativeSortOrder>;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/examples/generated-src/jni/NativeTextboxListener.cpp
+++ b/examples/generated-src/jni/NativeTextboxListener.cpp
@@ -23,4 +23,4 @@ void NativeTextboxListener::JavaProxy::update(const ::textsort::ItemList & c_ite
     ::djinni::jniExceptionCheck(jniEnv);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/examples/generated-src/jni/NativeTextboxListener.hpp
+++ b/examples/generated-src/jni/NativeTextboxListener.hpp
@@ -43,4 +43,4 @@ private:
     const jmethodID method_update { ::djinni::jniGetMethodID(clazz.get(), "update", "(Lcom/dropbox/textsort/ItemList;)V") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/examples/generated-src/objc/TXSItemList+Private.h
+++ b/examples/generated-src/objc/TXSItemList+Private.h
@@ -21,4 +21,4 @@ struct ItemList
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/examples/generated-src/objc/TXSItemList+Private.mm
+++ b/examples/generated-src/objc/TXSItemList+Private.mm
@@ -18,4 +18,4 @@ auto ItemList::fromCpp(const CppType& cpp) -> ObjcType
     return [[TXSItemList alloc] initWithItems:(::djinni::List<::djinni::String>::fromCpp(cpp.items))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/examples/generated-src/objc/TXSSortItems+Private.h
+++ b/examples/generated-src/objc/TXSSortItems+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/examples/generated-src/objc/TXSSortItems+Private.mm
+++ b/examples/generated-src/objc/TXSSortItems+Private.mm
@@ -72,6 +72,6 @@ auto SortItems::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<TXSSortItems>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/examples/generated-src/objc/TXSTextboxListener+Private.h
+++ b/examples/generated-src/objc/TXSTextboxListener+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/examples/generated-src/objc/TXSTextboxListener+Private.mm
+++ b/examples/generated-src/objc/TXSTextboxListener+Private.mm
@@ -26,7 +26,7 @@ public:
     }
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 namespace djinni_generated {
 
@@ -46,4 +46,4 @@ auto TextboxListener::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return dynamic_cast<ObjcProxy&>(*cpp).djinni_private_get_proxied_objc_object();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/examples/generated-src/wasm/NativeItemList.cpp
+++ b/examples/generated-src/wasm/NativeItemList.cpp
@@ -14,4 +14,4 @@ auto NativeItemList::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/examples/generated-src/wasm/NativeItemList.hpp
+++ b/examples/generated-src/wasm/NativeItemList.hpp
@@ -18,4 +18,4 @@ struct NativeItemList
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/examples/generated-src/wasm/NativeSortItems.cpp
+++ b/examples/generated-src/wasm/NativeSortItems.cpp
@@ -53,4 +53,4 @@ EMSCRIPTEN_BINDINGS(textsort_sort_items) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/examples/generated-src/wasm/NativeSortItems.hpp
+++ b/examples/generated-src/wasm/NativeSortItems.hpp
@@ -29,4 +29,4 @@ struct NativeSortItems : ::djinni::JsInterface<::textsort::SortItems, NativeSort
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/examples/generated-src/wasm/NativeSortOrder.cpp
+++ b/examples/generated-src/wasm/NativeSortOrder.cpp
@@ -27,4 +27,4 @@ EMSCRIPTEN_BINDINGS(textsort_sort_order) {
     NativeSortOrder::staticInitializeConstants();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/examples/generated-src/wasm/NativeSortOrder.hpp
+++ b/examples/generated-src/wasm/NativeSortOrder.hpp
@@ -12,4 +12,4 @@ struct NativeSortOrder: ::djinni::WasmEnum<::textsort::sort_order> {
     static void staticInitializeConstants();
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/examples/generated-src/wasm/NativeTextboxListener.cpp
+++ b/examples/generated-src/wasm/NativeTextboxListener.cpp
@@ -19,4 +19,4 @@ EMSCRIPTEN_BINDINGS(textsort_textbox_listener) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/examples/generated-src/wasm/NativeTextboxListener.hpp
+++ b/examples/generated-src/wasm/NativeTextboxListener.hpp
@@ -28,4 +28,4 @@ struct NativeTextboxListener : ::djinni::JsInterface<::textsort::TextboxListener
     };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/cpp/EnumSixValue.hpp
+++ b/perftest/generated-src/cpp/EnumSixValue.hpp
@@ -5,7 +5,7 @@
 
 #include <functional>
 
-namespace snapchat { namespace djinni { namespace benchmark {
+namespace snapchat::djinni::benchmark {
 
 enum class EnumSixValue : int {
     FIRST = 0,
@@ -28,7 +28,7 @@ constexpr const char* to_string(EnumSixValue e) noexcept {
     return names[static_cast<int>(e)];
 }
 
-} } }  // namespace snapchat::djinni::benchmark
+} // namespace snapchat::djinni::benchmark
 
 namespace std {
 
@@ -39,4 +39,4 @@ struct hash<::snapchat::djinni::benchmark::EnumSixValue> {
     }
 };
 
-}  // namespace std
+} // namespace std

--- a/perftest/generated-src/cpp/ObjectNative.hpp
+++ b/perftest/generated-src/cpp/ObjectNative.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-namespace snapchat { namespace djinni { namespace benchmark {
+namespace snapchat::djinni::benchmark {
 
 /** interfaces for native C++ objects, to be returned from C++ */
 class ObjectNative {
@@ -13,4 +13,4 @@ public:
     virtual void baseline() = 0;
 };
 
-} } }  // namespace snapchat::djinni::benchmark
+} // namespace snapchat::djinni::benchmark

--- a/perftest/generated-src/cpp/ObjectPlatform.hpp
+++ b/perftest/generated-src/cpp/ObjectPlatform.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-namespace snapchat { namespace djinni { namespace benchmark {
+namespace snapchat::djinni::benchmark {
 
 /** interfaces for platform Java or Objective-C objects, to be passed to C++ */
 class ObjectPlatform {
@@ -13,4 +13,4 @@ public:
     virtual void onDone() = 0;
 };
 
-} } }  // namespace snapchat::djinni::benchmark
+} // namespace snapchat::djinni::benchmark

--- a/perftest/generated-src/cpp/RecordSixInt.hpp
+++ b/perftest/generated-src/cpp/RecordSixInt.hpp
@@ -6,7 +6,7 @@
 #include <cstdint>
 #include <utility>
 
-namespace snapchat { namespace djinni { namespace benchmark {
+namespace snapchat::djinni::benchmark {
 
 struct RecordSixInt final {
     int64_t i1;
@@ -31,4 +31,4 @@ struct RecordSixInt final {
     {}
 };
 
-} } }  // namespace snapchat::djinni::benchmark
+} // namespace snapchat::djinni::benchmark

--- a/perftest/generated-src/cpp/djinni_perf_benchmark.hpp
+++ b/perftest/generated-src/cpp/djinni_perf_benchmark.hpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-namespace snapchat { namespace djinni { namespace benchmark {
+namespace snapchat::djinni::benchmark {
 
 class ObjectNative;
 class ObjectPlatform;
@@ -73,4 +73,4 @@ public:
     virtual std::string roundTripString(const std::string & s) = 0;
 };
 
-} } }  // namespace snapchat::djinni::benchmark
+} // namespace snapchat::djinni::benchmark

--- a/perftest/generated-src/jni/NativeDjinniPerfBenchmark.cpp
+++ b/perftest/generated-src/jni/NativeDjinniPerfBenchmark.cpp
@@ -235,4 +235,4 @@ CJNIEXPORT jstring JNICALL Java_com_snapchat_djinni_benchmark_DjinniPerfBenchmar
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/jni/NativeDjinniPerfBenchmark.hpp
+++ b/perftest/generated-src/jni/NativeDjinniPerfBenchmark.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/jni/NativeEnumSixValue.hpp
+++ b/perftest/generated-src/jni/NativeEnumSixValue.hpp
@@ -23,4 +23,4 @@ private:
     friend ::djinni::JniClass<NativeEnumSixValue>;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/jni/NativeObjectNative.cpp
+++ b/perftest/generated-src/jni/NativeObjectNative.cpp
@@ -25,4 +25,4 @@ CJNIEXPORT void JNICALL Java_com_snapchat_djinni_benchmark_ObjectNative_00024Cpp
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/jni/NativeObjectNative.hpp
+++ b/perftest/generated-src/jni/NativeObjectNative.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/jni/NativeObjectPlatform.cpp
+++ b/perftest/generated-src/jni/NativeObjectPlatform.cpp
@@ -21,4 +21,4 @@ void NativeObjectPlatform::JavaProxy::onDone() {
     ::djinni::jniExceptionCheck(jniEnv);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/jni/NativeObjectPlatform.hpp
+++ b/perftest/generated-src/jni/NativeObjectPlatform.hpp
@@ -43,4 +43,4 @@ private:
     const jmethodID method_onDone { ::djinni::jniGetMethodID(clazz.get(), "onDone", "()V") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/jni/NativeRecordSixInt.cpp
+++ b/perftest/generated-src/jni/NativeRecordSixInt.cpp
@@ -35,4 +35,4 @@ auto NativeRecordSixInt::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
             ::djinni::I64::toCpp(jniEnv, jniEnv->GetLongField(j, data.field_mI6))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/jni/NativeRecordSixInt.hpp
+++ b/perftest/generated-src/jni/NativeRecordSixInt.hpp
@@ -34,4 +34,4 @@ private:
     const jfieldID field_mI6 { ::djinni::jniGetFieldID(clazz.get(), "mI6", "J") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/objc/TXSDjinniPerfBenchmark+Private.h
+++ b/perftest/generated-src/objc/TXSDjinniPerfBenchmark+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/perftest/generated-src/objc/TXSDjinniPerfBenchmark+Private.mm
+++ b/perftest/generated-src/objc/TXSDjinniPerfBenchmark+Private.mm
@@ -216,6 +216,6 @@ auto DjinniPerfBenchmark::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<TXSDjinniPerfBenchmark>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/perftest/generated-src/objc/TXSObjectNative+Private.h
+++ b/perftest/generated-src/objc/TXSObjectNative+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/perftest/generated-src/objc/TXSObjectNative+Private.mm
+++ b/perftest/generated-src/objc/TXSObjectNative+Private.mm
@@ -53,6 +53,6 @@ auto ObjectNative::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<TXSObjectNative>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/perftest/generated-src/objc/TXSObjectPlatform+Private.h
+++ b/perftest/generated-src/objc/TXSObjectPlatform+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/perftest/generated-src/objc/TXSObjectPlatform+Private.mm
+++ b/perftest/generated-src/objc/TXSObjectPlatform+Private.mm
@@ -25,7 +25,7 @@ public:
     }
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 namespace djinni_generated {
 
@@ -45,4 +45,4 @@ auto ObjectPlatform::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return dynamic_cast<ObjcProxy&>(*cpp).djinni_private_get_proxied_objc_object();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/objc/TXSRecordSixInt+Private.h
+++ b/perftest/generated-src/objc/TXSRecordSixInt+Private.h
@@ -21,4 +21,4 @@ struct RecordSixInt
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/objc/TXSRecordSixInt+Private.mm
+++ b/perftest/generated-src/objc/TXSRecordSixInt+Private.mm
@@ -28,4 +28,4 @@ auto RecordSixInt::fromCpp(const CppType& cpp) -> ObjcType
                                             i6:(::djinni::I64::fromCpp(cpp.i6))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/wasm/NativeDjinniPerfBenchmark.cpp
+++ b/perftest/generated-src/wasm/NativeDjinniPerfBenchmark.cpp
@@ -286,4 +286,4 @@ EMSCRIPTEN_BINDINGS(snapchat_djinni_benchmark_djinni_perf_benchmark) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/wasm/NativeDjinniPerfBenchmark.hpp
+++ b/perftest/generated-src/wasm/NativeDjinniPerfBenchmark.hpp
@@ -51,4 +51,4 @@ struct NativeDjinniPerfBenchmark : ::djinni::JsInterface<::snapchat::djinni::ben
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/wasm/NativeEnumSixValue.cpp
+++ b/perftest/generated-src/wasm/NativeEnumSixValue.cpp
@@ -30,4 +30,4 @@ EMSCRIPTEN_BINDINGS(snapchat_djinni_benchmark_EnumSixValue) {
     NativeEnumSixValue::staticInitializeConstants();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/wasm/NativeEnumSixValue.hpp
+++ b/perftest/generated-src/wasm/NativeEnumSixValue.hpp
@@ -12,4 +12,4 @@ struct NativeEnumSixValue: ::djinni::WasmEnum<::snapchat::djinni::benchmark::Enu
     static void staticInitializeConstants();
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/wasm/NativeObjectNative.cpp
+++ b/perftest/generated-src/wasm/NativeObjectNative.cpp
@@ -29,4 +29,4 @@ EMSCRIPTEN_BINDINGS(snapchat_djinni_benchmark_ObjectNative) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/wasm/NativeObjectNative.hpp
+++ b/perftest/generated-src/wasm/NativeObjectNative.hpp
@@ -27,4 +27,4 @@ struct NativeObjectNative : ::djinni::JsInterface<::snapchat::djinni::benchmark:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/wasm/NativeObjectPlatform.cpp
+++ b/perftest/generated-src/wasm/NativeObjectPlatform.cpp
@@ -18,4 +18,4 @@ EMSCRIPTEN_BINDINGS(snapchat_djinni_benchmark_ObjectPlatform) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/wasm/NativeObjectPlatform.hpp
+++ b/perftest/generated-src/wasm/NativeObjectPlatform.hpp
@@ -28,4 +28,4 @@ struct NativeObjectPlatform : ::djinni::JsInterface<::snapchat::djinni::benchmar
     };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/wasm/NativeRecordSixInt.cpp
+++ b/perftest/generated-src/wasm/NativeRecordSixInt.cpp
@@ -24,4 +24,4 @@ auto NativeRecordSixInt::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/perftest/generated-src/wasm/NativeRecordSixInt.hpp
+++ b/perftest/generated-src/wasm/NativeRecordSixInt.hpp
@@ -18,4 +18,4 @@ struct NativeRecordSixInt
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -361,11 +361,10 @@ abstract class Generator(spec: Spec)
     ns match {
       case "" => f(w)
       case s =>
-        val parts = s.split("::")
-        w.wl(parts.map("namespace "+_+" {").mkString(" ")).wl
+        w.wl(s"namespace $s {").wl
         f(w)
         w.wl
-        w.wl(parts.map(p => "}").mkString(" ") + s"  // namespace $s")
+        w.wl(s"} // namespace $s")
     }
   }
 

--- a/test-suite/generated-src/cpp/Conflict.hpp
+++ b/test-suite/generated-src/cpp/Conflict.hpp
@@ -14,4 +14,4 @@ public:
     virtual ~Conflict() = default;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/DataRefTest.hpp
+++ b/test-suite/generated-src/cpp/DataRefTest.hpp
@@ -34,4 +34,4 @@ public:
     static /*not-null*/ std::shared_ptr<DataRefTest> create();
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/FunctionPrologueHelper.hpp
+++ b/test-suite/generated-src/cpp/FunctionPrologueHelper.hpp
@@ -14,4 +14,4 @@ public:
     static std::string foo();
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/RecordWithEmbeddedCppProto.hpp
+++ b/test-suite/generated-src/cpp/RecordWithEmbeddedCppProto.hpp
@@ -17,4 +17,4 @@ struct RecordWithEmbeddedCppProto final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/RecordWithEmbeddedProto.hpp
+++ b/test-suite/generated-src/cpp/RecordWithEmbeddedProto.hpp
@@ -17,4 +17,4 @@ struct RecordWithEmbeddedProto final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/_varname_interface_.hpp
+++ b/test-suite/generated-src/cpp/_varname_interface_.hpp
@@ -23,4 +23,4 @@ public:
     virtual /*not-null*/ std::shared_ptr<VarnameInterface> _imethod_(const /*not-null*/ std::shared_ptr<VarnameInterface> & _i_arg_) = 0;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/_varname_record_.hpp
+++ b/test-suite/generated-src/cpp/_varname_record_.hpp
@@ -22,4 +22,4 @@ struct VarnameRecord final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/access_flags.hpp
+++ b/test-suite/generated-src/cpp/access_flags.hpp
@@ -42,7 +42,7 @@ constexpr access_flags operator~(access_flags x) noexcept {
     return static_cast<access_flags>(~static_cast<unsigned>(x));
 }
 
-}  // namespace testsuite
+} // namespace testsuite
 
 namespace std {
 
@@ -53,4 +53,4 @@ struct hash<::testsuite::access_flags> {
     }
 };
 
-}  // namespace std
+} // namespace std

--- a/test-suite/generated-src/cpp/assorted_primitives.cpp
+++ b/test-suite/generated-src/cpp/assorted_primitives.cpp
@@ -27,4 +27,4 @@ bool operator!=(const AssortedPrimitives& lhs, const AssortedPrimitives& rhs) {
     return !(lhs == rhs);
 }
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/assorted_primitives.hpp
+++ b/test-suite/generated-src/cpp/assorted_primitives.hpp
@@ -59,4 +59,4 @@ struct AssortedPrimitives final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/async_interface.hpp
+++ b/test-suite/generated-src/cpp/async_interface.hpp
@@ -16,4 +16,4 @@ public:
     virtual ::djinni::Future<std::string> future_roundtrip(::djinni::Future<int32_t> f) = 0;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/client_interface.hpp
+++ b/test-suite/generated-src/cpp/client_interface.hpp
@@ -30,4 +30,4 @@ public:
     virtual std::string meth_taking_optional_interface(const /*nullable*/ std::shared_ptr<ClientInterface> & i) = 0;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/client_returned_record.hpp
+++ b/test-suite/generated-src/cpp/client_returned_record.hpp
@@ -25,4 +25,4 @@ struct ClientReturnedRecord final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/color.hpp
+++ b/test-suite/generated-src/cpp/color.hpp
@@ -35,7 +35,7 @@ constexpr const char* to_string(color e) noexcept {
     return names[static_cast<int>(e)];
 }
 
-}  // namespace testsuite
+} // namespace testsuite
 
 namespace std {
 
@@ -46,4 +46,4 @@ struct hash<::testsuite::color> {
     }
 };
 
-}  // namespace std
+} // namespace std

--- a/test-suite/generated-src/cpp/conflict_user.hpp
+++ b/test-suite/generated-src/cpp/conflict_user.hpp
@@ -19,4 +19,4 @@ public:
     virtual bool conflict_arg(const std::unordered_set</*not-null*/ std::shared_ptr<::testsuite::Conflict>> & cs) = 0;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/constant_enum.hpp
+++ b/test-suite/generated-src/cpp/constant_enum.hpp
@@ -20,7 +20,7 @@ constexpr const char* to_string(constant_enum e) noexcept {
     return names[static_cast<int>(e)];
 }
 
-}  // namespace testsuite
+} // namespace testsuite
 
 namespace std {
 
@@ -31,4 +31,4 @@ struct hash<::testsuite::constant_enum> {
     }
 };
 
-}  // namespace std
+} // namespace std

--- a/test-suite/generated-src/cpp/constant_interface_with_enum.cpp
+++ b/test-suite/generated-src/cpp/constant_interface_with_enum.cpp
@@ -8,4 +8,4 @@ namespace testsuite {
 
 constant_enum const ConstantInterfaceWithEnum::CONST_ENUM = constant_enum::SOME_VALUE;
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/constant_interface_with_enum.hpp
+++ b/test-suite/generated-src/cpp/constant_interface_with_enum.hpp
@@ -15,4 +15,4 @@ public:
     static constant_enum const CONST_ENUM;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/constant_record.hpp
+++ b/test-suite/generated-src/cpp/constant_record.hpp
@@ -21,4 +21,4 @@ struct ConstantRecord final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/constant_with_enum.cpp
+++ b/test-suite/generated-src/cpp/constant_with_enum.cpp
@@ -7,4 +7,4 @@ namespace testsuite {
 
 constant_enum const ConstantWithEnum::CONST_ENUM = constant_enum::SOME_VALUE;
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/constant_with_enum.hpp
+++ b/test-suite/generated-src/cpp/constant_with_enum.hpp
@@ -14,4 +14,4 @@ struct ConstantWithEnum final {
     static constant_enum const CONST_ENUM;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/constants.cpp
+++ b/test-suite/generated-src/cpp/constants.cpp
@@ -27,4 +27,4 @@ ConstantRecord const Constants::OBJECT_CONSTANT = ConstantRecord(
     Constants::I32_CONSTANT /* some_integer */ ,
     Constants::STRING_CONSTANT /* some_string */ );
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/constants.hpp
+++ b/test-suite/generated-src/cpp/constants.hpp
@@ -68,4 +68,4 @@ struct Constants final {
     static constexpr bool DUMMY = false;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/constants_interface.cpp
+++ b/test-suite/generated-src/cpp/constants_interface.cpp
@@ -30,4 +30,4 @@ ConstantRecord const ConstantsInterface::OBJECT_CONSTANT = ConstantRecord(
 
 std::string const ConstantsInterface::UPPER_CASE_CONSTANT = {"upper-case-constant"};
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/constants_interface.hpp
+++ b/test-suite/generated-src/cpp/constants_interface.hpp
@@ -76,4 +76,4 @@ public:
     virtual void dummy() = 0;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/cpp_exception.hpp
+++ b/test-suite/generated-src/cpp/cpp_exception.hpp
@@ -24,4 +24,4 @@ public:
     static /*not-null*/ std::shared_ptr<CppException> get();
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/date_record.cpp
+++ b/test-suite/generated-src/cpp/date_record.cpp
@@ -36,4 +36,4 @@ bool operator>=(const DateRecord& lhs, const DateRecord& rhs) {
     return !(lhs < rhs);
 }
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/date_record.hpp
+++ b/test-suite/generated-src/cpp/date_record.hpp
@@ -26,4 +26,4 @@ struct DateRecord final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/empty_flags.hpp
+++ b/test-suite/generated-src/cpp/empty_flags.hpp
@@ -33,7 +33,7 @@ constexpr empty_flags operator~(empty_flags x) noexcept {
     return static_cast<empty_flags>(~static_cast<unsigned>(x));
 }
 
-}  // namespace testsuite
+} // namespace testsuite
 
 namespace std {
 
@@ -44,4 +44,4 @@ struct hash<::testsuite::empty_flags> {
     }
 };
 
-}  // namespace std
+} // namespace std

--- a/test-suite/generated-src/cpp/empty_record.hpp
+++ b/test-suite/generated-src/cpp/empty_record.hpp
@@ -15,4 +15,4 @@ namespace testsuite {
 struct EmptyRecord final {
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/enum_usage_interface.hpp
+++ b/test-suite/generated-src/cpp/enum_usage_interface.hpp
@@ -27,4 +27,4 @@ public:
     virtual std::unordered_map<color, color> m(const std::unordered_map<color, color> & m) = 0;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/enum_usage_record.hpp
+++ b/test-suite/generated-src/cpp/enum_usage_record.hpp
@@ -32,4 +32,4 @@ struct EnumUsageRecord final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/extended_record_base.cpp
+++ b/test-suite/generated-src/cpp/extended_record_base.cpp
@@ -9,4 +9,4 @@ namespace testsuite {
 ExtendedRecord const ExtendedRecordBase::EXTENDED_RECORD_CONST = ExtendedRecord(
     true /* foo */ );
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/extended_record_base.hpp
+++ b/test-suite/generated-src/cpp/extended_record_base.hpp
@@ -29,4 +29,4 @@ protected:
     ExtendedRecordBase& operator=(ExtendedRecordBase&&) = default;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/first_listener.hpp
+++ b/test-suite/generated-src/cpp/first_listener.hpp
@@ -13,4 +13,4 @@ public:
     virtual void first() = 0;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/flag_roundtrip.hpp
+++ b/test-suite/generated-src/cpp/flag_roundtrip.hpp
@@ -23,4 +23,4 @@ public:
     static std::experimental::optional<empty_flags> roundtrip_empty_boxed(std::experimental::optional<empty_flags> flag);
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/interface_using_extended_record.cpp
+++ b/test-suite/generated-src/cpp/interface_using_extended_record.cpp
@@ -11,4 +11,4 @@ RecordUsingExtendedRecord const InterfaceUsingExtendedRecord::CR = RecordUsingEx
     ExtendedRecord(
         false /* foo */ ) /* er */ );
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/interface_using_extended_record.hpp
+++ b/test-suite/generated-src/cpp/interface_using_extended_record.hpp
@@ -17,4 +17,4 @@ public:
     virtual ExtendedRecord meth(const ExtendedRecord & er) = 0;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/java_only_listener.hpp
+++ b/test-suite/generated-src/cpp/java_only_listener.hpp
@@ -10,4 +10,4 @@ public:
     virtual ~JavaOnlyListener() = default;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/listener_caller.hpp
+++ b/test-suite/generated-src/cpp/listener_caller.hpp
@@ -27,4 +27,4 @@ public:
     virtual void callSecond() = 0;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/map_date_record.hpp
+++ b/test-suite/generated-src/cpp/map_date_record.hpp
@@ -19,4 +19,4 @@ struct MapDateRecord final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/map_list_record.hpp
+++ b/test-suite/generated-src/cpp/map_list_record.hpp
@@ -20,4 +20,4 @@ struct MapListRecord final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/map_record.hpp
+++ b/test-suite/generated-src/cpp/map_record.hpp
@@ -21,4 +21,4 @@ struct MapRecord final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/nested_collection.hpp
+++ b/test-suite/generated-src/cpp/nested_collection.hpp
@@ -19,4 +19,4 @@ struct NestedCollection final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/nested_outcome.cpp
+++ b/test-suite/generated-src/cpp/nested_outcome.cpp
@@ -14,4 +14,4 @@ bool operator!=(const NestedOutcome& lhs, const NestedOutcome& rhs) {
     return !(lhs == rhs);
 }
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/nested_outcome.hpp
+++ b/test-suite/generated-src/cpp/nested_outcome.hpp
@@ -22,4 +22,4 @@ struct NestedOutcome final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/objc_only_listener.hpp
+++ b/test-suite/generated-src/cpp/objc_only_listener.hpp
@@ -10,4 +10,4 @@ public:
     virtual ~ObjcOnlyListener() = default;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/primitive_list.hpp
+++ b/test-suite/generated-src/cpp/primitive_list.hpp
@@ -18,4 +18,4 @@ struct PrimitiveList final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/proto_tests.hpp
+++ b/test-suite/generated-src/cpp/proto_tests.hpp
@@ -47,4 +47,4 @@ public:
     static djinni::expected<::djinni::test::Person, int32_t> stringToProtoOutcome(const std::string & x);
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/record_using_extended_record.cpp
+++ b/test-suite/generated-src/cpp/record_using_extended_record.cpp
@@ -9,4 +9,4 @@ RecordUsingExtendedRecord const RecordUsingExtendedRecord::CR = RecordUsingExten
     ExtendedRecord(
         false /* foo */ ) /* er */ );
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/record_using_extended_record.hpp
+++ b/test-suite/generated-src/cpp/record_using_extended_record.hpp
@@ -19,4 +19,4 @@ struct RecordUsingExtendedRecord final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/record_with_derivings.cpp
+++ b/test-suite/generated-src/cpp/record_with_derivings.cpp
@@ -85,4 +85,4 @@ bool operator>=(const RecordWithDerivings& lhs, const RecordWithDerivings& rhs) 
     return !(lhs < rhs);
 }
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/record_with_derivings.hpp
+++ b/test-suite/generated-src/cpp/record_with_derivings.hpp
@@ -48,4 +48,4 @@ struct RecordWithDerivings final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/record_with_duration_and_derivings.cpp
+++ b/test-suite/generated-src/cpp/record_with_duration_and_derivings.cpp
@@ -36,4 +36,4 @@ bool operator>=(const RecordWithDurationAndDerivings& lhs, const RecordWithDurat
     return !(lhs < rhs);
 }
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/record_with_duration_and_derivings.hpp
+++ b/test-suite/generated-src/cpp/record_with_duration_and_derivings.hpp
@@ -26,4 +26,4 @@ struct RecordWithDurationAndDerivings final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/record_with_flags.hpp
+++ b/test-suite/generated-src/cpp/record_with_flags.hpp
@@ -17,4 +17,4 @@ struct RecordWithFlags final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/record_with_nested_derivings.cpp
+++ b/test-suite/generated-src/cpp/record_with_nested_derivings.cpp
@@ -43,4 +43,4 @@ bool operator>=(const RecordWithNestedDerivings& lhs, const RecordWithNestedDeri
     return !(lhs < rhs);
 }
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/record_with_nested_derivings.hpp
+++ b/test-suite/generated-src/cpp/record_with_nested_derivings.hpp
@@ -29,4 +29,4 @@ struct RecordWithNestedDerivings final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/return_one.hpp
+++ b/test-suite/generated-src/cpp/return_one.hpp
@@ -18,4 +18,4 @@ public:
     virtual int8_t return_one() = 0;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/return_two.hpp
+++ b/test-suite/generated-src/cpp/return_two.hpp
@@ -18,4 +18,4 @@ public:
     virtual int8_t return_two() = 0;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/reverse_client_interface.hpp
+++ b/test-suite/generated-src/cpp/reverse_client_interface.hpp
@@ -22,4 +22,4 @@ public:
     static /*not-null*/ std::shared_ptr<ReverseClientInterface> create();
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/sample_interface.hpp
+++ b/test-suite/generated-src/cpp/sample_interface.hpp
@@ -14,4 +14,4 @@ public:
     virtual ~SampleInterface() = default;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/second_listener.hpp
+++ b/test-suite/generated-src/cpp/second_listener.hpp
@@ -13,4 +13,4 @@ public:
     virtual void second() = 0;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/set_record.hpp
+++ b/test-suite/generated-src/cpp/set_record.hpp
@@ -21,4 +21,4 @@ struct SetRecord final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/support_copying.hpp
+++ b/test-suite/generated-src/cpp/support_copying.hpp
@@ -17,4 +17,4 @@ struct SupportCopying final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/test_array.hpp
+++ b/test-suite/generated-src/cpp/test_array.hpp
@@ -24,4 +24,4 @@ public:
     static std::vector<std::vector<int32_t>> testArrayOfArray(const std::vector<std::vector<int32_t>> & a);
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/test_duration.hpp
+++ b/test-suite/generated-src/cpp/test_duration.hpp
@@ -55,4 +55,4 @@ public:
     static int64_t unbox(std::experimental::optional<std::chrono::duration<int64_t, std::ratio<1>>> dt);
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/test_helpers.hpp
+++ b/test-suite/generated-src/cpp/test_helpers.hpp
@@ -113,4 +113,4 @@ public:
     static bool check_optional_map(const std::unordered_map<std::experimental::optional<std::string>, std::experimental::optional<std::string>> & om);
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/test_ident_enum.hpp
+++ b/test-suite/generated-src/cpp/test_ident_enum.hpp
@@ -21,7 +21,7 @@ constexpr const char* to_string(test_ident_enum e) noexcept {
     return names[static_cast<int>(e)];
 }
 
-}  // namespace testsuite
+} // namespace testsuite
 
 namespace std {
 
@@ -32,4 +32,4 @@ struct hash<::testsuite::test_ident_enum> {
     }
 };
 
-}  // namespace std
+} // namespace std

--- a/test-suite/generated-src/cpp/test_ident_record.cpp
+++ b/test-suite/generated-src/cpp/test_ident_record.cpp
@@ -7,4 +7,4 @@ namespace testsuite {
 
 std::string const TestIdentRecord::RECORD_CONST_VALUE = {"test"};
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/test_ident_record.hpp
+++ b/test-suite/generated-src/cpp/test_ident_record.hpp
@@ -25,4 +25,4 @@ struct TestIdentRecord final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/test_java_abstract_class_only.hpp
+++ b/test-suite/generated-src/cpp/test_java_abstract_class_only.hpp
@@ -12,4 +12,4 @@ public:
     static bool test_method();
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/test_java_interface_only.hpp
+++ b/test-suite/generated-src/cpp/test_java_interface_only.hpp
@@ -12,4 +12,4 @@ public:
     virtual bool test_method() = 0;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/test_outcome.hpp
+++ b/test-suite/generated-src/cpp/test_outcome.hpp
@@ -32,4 +32,4 @@ public:
     static std::string putNestedErrorOutcome(const NestedOutcome & x);
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/test_static_method_language.hpp
+++ b/test-suite/generated-src/cpp/test_static_method_language.hpp
@@ -16,4 +16,4 @@ public:
     static void test_method();
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/throwing_interface.hpp
+++ b/test-suite/generated-src/cpp/throwing_interface.hpp
@@ -12,4 +12,4 @@ public:
     virtual void throw_exception() = 0;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/user_token.hpp
+++ b/test-suite/generated-src/cpp/user_token.hpp
@@ -14,4 +14,4 @@ public:
     virtual std::string whoami() = 0;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/uses_single_language_listeners.hpp
+++ b/test-suite/generated-src/cpp/uses_single_language_listeners.hpp
@@ -27,4 +27,4 @@ public:
     virtual /*not-null*/ std::shared_ptr<JavaOnlyListener> returnForJava() = 0;
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/vec2.cpp
+++ b/test-suite/generated-src/cpp/vec2.cpp
@@ -15,4 +15,4 @@ bool operator!=(const Vec2& lhs, const Vec2& rhs) {
     return !(lhs == rhs);
 }
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/vec2.hpp
+++ b/test-suite/generated-src/cpp/vec2.hpp
@@ -22,4 +22,4 @@ struct Vec2 final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/wchar_test_helpers.hpp
+++ b/test-suite/generated-src/cpp/wchar_test_helpers.hpp
@@ -22,4 +22,4 @@ public:
     static bool check_record(const WcharTestRec & rec);
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/cpp/wchar_test_rec.hpp
+++ b/test-suite/generated-src/cpp/wchar_test_rec.hpp
@@ -17,4 +17,4 @@ struct WcharTestRec final {
     {}
 };
 
-}  // namespace testsuite
+} // namespace testsuite

--- a/test-suite/generated-src/jni/NativeAccessFlags.hpp
+++ b/test-suite/generated-src/jni/NativeAccessFlags.hpp
@@ -23,4 +23,4 @@ private:
     friend ::djinni::JniClass<NativeAccessFlags>;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeAssortedPrimitives.cpp
+++ b/test-suite/generated-src/jni/NativeAssortedPrimitives.cpp
@@ -51,4 +51,4 @@ auto NativeAssortedPrimitives::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
             ::djinni::Optional<std::experimental::optional, ::djinni::F64>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mOFsixtyfour))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeAssortedPrimitives.hpp
+++ b/test-suite/generated-src/jni/NativeAssortedPrimitives.hpp
@@ -42,4 +42,4 @@ private:
     const jfieldID field_mOFsixtyfour { ::djinni::jniGetFieldID(clazz.get(), "mOFsixtyfour", "Ljava/lang/Double;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeAsyncInterface.cpp
+++ b/test-suite/generated-src/jni/NativeAsyncInterface.cpp
@@ -25,4 +25,4 @@ NativeAsyncInterface::JavaProxy::~JavaProxy() = default;
     return ::djinni::FutureAdaptor<::djinni::String>::toCpp(jniEnv, jret);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeAsyncInterface.hpp
+++ b/test-suite/generated-src/jni/NativeAsyncInterface.hpp
@@ -43,4 +43,4 @@ private:
     const jmethodID method_futureRoundtrip { ::djinni::jniGetMethodID(clazz.get(), "futureRoundtrip", "(Lcom/snapchat/djinni/Future;)Lcom/snapchat/djinni/Future;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeClientInterface.cpp
+++ b/test-suite/generated-src/jni/NativeClientInterface.cpp
@@ -64,4 +64,4 @@ std::string NativeClientInterface::JavaProxy::meth_taking_optional_interface(con
     return ::djinni::String::toCpp(jniEnv, jret);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeClientInterface.hpp
+++ b/test-suite/generated-src/jni/NativeClientInterface.hpp
@@ -51,4 +51,4 @@ private:
     const jmethodID method_methTakingOptionalInterface { ::djinni::jniGetMethodID(clazz.get(), "methTakingOptionalInterface", "(Lcom/dropbox/djinni/test/ClientInterface;)Ljava/lang/String;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeClientReturnedRecord.cpp
+++ b/test-suite/generated-src/jni/NativeClientReturnedRecord.cpp
@@ -29,4 +29,4 @@ auto NativeClientReturnedRecord::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
             ::djinni::Optional<std::experimental::optional, ::djinni::String>::toCpp(jniEnv, (jstring)jniEnv->GetObjectField(j, data.field_mMisc))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeClientReturnedRecord.hpp
+++ b/test-suite/generated-src/jni/NativeClientReturnedRecord.hpp
@@ -31,4 +31,4 @@ private:
     const jfieldID field_mMisc { ::djinni::jniGetFieldID(clazz.get(), "mMisc", "Ljava/lang/String;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeColor.hpp
+++ b/test-suite/generated-src/jni/NativeColor.hpp
@@ -23,4 +23,4 @@ private:
     friend ::djinni::JniClass<NativeColor>;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeConflict.cpp
+++ b/test-suite/generated-src/jni/NativeConflict.cpp
@@ -17,4 +17,4 @@ CJNIEXPORT void JNICALL Java_com_dropbox_djinni_test_Conflict_00024CppProxy_nati
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeConflict.hpp
+++ b/test-suite/generated-src/jni/NativeConflict.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeConflictUser.cpp
+++ b/test-suite/generated-src/jni/NativeConflictUser.cpp
@@ -37,4 +37,4 @@ CJNIEXPORT jboolean JNICALL Java_com_dropbox_djinni_test_ConflictUser_00024CppPr
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeConflictUser.hpp
+++ b/test-suite/generated-src/jni/NativeConflictUser.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeConstantEnum.hpp
+++ b/test-suite/generated-src/jni/NativeConstantEnum.hpp
@@ -23,4 +23,4 @@ private:
     friend ::djinni::JniClass<NativeConstantEnum>;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeConstantInterfaceWithEnum.cpp
+++ b/test-suite/generated-src/jni/NativeConstantInterfaceWithEnum.cpp
@@ -18,4 +18,4 @@ CJNIEXPORT void JNICALL Java_com_dropbox_djinni_test_ConstantInterfaceWithEnum_0
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeConstantInterfaceWithEnum.hpp
+++ b/test-suite/generated-src/jni/NativeConstantInterfaceWithEnum.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeConstantRecord.cpp
+++ b/test-suite/generated-src/jni/NativeConstantRecord.cpp
@@ -27,4 +27,4 @@ auto NativeConstantRecord::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
             ::djinni::String::toCpp(jniEnv, (jstring)jniEnv->GetObjectField(j, data.field_mSomeString))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeConstantRecord.hpp
+++ b/test-suite/generated-src/jni/NativeConstantRecord.hpp
@@ -30,4 +30,4 @@ private:
     const jfieldID field_mSomeString { ::djinni::jniGetFieldID(clazz.get(), "mSomeString", "Ljava/lang/String;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeConstantWithEnum.cpp
+++ b/test-suite/generated-src/jni/NativeConstantWithEnum.cpp
@@ -24,4 +24,4 @@ auto NativeConstantWithEnum::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
     return {};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeConstantWithEnum.hpp
+++ b/test-suite/generated-src/jni/NativeConstantWithEnum.hpp
@@ -28,4 +28,4 @@ private:
     const jmethodID jconstructor { ::djinni::jniGetMethodID(clazz.get(), "<init>", "()V") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeConstants.cpp
+++ b/test-suite/generated-src/jni/NativeConstants.cpp
@@ -24,4 +24,4 @@ auto NativeConstants::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
     return {};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeConstants.hpp
+++ b/test-suite/generated-src/jni/NativeConstants.hpp
@@ -28,4 +28,4 @@ private:
     const jmethodID jconstructor { ::djinni::jniGetMethodID(clazz.get(), "<init>", "()V") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeConstantsInterface.cpp
+++ b/test-suite/generated-src/jni/NativeConstantsInterface.cpp
@@ -27,4 +27,4 @@ CJNIEXPORT void JNICALL Java_com_dropbox_djinni_test_ConstantsInterface_00024Cpp
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeConstantsInterface.hpp
+++ b/test-suite/generated-src/jni/NativeConstantsInterface.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeCppException.cpp
+++ b/test-suite/generated-src/jni/NativeCppException.cpp
@@ -54,4 +54,4 @@ CJNIEXPORT jobject JNICALL Java_com_dropbox_djinni_test_CppException_get(JNIEnv*
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeCppException.hpp
+++ b/test-suite/generated-src/jni/NativeCppException.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeDataRefTest.cpp
+++ b/test-suite/generated-src/jni/NativeDataRefTest.cpp
@@ -98,4 +98,4 @@ CJNIEXPORT jobject JNICALL Java_com_dropbox_djinni_test_DataRefTest_create(JNIEn
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeDataRefTest.hpp
+++ b/test-suite/generated-src/jni/NativeDataRefTest.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeDateRecord.cpp
+++ b/test-suite/generated-src/jni/NativeDateRecord.cpp
@@ -25,4 +25,4 @@ auto NativeDateRecord::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
     return {::djinni::Date::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mCreatedAt))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeDateRecord.hpp
+++ b/test-suite/generated-src/jni/NativeDateRecord.hpp
@@ -29,4 +29,4 @@ private:
     const jfieldID field_mCreatedAt { ::djinni::jniGetFieldID(clazz.get(), "mCreatedAt", "Ljava/util/Date;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeEmptyFlags.hpp
+++ b/test-suite/generated-src/jni/NativeEmptyFlags.hpp
@@ -23,4 +23,4 @@ private:
     friend ::djinni::JniClass<NativeEmptyFlags>;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeEmptyRecord.cpp
+++ b/test-suite/generated-src/jni/NativeEmptyRecord.cpp
@@ -24,4 +24,4 @@ auto NativeEmptyRecord::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
     return {};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeEmptyRecord.hpp
+++ b/test-suite/generated-src/jni/NativeEmptyRecord.hpp
@@ -28,4 +28,4 @@ private:
     const jmethodID jconstructor { ::djinni::jniGetMethodID(clazz.get(), "<init>", "()V") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeEnumUsageInterface.cpp
+++ b/test-suite/generated-src/jni/NativeEnumUsageInterface.cpp
@@ -113,4 +113,4 @@ CJNIEXPORT jobject JNICALL Java_com_dropbox_djinni_test_EnumUsageInterface_00024
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeEnumUsageInterface.hpp
+++ b/test-suite/generated-src/jni/NativeEnumUsageInterface.hpp
@@ -51,4 +51,4 @@ private:
     const jmethodID method_m { ::djinni::jniGetMethodID(clazz.get(), "m", "(Ljava/util/HashMap;)Ljava/util/HashMap;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeEnumUsageRecord.cpp
+++ b/test-suite/generated-src/jni/NativeEnumUsageRecord.cpp
@@ -34,4 +34,4 @@ auto NativeEnumUsageRecord::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
             ::djinni::Map<::djinni_generated::NativeColor, ::djinni_generated::NativeColor>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mM))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeEnumUsageRecord.hpp
+++ b/test-suite/generated-src/jni/NativeEnumUsageRecord.hpp
@@ -33,4 +33,4 @@ private:
     const jfieldID field_mM { ::djinni::jniGetFieldID(clazz.get(), "mM", "Ljava/util/HashMap;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeExtendedRecord.cpp
+++ b/test-suite/generated-src/jni/NativeExtendedRecord.cpp
@@ -25,4 +25,4 @@ auto NativeExtendedRecord::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
     return {::djinni::Bool::toCpp(jniEnv, jniEnv->GetBooleanField(j, data.field_mFoo))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeExtendedRecord.hpp
+++ b/test-suite/generated-src/jni/NativeExtendedRecord.hpp
@@ -29,4 +29,4 @@ private:
     const jfieldID field_mFoo { ::djinni::jniGetFieldID(clazz.get(), "mFoo", "Z") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeExternInterface1.cpp
+++ b/test-suite/generated-src/jni/NativeExternInterface1.cpp
@@ -38,4 +38,4 @@ CJNIEXPORT ::djinni_generated::NativeColor::JniType JNICALL Java_com_dropbox_dji
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeExternInterface1.hpp
+++ b/test-suite/generated-src/jni/NativeExternInterface1.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeExternInterface2.cpp
+++ b/test-suite/generated-src/jni/NativeExternInterface2.cpp
@@ -25,4 +25,4 @@ NativeExternInterface2::JavaProxy::~JavaProxy() = default;
     return ::djinni_generated::NativeExternRecordWithDerivings::toCpp(jniEnv, jret);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeExternInterface2.hpp
+++ b/test-suite/generated-src/jni/NativeExternInterface2.hpp
@@ -43,4 +43,4 @@ private:
     const jmethodID method_foo { ::djinni::jniGetMethodID(clazz.get(), "foo", "(Lcom/dropbox/djinni/test/TestHelpers;)Lcom/dropbox/djinni/test/ExternRecordWithDerivings;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeExternRecordWithDerivings.cpp
+++ b/test-suite/generated-src/jni/NativeExternRecordWithDerivings.cpp
@@ -28,4 +28,4 @@ auto NativeExternRecordWithDerivings::toCpp(JNIEnv* jniEnv, JniType j) -> CppTyp
             ::djinni_generated::NativeColor::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mE))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeExternRecordWithDerivings.hpp
+++ b/test-suite/generated-src/jni/NativeExternRecordWithDerivings.hpp
@@ -30,4 +30,4 @@ private:
     const jfieldID field_mE { ::djinni::jniGetFieldID(clazz.get(), "mE", "Lcom/dropbox/djinni/test/Color;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeFirstListener.cpp
+++ b/test-suite/generated-src/jni/NativeFirstListener.cpp
@@ -10,4 +10,4 @@ NativeFirstListener::NativeFirstListener() : ::djinni::JniInterface<::testsuite:
 NativeFirstListener::~NativeFirstListener() = default;
 
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeFirstListener.hpp
+++ b/test-suite/generated-src/jni/NativeFirstListener.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeFlagRoundtrip.cpp
+++ b/test-suite/generated-src/jni/NativeFlagRoundtrip.cpp
@@ -52,4 +52,4 @@ CJNIEXPORT jobject JNICALL Java_com_dropbox_djinni_test_FlagRoundtrip_roundtripE
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeFlagRoundtrip.hpp
+++ b/test-suite/generated-src/jni/NativeFlagRoundtrip.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeFunctionPrologueHelper.cpp
+++ b/test-suite/generated-src/jni/NativeFunctionPrologueHelper.cpp
@@ -29,4 +29,4 @@ CJNIEXPORT jstring JNICALL Java_com_dropbox_djinni_test_FunctionPrologueHelper_f
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeFunctionPrologueHelper.hpp
+++ b/test-suite/generated-src/jni/NativeFunctionPrologueHelper.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeInterfaceUsingExtendedRecord.cpp
+++ b/test-suite/generated-src/jni/NativeInterfaceUsingExtendedRecord.cpp
@@ -28,4 +28,4 @@ CJNIEXPORT jobject JNICALL Java_com_dropbox_djinni_test_InterfaceUsingExtendedRe
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeInterfaceUsingExtendedRecord.hpp
+++ b/test-suite/generated-src/jni/NativeInterfaceUsingExtendedRecord.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeJavaOnlyListener.cpp
+++ b/test-suite/generated-src/jni/NativeJavaOnlyListener.cpp
@@ -14,4 +14,4 @@ NativeJavaOnlyListener::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::jniGe
 NativeJavaOnlyListener::JavaProxy::~JavaProxy() = default;
 
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeJavaOnlyListener.hpp
+++ b/test-suite/generated-src/jni/NativeJavaOnlyListener.hpp
@@ -41,4 +41,4 @@ private:
     const ::djinni::GlobalRef<jclass> clazz { ::djinni::jniFindClass("com/dropbox/djinni/test/JavaOnlyListener") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeListenerCaller.cpp
+++ b/test-suite/generated-src/jni/NativeListenerCaller.cpp
@@ -44,4 +44,4 @@ CJNIEXPORT void JNICALL Java_com_dropbox_djinni_test_ListenerCaller_00024CppProx
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeListenerCaller.hpp
+++ b/test-suite/generated-src/jni/NativeListenerCaller.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeMapDateRecord.cpp
+++ b/test-suite/generated-src/jni/NativeMapDateRecord.cpp
@@ -25,4 +25,4 @@ auto NativeMapDateRecord::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
     return {::djinni::Map<::djinni::String, ::djinni::Date>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mDatesById))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeMapDateRecord.hpp
+++ b/test-suite/generated-src/jni/NativeMapDateRecord.hpp
@@ -29,4 +29,4 @@ private:
     const jfieldID field_mDatesById { ::djinni::jniGetFieldID(clazz.get(), "mDatesById", "Ljava/util/HashMap;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeMapListRecord.cpp
+++ b/test-suite/generated-src/jni/NativeMapListRecord.cpp
@@ -25,4 +25,4 @@ auto NativeMapListRecord::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
     return {::djinni::List<::djinni::Map<::djinni::String, ::djinni::I64>>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mMapList))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeMapListRecord.hpp
+++ b/test-suite/generated-src/jni/NativeMapListRecord.hpp
@@ -29,4 +29,4 @@ private:
     const jfieldID field_mMapList { ::djinni::jniGetFieldID(clazz.get(), "mMapList", "Ljava/util/ArrayList;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeMapRecord.cpp
+++ b/test-suite/generated-src/jni/NativeMapRecord.cpp
@@ -27,4 +27,4 @@ auto NativeMapRecord::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
             ::djinni::Map<::djinni::I32, ::djinni::I32>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mImap))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeMapRecord.hpp
+++ b/test-suite/generated-src/jni/NativeMapRecord.hpp
@@ -30,4 +30,4 @@ private:
     const jfieldID field_mImap { ::djinni::jniGetFieldID(clazz.get(), "mImap", "Ljava/util/HashMap;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeNestedCollection.cpp
+++ b/test-suite/generated-src/jni/NativeNestedCollection.cpp
@@ -25,4 +25,4 @@ auto NativeNestedCollection::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
     return {::djinni::List<::djinni::Set<::djinni::String>>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mSetList))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeNestedCollection.hpp
+++ b/test-suite/generated-src/jni/NativeNestedCollection.hpp
@@ -29,4 +29,4 @@ private:
     const jfieldID field_mSetList { ::djinni::jniGetFieldID(clazz.get(), "mSetList", "Ljava/util/ArrayList;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeNestedOutcome.cpp
+++ b/test-suite/generated-src/jni/NativeNestedOutcome.cpp
@@ -26,4 +26,4 @@ auto NativeNestedOutcome::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
     return {::djinni::Outcome<::djinni::I32, ::djinni::String>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mO))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeNestedOutcome.hpp
+++ b/test-suite/generated-src/jni/NativeNestedOutcome.hpp
@@ -29,4 +29,4 @@ private:
     const jfieldID field_mO { ::djinni::jniGetFieldID(clazz.get(), "mO", "Lcom/snapchat/djinni/Outcome;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeObjcOnlyListener.cpp
+++ b/test-suite/generated-src/jni/NativeObjcOnlyListener.cpp
@@ -10,4 +10,4 @@ NativeObjcOnlyListener::NativeObjcOnlyListener() : ::djinni::JniInterface<::test
 NativeObjcOnlyListener::~NativeObjcOnlyListener() = default;
 
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeObjcOnlyListener.hpp
+++ b/test-suite/generated-src/jni/NativeObjcOnlyListener.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativePrimitiveList.cpp
+++ b/test-suite/generated-src/jni/NativePrimitiveList.cpp
@@ -25,4 +25,4 @@ auto NativePrimitiveList::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
     return {::djinni::List<::djinni::I64>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mList))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativePrimitiveList.hpp
+++ b/test-suite/generated-src/jni/NativePrimitiveList.hpp
@@ -29,4 +29,4 @@ private:
     const jfieldID field_mList { ::djinni::jniGetFieldID(clazz.get(), "mList", "Ljava/util/ArrayList;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeProtoTests.cpp
+++ b/test-suite/generated-src/jni/NativeProtoTests.cpp
@@ -125,4 +125,4 @@ CJNIEXPORT ::djinni::Outcome<::djinni::Protobuf<::djinni::test::Person, ::djinni
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeProtoTests.hpp
+++ b/test-suite/generated-src/jni/NativeProtoTests.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeRecordUsingExtendedRecord.cpp
+++ b/test-suite/generated-src/jni/NativeRecordUsingExtendedRecord.cpp
@@ -25,4 +25,4 @@ auto NativeRecordUsingExtendedRecord::toCpp(JNIEnv* jniEnv, JniType j) -> CppTyp
     return {::djinni_generated::NativeExtendedRecord::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mEr))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeRecordUsingExtendedRecord.hpp
+++ b/test-suite/generated-src/jni/NativeRecordUsingExtendedRecord.hpp
@@ -29,4 +29,4 @@ private:
     const jfieldID field_mEr { ::djinni::jniGetFieldID(clazz.get(), "mEr", "Lcom/dropbox/djinni/test/ExtendedRecord;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeRecordWithDerivings.cpp
+++ b/test-suite/generated-src/jni/NativeRecordWithDerivings.cpp
@@ -39,4 +39,4 @@ auto NativeRecordWithDerivings::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
             ::djinni::String::toCpp(jniEnv, (jstring)jniEnv->GetObjectField(j, data.field_mS))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeRecordWithDerivings.hpp
+++ b/test-suite/generated-src/jni/NativeRecordWithDerivings.hpp
@@ -36,4 +36,4 @@ private:
     const jfieldID field_mS { ::djinni::jniGetFieldID(clazz.get(), "mS", "Ljava/lang/String;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeRecordWithDurationAndDerivings.cpp
+++ b/test-suite/generated-src/jni/NativeRecordWithDurationAndDerivings.cpp
@@ -26,4 +26,4 @@ auto NativeRecordWithDurationAndDerivings::toCpp(JNIEnv* jniEnv, JniType j) -> C
     return {::djinni::Duration<::djinni::F64, ::djinni::Duration_ns>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mDt))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeRecordWithDurationAndDerivings.hpp
+++ b/test-suite/generated-src/jni/NativeRecordWithDurationAndDerivings.hpp
@@ -29,4 +29,4 @@ private:
     const jfieldID field_mDt { ::djinni::jniGetFieldID(clazz.get(), "mDt", "Ljava/time/Duration;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeRecordWithEmbeddedCppProto.cpp
+++ b/test-suite/generated-src/jni/NativeRecordWithEmbeddedCppProto.cpp
@@ -25,4 +25,4 @@ auto NativeRecordWithEmbeddedCppProto::toCpp(JNIEnv* jniEnv, JniType j) -> CppTy
     return {::djinni::Protobuf<::djinni::test2::PersistingState, ::djinni::JavaClassName<'d','j','i','n','n','i','/','t','e','s','t','2','/','T','e','s','t','2','$','P','e','r','s','i','s','t','i','n','g','S','t','a','t','e'>>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mState))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeRecordWithEmbeddedCppProto.hpp
+++ b/test-suite/generated-src/jni/NativeRecordWithEmbeddedCppProto.hpp
@@ -29,4 +29,4 @@ private:
     const jfieldID field_mState { ::djinni::jniGetFieldID(clazz.get(), "mState", "Ldjinni/test2/Test2$PersistingState;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeRecordWithEmbeddedProto.cpp
+++ b/test-suite/generated-src/jni/NativeRecordWithEmbeddedProto.cpp
@@ -25,4 +25,4 @@ auto NativeRecordWithEmbeddedProto::toCpp(JNIEnv* jniEnv, JniType j) -> CppType 
     return {::djinni::Protobuf<::djinni::test::Person, ::djinni::JavaClassName<'d','j','i','n','n','i','/','t','e','s','t','/','T','e','s','t','$','P','e','r','s','o','n'>>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mPerson))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeRecordWithEmbeddedProto.hpp
+++ b/test-suite/generated-src/jni/NativeRecordWithEmbeddedProto.hpp
@@ -29,4 +29,4 @@ private:
     const jfieldID field_mPerson { ::djinni::jniGetFieldID(clazz.get(), "mPerson", "Ldjinni/test/Test$Person;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeRecordWithFlags.cpp
+++ b/test-suite/generated-src/jni/NativeRecordWithFlags.cpp
@@ -25,4 +25,4 @@ auto NativeRecordWithFlags::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
     return {::djinni_generated::NativeAccessFlags::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mAccess))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeRecordWithFlags.hpp
+++ b/test-suite/generated-src/jni/NativeRecordWithFlags.hpp
@@ -29,4 +29,4 @@ private:
     const jfieldID field_mAccess { ::djinni::jniGetFieldID(clazz.get(), "mAccess", "Ljava/util/EnumSet;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeRecordWithNestedDerivings.cpp
+++ b/test-suite/generated-src/jni/NativeRecordWithNestedDerivings.cpp
@@ -28,4 +28,4 @@ auto NativeRecordWithNestedDerivings::toCpp(JNIEnv* jniEnv, JniType j) -> CppTyp
             ::djinni_generated::NativeRecordWithDerivings::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mRec))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeRecordWithNestedDerivings.hpp
+++ b/test-suite/generated-src/jni/NativeRecordWithNestedDerivings.hpp
@@ -30,4 +30,4 @@ private:
     const jfieldID field_mRec { ::djinni::jniGetFieldID(clazz.get(), "mRec", "Lcom/dropbox/djinni/test/RecordWithDerivings;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeReturnOne.cpp
+++ b/test-suite/generated-src/jni/NativeReturnOne.cpp
@@ -35,4 +35,4 @@ CJNIEXPORT jbyte JNICALL Java_com_dropbox_djinni_test_ReturnOne_00024CppProxy_na
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeReturnOne.hpp
+++ b/test-suite/generated-src/jni/NativeReturnOne.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeReturnTwo.cpp
+++ b/test-suite/generated-src/jni/NativeReturnTwo.cpp
@@ -35,4 +35,4 @@ CJNIEXPORT jbyte JNICALL Java_com_dropbox_djinni_test_ReturnTwo_00024CppProxy_na
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeReturnTwo.hpp
+++ b/test-suite/generated-src/jni/NativeReturnTwo.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeReverseClientInterface.cpp
+++ b/test-suite/generated-src/jni/NativeReverseClientInterface.cpp
@@ -53,4 +53,4 @@ CJNIEXPORT jobject JNICALL Java_com_dropbox_djinni_test_ReverseClientInterface_c
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeReverseClientInterface.hpp
+++ b/test-suite/generated-src/jni/NativeReverseClientInterface.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeSampleInterface.cpp
+++ b/test-suite/generated-src/jni/NativeSampleInterface.cpp
@@ -17,4 +17,4 @@ CJNIEXPORT void JNICALL Java_com_dropbox_djinni_test_SampleInterface_00024CppPro
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeSampleInterface.hpp
+++ b/test-suite/generated-src/jni/NativeSampleInterface.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeSecondListener.cpp
+++ b/test-suite/generated-src/jni/NativeSecondListener.cpp
@@ -10,4 +10,4 @@ NativeSecondListener::NativeSecondListener() : ::djinni::JniInterface<::testsuit
 NativeSecondListener::~NativeSecondListener() = default;
 
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeSecondListener.hpp
+++ b/test-suite/generated-src/jni/NativeSecondListener.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeSetRecord.cpp
+++ b/test-suite/generated-src/jni/NativeSetRecord.cpp
@@ -27,4 +27,4 @@ auto NativeSetRecord::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
             ::djinni::Set<::djinni::I32>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mIset))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeSetRecord.hpp
+++ b/test-suite/generated-src/jni/NativeSetRecord.hpp
@@ -30,4 +30,4 @@ private:
     const jfieldID field_mIset { ::djinni::jniGetFieldID(clazz.get(), "mIset", "Ljava/util/HashSet;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeSupportCopying.cpp
+++ b/test-suite/generated-src/jni/NativeSupportCopying.cpp
@@ -25,4 +25,4 @@ auto NativeSupportCopying::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
     return {::djinni::I32::toCpp(jniEnv, jniEnv->GetIntField(j, data.field_mX))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeSupportCopying.hpp
+++ b/test-suite/generated-src/jni/NativeSupportCopying.hpp
@@ -29,4 +29,4 @@ private:
     const jfieldID field_mX { ::djinni::jniGetFieldID(clazz.get(), "mX", "I") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestArray.cpp
+++ b/test-suite/generated-src/jni/NativeTestArray.cpp
@@ -51,4 +51,4 @@ CJNIEXPORT jobject JNICALL Java_com_dropbox_djinni_test_TestArray_testArrayOfArr
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestArray.hpp
+++ b/test-suite/generated-src/jni/NativeTestArray.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestDuration.cpp
+++ b/test-suite/generated-src/jni/NativeTestDuration.cpp
@@ -179,4 +179,4 @@ CJNIEXPORT jlong JNICALL Java_com_dropbox_djinni_test_TestDuration_unbox(JNIEnv*
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestDuration.hpp
+++ b/test-suite/generated-src/jni/NativeTestDuration.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestHelpers.cpp
+++ b/test-suite/generated-src/jni/NativeTestHelpers.cpp
@@ -310,4 +310,4 @@ CJNIEXPORT jboolean JNICALL Java_com_dropbox_djinni_test_TestHelpers_checkOption
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestHelpers.hpp
+++ b/test-suite/generated-src/jni/NativeTestHelpers.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestIdentEnum.hpp
+++ b/test-suite/generated-src/jni/NativeTestIdentEnum.hpp
@@ -23,4 +23,4 @@ private:
     friend ::djinni::JniClass<NativeTestIdentEnum>;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestIdentRecord.cpp
+++ b/test-suite/generated-src/jni/NativeTestIdentRecord.cpp
@@ -27,4 +27,4 @@ auto NativeTestIdentRecord::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
             ::djinni::String::toCpp(jniEnv, (jstring)jniEnv->GetObjectField(j, data.field_mSecondValue))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestIdentRecord.hpp
+++ b/test-suite/generated-src/jni/NativeTestIdentRecord.hpp
@@ -30,4 +30,4 @@ private:
     const jfieldID field_mSecondValue { ::djinni::jniGetFieldID(clazz.get(), "mSecondValue", "Ljava/lang/String;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestJavaAbstractClassOnly.cpp
+++ b/test-suite/generated-src/jni/NativeTestJavaAbstractClassOnly.cpp
@@ -26,4 +26,4 @@ CJNIEXPORT jboolean JNICALL Java_com_dropbox_djinni_test_TestJavaAbstractClassOn
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestJavaAbstractClassOnly.hpp
+++ b/test-suite/generated-src/jni/NativeTestJavaAbstractClassOnly.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestJavaInterfaceOnly.cpp
+++ b/test-suite/generated-src/jni/NativeTestJavaInterfaceOnly.cpp
@@ -23,4 +23,4 @@ bool NativeTestJavaInterfaceOnly::JavaProxy::test_method() {
     return ::djinni::Bool::toCpp(jniEnv, jret);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestJavaInterfaceOnly.hpp
+++ b/test-suite/generated-src/jni/NativeTestJavaInterfaceOnly.hpp
@@ -43,4 +43,4 @@ private:
     const jmethodID method_testMethod { ::djinni::jniGetMethodID(clazz.get(), "testMethod", "()Z") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestOptionalExternInterfaceRecord.cpp
+++ b/test-suite/generated-src/jni/NativeTestOptionalExternInterfaceRecord.cpp
@@ -26,4 +26,4 @@ auto NativeTestOptionalExternInterfaceRecord::toCpp(JNIEnv* jniEnv, JniType j) -
     return {::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeSampleInterface>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_mSampleInterface))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestOptionalExternInterfaceRecord.hpp
+++ b/test-suite/generated-src/jni/NativeTestOptionalExternInterfaceRecord.hpp
@@ -29,4 +29,4 @@ private:
     const jfieldID field_mSampleInterface { ::djinni::jniGetFieldID(clazz.get(), "mSampleInterface", "Lcom/dropbox/djinni/test/SampleInterface;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestOutcome.cpp
+++ b/test-suite/generated-src/jni/NativeTestOutcome.cpp
@@ -84,4 +84,4 @@ CJNIEXPORT jstring JNICALL Java_com_dropbox_djinni_test_TestOutcome_putNestedErr
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestOutcome.hpp
+++ b/test-suite/generated-src/jni/NativeTestOutcome.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestStaticMethodLanguage.cpp
+++ b/test-suite/generated-src/jni/NativeTestStaticMethodLanguage.cpp
@@ -17,4 +17,4 @@ CJNIEXPORT void JNICALL Java_com_dropbox_djinni_test_TestStaticMethodLanguage_00
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeTestStaticMethodLanguage.hpp
+++ b/test-suite/generated-src/jni/NativeTestStaticMethodLanguage.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeThrowingInterface.cpp
+++ b/test-suite/generated-src/jni/NativeThrowingInterface.cpp
@@ -10,4 +10,4 @@ NativeThrowingInterface::NativeThrowingInterface() : ::djinni::JniInterface<::te
 NativeThrowingInterface::~NativeThrowingInterface() = default;
 
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeThrowingInterface.hpp
+++ b/test-suite/generated-src/jni/NativeThrowingInterface.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeUserToken.cpp
+++ b/test-suite/generated-src/jni/NativeUserToken.cpp
@@ -39,4 +39,4 @@ CJNIEXPORT jstring JNICALL Java_com_dropbox_djinni_test_UserToken_00024CppProxy_
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeUserToken.hpp
+++ b/test-suite/generated-src/jni/NativeUserToken.hpp
@@ -43,4 +43,4 @@ private:
     const jmethodID method_whoami { ::djinni::jniGetMethodID(clazz.get(), "whoami", "()Ljava/lang/String;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeUsesSingleLanguageListeners.cpp
+++ b/test-suite/generated-src/jni/NativeUsesSingleLanguageListeners.cpp
@@ -89,4 +89,4 @@ CJNIEXPORT jobject JNICALL Java_com_dropbox_djinni_test_UsesSingleLanguageListen
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeUsesSingleLanguageListeners.hpp
+++ b/test-suite/generated-src/jni/NativeUsesSingleLanguageListeners.hpp
@@ -49,4 +49,4 @@ private:
     const jmethodID method_returnForJava { ::djinni::jniGetMethodID(clazz.get(), "returnForJava", "()Lcom/dropbox/djinni/test/JavaOnlyListener;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeVarnameInterface.cpp
+++ b/test-suite/generated-src/jni/NativeVarnameInterface.cpp
@@ -36,4 +36,4 @@ CJNIEXPORT jobject JNICALL Java_com_dropbox_djinni_test_VarnameInterface_00024Cp
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeVarnameInterface.hpp
+++ b/test-suite/generated-src/jni/NativeVarnameInterface.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeVarnameRecord.cpp
+++ b/test-suite/generated-src/jni/NativeVarnameRecord.cpp
@@ -25,4 +25,4 @@ auto NativeVarnameRecord::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
     return {::djinni::I8::toCpp(jniEnv, jniEnv->GetByteField(j, data.field_mField))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeVarnameRecord.hpp
+++ b/test-suite/generated-src/jni/NativeVarnameRecord.hpp
@@ -29,4 +29,4 @@ private:
     const jfieldID field_mField { ::djinni::jniGetFieldID(clazz.get(), "mField", "B") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeVec2.cpp
+++ b/test-suite/generated-src/jni/NativeVec2.cpp
@@ -27,4 +27,4 @@ auto NativeVec2::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
             ::djinni::I32::toCpp(jniEnv, jniEnv->GetIntField(j, data.field_mY))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeVec2.hpp
+++ b/test-suite/generated-src/jni/NativeVec2.hpp
@@ -30,4 +30,4 @@ private:
     const jfieldID field_mY { ::djinni::jniGetFieldID(clazz.get(), "mY", "I") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeWcharTestHelpers.cpp
+++ b/test-suite/generated-src/jni/NativeWcharTestHelpers.cpp
@@ -51,4 +51,4 @@ CJNIEXPORT jboolean JNICALL Java_com_dropbox_djinni_test_WcharTestHelpers_checkR
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeWcharTestHelpers.hpp
+++ b/test-suite/generated-src/jni/NativeWcharTestHelpers.hpp
@@ -29,4 +29,4 @@ private:
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeWcharTestRec.cpp
+++ b/test-suite/generated-src/jni/NativeWcharTestRec.cpp
@@ -25,4 +25,4 @@ auto NativeWcharTestRec::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
     return {::djinni::WString::toCpp(jniEnv, (jstring)jniEnv->GetObjectField(j, data.field_mS))};
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/jni/NativeWcharTestRec.hpp
+++ b/test-suite/generated-src/jni/NativeWcharTestRec.hpp
@@ -29,4 +29,4 @@ private:
     const jfieldID field_mS { ::djinni::jniGetFieldID(clazz.get(), "mS", "Ljava/lang/String;") };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBAssortedPrimitives+Private.h
+++ b/test-suite/generated-src/objc/DBAssortedPrimitives+Private.h
@@ -21,4 +21,4 @@ struct AssortedPrimitives
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBAssortedPrimitives+Private.mm
+++ b/test-suite/generated-src/objc/DBAssortedPrimitives+Private.mm
@@ -44,4 +44,4 @@ auto AssortedPrimitives::fromCpp(const CppType& cpp) -> ObjcType
                                        oFsixtyfour:(::djinni::Optional<std::experimental::optional, ::djinni::F64>::fromCpp(cpp.o_fsixtyfour))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBAsyncInterface+Private.h
+++ b/test-suite/generated-src/objc/DBAsyncInterface+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBAsyncInterface+Private.mm
+++ b/test-suite/generated-src/objc/DBAsyncInterface+Private.mm
@@ -28,7 +28,7 @@ public:
     }
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 namespace djinni_generated {
 
@@ -48,4 +48,4 @@ auto AsyncInterface::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return dynamic_cast<ObjcProxy&>(*cpp).djinni_private_get_proxied_objc_object();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBClientInterface+Private.h
+++ b/test-suite/generated-src/objc/DBClientInterface+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBClientInterface+Private.mm
+++ b/test-suite/generated-src/objc/DBClientInterface+Private.mm
@@ -60,7 +60,7 @@ public:
     }
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 namespace djinni_generated {
 
@@ -80,4 +80,4 @@ auto ClientInterface::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return dynamic_cast<ObjcProxy&>(*cpp).djinni_private_get_proxied_objc_object();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBClientReturnedRecord+Private.h
+++ b/test-suite/generated-src/objc/DBClientReturnedRecord+Private.h
@@ -21,4 +21,4 @@ struct ClientReturnedRecord
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBClientReturnedRecord+Private.mm
+++ b/test-suite/generated-src/objc/DBClientReturnedRecord+Private.mm
@@ -22,4 +22,4 @@ auto ClientReturnedRecord::fromCpp(const CppType& cpp) -> ObjcType
                                                        misc:(::djinni::Optional<std::experimental::optional, ::djinni::String>::fromCpp(cpp.misc))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBConflict+Private.h
+++ b/test-suite/generated-src/objc/DBConflict+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBConflict+Private.mm
+++ b/test-suite/generated-src/objc/DBConflict+Private.mm
@@ -47,6 +47,6 @@ auto Conflict::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBConflict>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBConflictUser+Private.h
+++ b/test-suite/generated-src/objc/DBConflictUser+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBConflictUser+Private.mm
+++ b/test-suite/generated-src/objc/DBConflictUser+Private.mm
@@ -63,6 +63,6 @@ auto ConflictUser::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBConflictUser>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBConstantInterfaceWithEnum+Private.h
+++ b/test-suite/generated-src/objc/DBConstantInterfaceWithEnum+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBConstantInterfaceWithEnum+Private.mm
+++ b/test-suite/generated-src/objc/DBConstantInterfaceWithEnum+Private.mm
@@ -55,6 +55,6 @@ auto ConstantInterfaceWithEnum::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBConstantInterfaceWithEnum>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBConstantRecord+Private.h
+++ b/test-suite/generated-src/objc/DBConstantRecord+Private.h
@@ -21,4 +21,4 @@ struct ConstantRecord
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBConstantRecord+Private.mm
+++ b/test-suite/generated-src/objc/DBConstantRecord+Private.mm
@@ -20,4 +20,4 @@ auto ConstantRecord::fromCpp(const CppType& cpp) -> ObjcType
                                               someString:(::djinni::String::fromCpp(cpp.some_string))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBConstantWithEnum+Private.h
+++ b/test-suite/generated-src/objc/DBConstantWithEnum+Private.h
@@ -21,4 +21,4 @@ struct ConstantWithEnum
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBConstantWithEnum+Private.mm
+++ b/test-suite/generated-src/objc/DBConstantWithEnum+Private.mm
@@ -20,4 +20,4 @@ auto ConstantWithEnum::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBConstantWithEnum alloc] init];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBConstants+Private.h
+++ b/test-suite/generated-src/objc/DBConstants+Private.h
@@ -21,4 +21,4 @@ struct Constants
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBConstants+Private.mm
+++ b/test-suite/generated-src/objc/DBConstants+Private.mm
@@ -21,4 +21,4 @@ auto Constants::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBConstants alloc] init];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBConstantsInterface+Private.h
+++ b/test-suite/generated-src/objc/DBConstantsInterface+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBConstantsInterface+Private.mm
+++ b/test-suite/generated-src/objc/DBConstantsInterface+Private.mm
@@ -105,6 +105,6 @@ auto ConstantsInterface::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBConstantsInterface>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBCppException+Private.h
+++ b/test-suite/generated-src/objc/DBCppException+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBCppException+Private.mm
+++ b/test-suite/generated-src/objc/DBCppException+Private.mm
@@ -77,6 +77,6 @@ auto CppException::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBCppException>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBDataRefTest+Private.h
+++ b/test-suite/generated-src/objc/DBDataRefTest+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBDataRefTest+Private.mm
+++ b/test-suite/generated-src/objc/DBDataRefTest+Private.mm
@@ -111,6 +111,6 @@ auto DataRefTest::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBDataRefTest>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBDateRecord+Private.h
+++ b/test-suite/generated-src/objc/DBDateRecord+Private.h
@@ -21,4 +21,4 @@ struct DateRecord
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBDateRecord+Private.mm
+++ b/test-suite/generated-src/objc/DBDateRecord+Private.mm
@@ -18,4 +18,4 @@ auto DateRecord::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBDateRecord alloc] initWithCreatedAt:(::djinni::Date::fromCpp(cpp.created_at))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBEmptyRecord+Private.h
+++ b/test-suite/generated-src/objc/DBEmptyRecord+Private.h
@@ -21,4 +21,4 @@ struct EmptyRecord
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBEmptyRecord+Private.mm
+++ b/test-suite/generated-src/objc/DBEmptyRecord+Private.mm
@@ -19,4 +19,4 @@ auto EmptyRecord::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBEmptyRecord alloc] init];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBEnumUsageInterface+Private.h
+++ b/test-suite/generated-src/objc/DBEnumUsageInterface+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBEnumUsageInterface+Private.mm
+++ b/test-suite/generated-src/objc/DBEnumUsageInterface+Private.mm
@@ -113,7 +113,7 @@ public:
     }
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 namespace djinni_generated {
 
@@ -139,6 +139,6 @@ auto EnumUsageInterface::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBEnumUsageInterfaceCppProxy>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBEnumUsageRecord+Private.h
+++ b/test-suite/generated-src/objc/DBEnumUsageRecord+Private.h
@@ -21,4 +21,4 @@ struct EnumUsageRecord
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBEnumUsageRecord+Private.mm
+++ b/test-suite/generated-src/objc/DBEnumUsageRecord+Private.mm
@@ -27,4 +27,4 @@ auto EnumUsageRecord::fromCpp(const CppType& cpp) -> ObjcType
                                               m:(::djinni::Map<::djinni::Enum<::testsuite::color, DBColor>, ::djinni::Enum<::testsuite::color, DBColor>>::fromCpp(cpp.m))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBExtendedRecord+Private.h
+++ b/test-suite/generated-src/objc/DBExtendedRecord+Private.h
@@ -21,4 +21,4 @@ struct ExtendedRecord
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBExtendedRecord+Private.mm
+++ b/test-suite/generated-src/objc/DBExtendedRecord+Private.mm
@@ -18,4 +18,4 @@ auto ExtendedRecord::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBExtendedRecord alloc] initWithFoo:(::djinni::Bool::fromCpp(cpp.foo))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBExternInterface1+Private.h
+++ b/test-suite/generated-src/objc/DBExternInterface1+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBExternInterface1+Private.mm
+++ b/test-suite/generated-src/objc/DBExternInterface1+Private.mm
@@ -64,6 +64,6 @@ auto ExternInterface1::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBExternInterface1>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBExternInterface2+Private.h
+++ b/test-suite/generated-src/objc/DBExternInterface2+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBExternInterface2+Private.mm
+++ b/test-suite/generated-src/objc/DBExternInterface2+Private.mm
@@ -28,7 +28,7 @@ public:
     }
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 namespace djinni_generated {
 
@@ -48,4 +48,4 @@ auto ExternInterface2::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return dynamic_cast<ObjcProxy&>(*cpp).djinni_private_get_proxied_objc_object();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBExternRecordWithDerivings+Private.h
+++ b/test-suite/generated-src/objc/DBExternRecordWithDerivings+Private.h
@@ -21,4 +21,4 @@ struct ExternRecordWithDerivings
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBExternRecordWithDerivings+Private.mm
+++ b/test-suite/generated-src/objc/DBExternRecordWithDerivings+Private.mm
@@ -21,4 +21,4 @@ auto ExternRecordWithDerivings::fromCpp(const CppType& cpp) -> ObjcType
                                                              e:(::djinni::Enum<::testsuite::color, DBColor>::fromCpp(cpp.e))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBFirstListener+Private.h
+++ b/test-suite/generated-src/objc/DBFirstListener+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBFirstListener+Private.mm
+++ b/test-suite/generated-src/objc/DBFirstListener+Private.mm
@@ -25,7 +25,7 @@ public:
     }
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 namespace djinni_generated {
 
@@ -45,4 +45,4 @@ auto FirstListener::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return dynamic_cast<ObjcProxy&>(*cpp).djinni_private_get_proxied_objc_object();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBFlagRoundtrip+Private.h
+++ b/test-suite/generated-src/objc/DBFlagRoundtrip+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBFlagRoundtrip+Private.mm
+++ b/test-suite/generated-src/objc/DBFlagRoundtrip+Private.mm
@@ -78,6 +78,6 @@ auto FlagRoundtrip::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBFlagRoundtrip>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBFunctionPrologueHelper+Private.h
+++ b/test-suite/generated-src/objc/DBFunctionPrologueHelper+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBFunctionPrologueHelper+Private.mm
+++ b/test-suite/generated-src/objc/DBFunctionPrologueHelper+Private.mm
@@ -57,6 +57,6 @@ auto FunctionPrologueHelper::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBFunctionPrologueHelper>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBInterfaceUsingExtendedRecord+Private.h
+++ b/test-suite/generated-src/objc/DBInterfaceUsingExtendedRecord+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBInterfaceUsingExtendedRecord+Private.mm
+++ b/test-suite/generated-src/objc/DBInterfaceUsingExtendedRecord+Private.mm
@@ -63,6 +63,6 @@ auto InterfaceUsingExtendedRecord::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBInterfaceUsingExtendedRecord>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBJavaOnlyListener+Private.h
+++ b/test-suite/generated-src/objc/DBJavaOnlyListener+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBJavaOnlyListener+Private.mm
+++ b/test-suite/generated-src/objc/DBJavaOnlyListener+Private.mm
@@ -26,4 +26,4 @@ auto JavaOnlyListener::fromCppOpt(const CppOptType& cpp) -> ObjcType
     DJINNI_UNIMPLEMENTED(@"Interface not implementable in any language.");
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBListenerCaller+Private.h
+++ b/test-suite/generated-src/objc/DBListenerCaller+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBListenerCaller+Private.mm
+++ b/test-suite/generated-src/objc/DBListenerCaller+Private.mm
@@ -70,6 +70,6 @@ auto ListenerCaller::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBListenerCaller>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBMapDateRecord+Private.h
+++ b/test-suite/generated-src/objc/DBMapDateRecord+Private.h
@@ -21,4 +21,4 @@ struct MapDateRecord
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBMapDateRecord+Private.mm
+++ b/test-suite/generated-src/objc/DBMapDateRecord+Private.mm
@@ -18,4 +18,4 @@ auto MapDateRecord::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBMapDateRecord alloc] initWithDatesById:(::djinni::Map<::djinni::String, ::djinni::Date>::fromCpp(cpp.dates_by_id))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBMapListRecord+Private.h
+++ b/test-suite/generated-src/objc/DBMapListRecord+Private.h
@@ -21,4 +21,4 @@ struct MapListRecord
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBMapListRecord+Private.mm
+++ b/test-suite/generated-src/objc/DBMapListRecord+Private.mm
@@ -18,4 +18,4 @@ auto MapListRecord::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBMapListRecord alloc] initWithMapList:(::djinni::List<::djinni::Map<::djinni::String, ::djinni::I64>>::fromCpp(cpp.map_list))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBMapRecord+Private.h
+++ b/test-suite/generated-src/objc/DBMapRecord+Private.h
@@ -21,4 +21,4 @@ struct MapRecord
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBMapRecord+Private.mm
+++ b/test-suite/generated-src/objc/DBMapRecord+Private.mm
@@ -20,4 +20,4 @@ auto MapRecord::fromCpp(const CppType& cpp) -> ObjcType
                                        imap:(::djinni::Map<::djinni::I32, ::djinni::I32>::fromCpp(cpp.imap))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBNestedCollection+Private.h
+++ b/test-suite/generated-src/objc/DBNestedCollection+Private.h
@@ -21,4 +21,4 @@ struct NestedCollection
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBNestedCollection+Private.mm
+++ b/test-suite/generated-src/objc/DBNestedCollection+Private.mm
@@ -18,4 +18,4 @@ auto NestedCollection::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBNestedCollection alloc] initWithSetList:(::djinni::List<::djinni::Set<::djinni::String>>::fromCpp(cpp.set_list))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBNestedOutcome+Private.h
+++ b/test-suite/generated-src/objc/DBNestedOutcome+Private.h
@@ -21,4 +21,4 @@ struct NestedOutcome
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBNestedOutcome+Private.mm
+++ b/test-suite/generated-src/objc/DBNestedOutcome+Private.mm
@@ -19,4 +19,4 @@ auto NestedOutcome::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBNestedOutcome alloc] initWithO:(::djinni::Outcome<::djinni::I32, ::djinni::String>::fromCpp(cpp.o))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBObjcOnlyListener+Private.h
+++ b/test-suite/generated-src/objc/DBObjcOnlyListener+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBObjcOnlyListener+Private.mm
+++ b/test-suite/generated-src/objc/DBObjcOnlyListener+Private.mm
@@ -19,7 +19,7 @@ public:
     using ObjcProxyBase::ObjcProxyBase;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 namespace djinni_generated {
 
@@ -39,4 +39,4 @@ auto ObjcOnlyListener::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return dynamic_cast<ObjcProxy&>(*cpp).djinni_private_get_proxied_objc_object();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBPrimitiveList+Private.h
+++ b/test-suite/generated-src/objc/DBPrimitiveList+Private.h
@@ -21,4 +21,4 @@ struct PrimitiveList
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBPrimitiveList+Private.mm
+++ b/test-suite/generated-src/objc/DBPrimitiveList+Private.mm
@@ -18,4 +18,4 @@ auto PrimitiveList::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBPrimitiveList alloc] initWithList:(::djinni::List<::djinni::I64>::fromCpp(cpp.list))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBProtoTests+Private.h
+++ b/test-suite/generated-src/objc/DBProtoTests+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBProtoTests+Private.mm
+++ b/test-suite/generated-src/objc/DBProtoTests+Private.mm
@@ -143,6 +143,6 @@ auto ProtoTests::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBProtoTests>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBRecordUsingExtendedRecord+Private.h
+++ b/test-suite/generated-src/objc/DBRecordUsingExtendedRecord+Private.h
@@ -21,4 +21,4 @@ struct RecordUsingExtendedRecord
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBRecordUsingExtendedRecord+Private.mm
+++ b/test-suite/generated-src/objc/DBRecordUsingExtendedRecord+Private.mm
@@ -18,4 +18,4 @@ auto RecordUsingExtendedRecord::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBRecordUsingExtendedRecord alloc] initWithEr:(::djinni_generated::ExtendedRecord::fromCpp(cpp.er))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBRecordWithDerivings+Private.h
+++ b/test-suite/generated-src/objc/DBRecordWithDerivings+Private.h
@@ -21,4 +21,4 @@ struct RecordWithDerivings
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBRecordWithDerivings+Private.mm
+++ b/test-suite/generated-src/objc/DBRecordWithDerivings+Private.mm
@@ -32,4 +32,4 @@ auto RecordWithDerivings::fromCpp(const CppType& cpp) -> ObjcType
                                                       s:(::djinni::String::fromCpp(cpp.s))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBRecordWithDurationAndDerivings+Private.h
+++ b/test-suite/generated-src/objc/DBRecordWithDurationAndDerivings+Private.h
@@ -21,4 +21,4 @@ struct RecordWithDurationAndDerivings
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBRecordWithDurationAndDerivings+Private.mm
+++ b/test-suite/generated-src/objc/DBRecordWithDurationAndDerivings+Private.mm
@@ -19,4 +19,4 @@ auto RecordWithDurationAndDerivings::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBRecordWithDurationAndDerivings alloc] initWithDt:(::djinni::Duration<::djinni::F64, ::djinni::Duration_ns>::fromCpp(cpp.dt))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBRecordWithEmbeddedCppProto+Private.h
+++ b/test-suite/generated-src/objc/DBRecordWithEmbeddedCppProto+Private.h
@@ -21,4 +21,4 @@ struct RecordWithEmbeddedCppProto
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBRecordWithEmbeddedCppProto+Private.mm
+++ b/test-suite/generated-src/objc/DBRecordWithEmbeddedCppProto+Private.mm
@@ -18,4 +18,4 @@ auto RecordWithEmbeddedCppProto::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBRecordWithEmbeddedCppProto alloc] initWithState:(::djinni::ProtobufPassthrough<::djinni::test2::PersistingState>::fromCpp(cpp.state))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBRecordWithEmbeddedProto+Private.h
+++ b/test-suite/generated-src/objc/DBRecordWithEmbeddedProto+Private.h
@@ -21,4 +21,4 @@ struct RecordWithEmbeddedProto
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBRecordWithEmbeddedProto+Private.mm
+++ b/test-suite/generated-src/objc/DBRecordWithEmbeddedProto+Private.mm
@@ -19,4 +19,4 @@ auto RecordWithEmbeddedProto::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBRecordWithEmbeddedProto alloc] initWithPerson:(::djinni::Protobuf<::djinni::test::Person, DJTestPerson>::fromCpp(cpp.person))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBRecordWithFlags+Private.h
+++ b/test-suite/generated-src/objc/DBRecordWithFlags+Private.h
@@ -21,4 +21,4 @@ struct RecordWithFlags
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBRecordWithFlags+Private.mm
+++ b/test-suite/generated-src/objc/DBRecordWithFlags+Private.mm
@@ -18,4 +18,4 @@ auto RecordWithFlags::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBRecordWithFlags alloc] initWithAccess:(::djinni::Enum<::testsuite::access_flags, DBAccessFlags>::fromCpp(cpp.access))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBRecordWithNestedDerivings+Private.h
+++ b/test-suite/generated-src/objc/DBRecordWithNestedDerivings+Private.h
@@ -21,4 +21,4 @@ struct RecordWithNestedDerivings
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBRecordWithNestedDerivings+Private.mm
+++ b/test-suite/generated-src/objc/DBRecordWithNestedDerivings+Private.mm
@@ -21,4 +21,4 @@ auto RecordWithNestedDerivings::fromCpp(const CppType& cpp) -> ObjcType
                                                         rec:(::djinni_generated::RecordWithDerivings::fromCpp(cpp.rec))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBReturnOne+Private.h
+++ b/test-suite/generated-src/objc/DBReturnOne+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBReturnOne+Private.mm
+++ b/test-suite/generated-src/objc/DBReturnOne+Private.mm
@@ -62,6 +62,6 @@ auto ReturnOne::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBReturnOne>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBReturnTwo+Private.h
+++ b/test-suite/generated-src/objc/DBReturnTwo+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBReturnTwo+Private.mm
+++ b/test-suite/generated-src/objc/DBReturnTwo+Private.mm
@@ -62,6 +62,6 @@ auto ReturnTwo::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBReturnTwo>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBReverseClientInterface+Private.h
+++ b/test-suite/generated-src/objc/DBReverseClientInterface+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBReverseClientInterface+Private.mm
+++ b/test-suite/generated-src/objc/DBReverseClientInterface+Private.mm
@@ -76,6 +76,6 @@ auto ReverseClientInterface::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBReverseClientInterface>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBSampleInterface+Private.h
+++ b/test-suite/generated-src/objc/DBSampleInterface+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBSampleInterface+Private.mm
+++ b/test-suite/generated-src/objc/DBSampleInterface+Private.mm
@@ -47,6 +47,6 @@ auto SampleInterface::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBSampleInterface>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBSecondListener+Private.h
+++ b/test-suite/generated-src/objc/DBSecondListener+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBSecondListener+Private.mm
+++ b/test-suite/generated-src/objc/DBSecondListener+Private.mm
@@ -25,7 +25,7 @@ public:
     }
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 namespace djinni_generated {
 
@@ -45,4 +45,4 @@ auto SecondListener::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return dynamic_cast<ObjcProxy&>(*cpp).djinni_private_get_proxied_objc_object();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBSetRecord+Private.h
+++ b/test-suite/generated-src/objc/DBSetRecord+Private.h
@@ -21,4 +21,4 @@ struct SetRecord
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBSetRecord+Private.mm
+++ b/test-suite/generated-src/objc/DBSetRecord+Private.mm
@@ -20,4 +20,4 @@ auto SetRecord::fromCpp(const CppType& cpp) -> ObjcType
                                        iset:(::djinni::Set<::djinni::I32>::fromCpp(cpp.iset))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBSupportCopying+Private.h
+++ b/test-suite/generated-src/objc/DBSupportCopying+Private.h
@@ -21,4 +21,4 @@ struct SupportCopying
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBSupportCopying+Private.mm
+++ b/test-suite/generated-src/objc/DBSupportCopying+Private.mm
@@ -18,4 +18,4 @@ auto SupportCopying::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBSupportCopying alloc] initWithX:(::djinni::I32::fromCpp(cpp.x))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBTestArray+Private.h
+++ b/test-suite/generated-src/objc/DBTestArray+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBTestArray+Private.mm
+++ b/test-suite/generated-src/objc/DBTestArray+Private.mm
@@ -77,6 +77,6 @@ auto TestArray::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBTestArray>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBTestDuration+Private.h
+++ b/test-suite/generated-src/objc/DBTestDuration+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBTestDuration+Private.mm
+++ b/test-suite/generated-src/objc/DBTestDuration+Private.mm
@@ -189,6 +189,6 @@ auto TestDuration::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBTestDuration>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBTestHelpers+Private.h
+++ b/test-suite/generated-src/objc/DBTestHelpers+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBTestHelpers+Private.mm
+++ b/test-suite/generated-src/objc/DBTestHelpers+Private.mm
@@ -305,6 +305,6 @@ auto TestHelpers::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBTestHelpers>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBTestIdentRecord+Private.h
+++ b/test-suite/generated-src/objc/DBTestIdentRecord+Private.h
@@ -21,4 +21,4 @@ struct TestIdentRecord
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBTestIdentRecord+Private.mm
+++ b/test-suite/generated-src/objc/DBTestIdentRecord+Private.mm
@@ -20,4 +20,4 @@ auto TestIdentRecord::fromCpp(const CppType& cpp) -> ObjcType
                                              secondValue:(::djinni::String::fromCpp(cpp.second_value))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBTestJavaAbstractClassOnly+Private.h
+++ b/test-suite/generated-src/objc/DBTestJavaAbstractClassOnly+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBTestJavaAbstractClassOnly+Private.mm
+++ b/test-suite/generated-src/objc/DBTestJavaAbstractClassOnly+Private.mm
@@ -55,6 +55,6 @@ auto TestJavaAbstractClassOnly::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBTestJavaAbstractClassOnly>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBTestJavaInterfaceOnly+Private.h
+++ b/test-suite/generated-src/objc/DBTestJavaInterfaceOnly+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBTestJavaInterfaceOnly+Private.mm
+++ b/test-suite/generated-src/objc/DBTestJavaInterfaceOnly+Private.mm
@@ -27,4 +27,4 @@ auto TestJavaInterfaceOnly::fromCppOpt(const CppOptType& cpp) -> ObjcType
     DJINNI_UNIMPLEMENTED(@"Interface not implementable in any language.");
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBTestOptionalExternInterfaceRecord+Private.h
+++ b/test-suite/generated-src/objc/DBTestOptionalExternInterfaceRecord+Private.h
@@ -21,4 +21,4 @@ struct TestOptionalExternInterfaceRecord
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBTestOptionalExternInterfaceRecord+Private.mm
+++ b/test-suite/generated-src/objc/DBTestOptionalExternInterfaceRecord+Private.mm
@@ -19,4 +19,4 @@ auto TestOptionalExternInterfaceRecord::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBTestOptionalExternInterfaceRecord alloc] initWithSampleInterface:(::djinni::Optional<std::experimental::optional, ::djinni_generated::SampleInterface>::fromCpp(cpp.sample_interface))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBTestOutcome+Private.h
+++ b/test-suite/generated-src/objc/DBTestOutcome+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBTestOutcome+Private.mm
+++ b/test-suite/generated-src/objc/DBTestOutcome+Private.mm
@@ -106,6 +106,6 @@ auto TestOutcome::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBTestOutcome>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBTestStaticMethodLanguage+Private.h
+++ b/test-suite/generated-src/objc/DBTestStaticMethodLanguage+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBTestStaticMethodLanguage+Private.mm
+++ b/test-suite/generated-src/objc/DBTestStaticMethodLanguage+Private.mm
@@ -47,6 +47,6 @@ auto TestStaticMethodLanguage::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBTestStaticMethodLanguage>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBThrowingInterface+Private.h
+++ b/test-suite/generated-src/objc/DBThrowingInterface+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBThrowingInterface+Private.mm
+++ b/test-suite/generated-src/objc/DBThrowingInterface+Private.mm
@@ -26,4 +26,4 @@ auto ThrowingInterface::fromCppOpt(const CppOptType& cpp) -> ObjcType
     DJINNI_UNIMPLEMENTED(@"Interface not implementable in any language.");
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBUserToken+Private.h
+++ b/test-suite/generated-src/objc/DBUserToken+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBUserToken+Private.mm
+++ b/test-suite/generated-src/objc/DBUserToken+Private.mm
@@ -56,7 +56,7 @@ public:
     }
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 namespace djinni_generated {
 
@@ -82,6 +82,6 @@ auto UserToken::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBUserTokenCppProxy>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBUsesSingleLanguageListeners+Private.h
+++ b/test-suite/generated-src/objc/DBUsesSingleLanguageListeners+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBUsesSingleLanguageListeners+Private.mm
+++ b/test-suite/generated-src/objc/DBUsesSingleLanguageListeners+Private.mm
@@ -95,7 +95,7 @@ public:
     }
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 namespace djinni_generated {
 
@@ -121,6 +121,6 @@ auto UsesSingleLanguageListeners::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBUsesSingleLanguageListenersCppProxy>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBVarnameInterface+Private.h
+++ b/test-suite/generated-src/objc/DBVarnameInterface+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBVarnameInterface+Private.mm
+++ b/test-suite/generated-src/objc/DBVarnameInterface+Private.mm
@@ -62,6 +62,6 @@ auto VarnameInterface::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBVarnameInterface>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBVarnameRecord+Private.h
+++ b/test-suite/generated-src/objc/DBVarnameRecord+Private.h
@@ -21,4 +21,4 @@ struct VarnameRecord
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBVarnameRecord+Private.mm
+++ b/test-suite/generated-src/objc/DBVarnameRecord+Private.mm
@@ -18,4 +18,4 @@ auto VarnameRecord::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBVarnameRecord alloc] initWithField:(::djinni::I8::fromCpp(cpp._field_))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBVec2+Private.h
+++ b/test-suite/generated-src/objc/DBVec2+Private.h
@@ -21,4 +21,4 @@ struct Vec2
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBVec2+Private.mm
+++ b/test-suite/generated-src/objc/DBVec2+Private.mm
@@ -20,4 +20,4 @@ auto Vec2::fromCpp(const CppType& cpp) -> ObjcType
                                    y:(::djinni::I32::fromCpp(cpp.y))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBWcharTestHelpers+Private.h
+++ b/test-suite/generated-src/objc/DBWcharTestHelpers+Private.h
@@ -27,5 +27,5 @@ private:
     class ObjcProxy;
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 

--- a/test-suite/generated-src/objc/DBWcharTestHelpers+Private.mm
+++ b/test-suite/generated-src/objc/DBWcharTestHelpers+Private.mm
@@ -77,6 +77,6 @@ auto WcharTestHelpers::fromCppOpt(const CppOptType& cpp) -> ObjcType
     return ::djinni::get_cpp_proxy<DBWcharTestHelpers>(cpp);
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated
 
 @end

--- a/test-suite/generated-src/objc/DBWcharTestRec+Private.h
+++ b/test-suite/generated-src/objc/DBWcharTestRec+Private.h
@@ -21,4 +21,4 @@ struct WcharTestRec
     static ObjcType fromCpp(const CppType& cpp);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/objc/DBWcharTestRec+Private.mm
+++ b/test-suite/generated-src/objc/DBWcharTestRec+Private.mm
@@ -18,4 +18,4 @@ auto WcharTestRec::fromCpp(const CppType& cpp) -> ObjcType
     return [[DBWcharTestRec alloc] initWithS:(::djinni::WString::fromCpp(cpp.s))];
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeAccessFlags.cpp
+++ b/test-suite/generated-src/wasm/NativeAccessFlags.cpp
@@ -36,4 +36,4 @@ EMSCRIPTEN_BINDINGS(testsuite_access_flags) {
     NativeAccessFlags::staticInitializeConstants();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeAccessFlags.hpp
+++ b/test-suite/generated-src/wasm/NativeAccessFlags.hpp
@@ -12,4 +12,4 @@ struct NativeAccessFlags: ::djinni::WasmEnum<::testsuite::access_flags> {
     static void staticInitializeConstants();
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeAssortedPrimitives.cpp
+++ b/test-suite/generated-src/wasm/NativeAssortedPrimitives.cpp
@@ -40,4 +40,4 @@ auto NativeAssortedPrimitives::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeAssortedPrimitives.hpp
+++ b/test-suite/generated-src/wasm/NativeAssortedPrimitives.hpp
@@ -18,4 +18,4 @@ struct NativeAssortedPrimitives
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeAsyncInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeAsyncInterface.cpp
@@ -20,4 +20,4 @@ EMSCRIPTEN_BINDINGS(testsuite_async_interface) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeAsyncInterface.hpp
+++ b/test-suite/generated-src/wasm/NativeAsyncInterface.hpp
@@ -28,4 +28,4 @@ struct NativeAsyncInterface : ::djinni::JsInterface<::testsuite::AsyncInterface,
     };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeClientInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeClientInterface.cpp
@@ -48,4 +48,4 @@ EMSCRIPTEN_BINDINGS(testsuite_client_interface) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeClientInterface.hpp
+++ b/test-suite/generated-src/wasm/NativeClientInterface.hpp
@@ -32,4 +32,4 @@ struct NativeClientInterface : ::djinni::JsInterface<::testsuite::ClientInterfac
     };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeClientReturnedRecord.cpp
+++ b/test-suite/generated-src/wasm/NativeClientReturnedRecord.cpp
@@ -18,4 +18,4 @@ auto NativeClientReturnedRecord::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeClientReturnedRecord.hpp
+++ b/test-suite/generated-src/wasm/NativeClientReturnedRecord.hpp
@@ -18,4 +18,4 @@ struct NativeClientReturnedRecord
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeColor.cpp
+++ b/test-suite/generated-src/wasm/NativeColor.cpp
@@ -37,4 +37,4 @@ EMSCRIPTEN_BINDINGS(testsuite_color) {
     NativeColor::staticInitializeConstants();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeColor.hpp
+++ b/test-suite/generated-src/wasm/NativeColor.hpp
@@ -12,4 +12,4 @@ struct NativeColor: ::djinni::WasmEnum<::testsuite::color> {
     static void staticInitializeConstants();
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeConflict.cpp
+++ b/test-suite/generated-src/wasm/NativeConflict.cpp
@@ -19,4 +19,4 @@ EMSCRIPTEN_BINDINGS(testsuite_Conflict) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeConflict.hpp
+++ b/test-suite/generated-src/wasm/NativeConflict.hpp
@@ -26,4 +26,4 @@ struct NativeConflict : ::djinni::JsInterface<::testsuite::Conflict, NativeConfl
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeConflictUser.cpp
+++ b/test-suite/generated-src/wasm/NativeConflictUser.cpp
@@ -42,4 +42,4 @@ EMSCRIPTEN_BINDINGS(testsuite_conflict_user) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeConflictUser.hpp
+++ b/test-suite/generated-src/wasm/NativeConflictUser.hpp
@@ -28,4 +28,4 @@ struct NativeConflictUser : ::djinni::JsInterface<::testsuite::ConflictUser, Nat
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeConstantEnum.cpp
+++ b/test-suite/generated-src/wasm/NativeConstantEnum.cpp
@@ -27,4 +27,4 @@ EMSCRIPTEN_BINDINGS(testsuite_constant_enum) {
     NativeConstantEnum::staticInitializeConstants();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeConstantEnum.hpp
+++ b/test-suite/generated-src/wasm/NativeConstantEnum.hpp
@@ -12,4 +12,4 @@ struct NativeConstantEnum: ::djinni::WasmEnum<::testsuite::constant_enum> {
     static void staticInitializeConstants();
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeConstantInterfaceWithEnum.cpp
+++ b/test-suite/generated-src/wasm/NativeConstantInterfaceWithEnum.cpp
@@ -41,4 +41,4 @@ EMSCRIPTEN_BINDINGS(testsuite_constant_interface_with_enum_consts) {
     NativeConstantInterfaceWithEnum::staticInitializeConstants();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeConstantInterfaceWithEnum.hpp
+++ b/test-suite/generated-src/wasm/NativeConstantInterfaceWithEnum.hpp
@@ -27,4 +27,4 @@ struct NativeConstantInterfaceWithEnum : ::djinni::JsInterface<::testsuite::Cons
     static void staticInitializeConstants();
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeConstantRecord.cpp
+++ b/test-suite/generated-src/wasm/NativeConstantRecord.cpp
@@ -16,4 +16,4 @@ auto NativeConstantRecord::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeConstantRecord.hpp
+++ b/test-suite/generated-src/wasm/NativeConstantRecord.hpp
@@ -18,4 +18,4 @@ struct NativeConstantRecord
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeConstantWithEnum.cpp
+++ b/test-suite/generated-src/wasm/NativeConstantWithEnum.cpp
@@ -35,4 +35,4 @@ EMSCRIPTEN_BINDINGS(testsuite_constant_with_enum_consts) {
     NativeConstantWithEnum::staticInitializeConstants();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeConstantWithEnum.hpp
+++ b/test-suite/generated-src/wasm/NativeConstantWithEnum.hpp
@@ -19,4 +19,4 @@ struct NativeConstantWithEnum
     static void staticInitializeConstants();
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeConstants.cpp
+++ b/test-suite/generated-src/wasm/NativeConstants.cpp
@@ -55,4 +55,4 @@ EMSCRIPTEN_BINDINGS(testsuite_constants_consts) {
     NativeConstants::staticInitializeConstants();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeConstants.hpp
+++ b/test-suite/generated-src/wasm/NativeConstants.hpp
@@ -19,4 +19,4 @@ struct NativeConstants
     static void staticInitializeConstants();
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeConstantsInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeConstantsInterface.cpp
@@ -71,4 +71,4 @@ EMSCRIPTEN_BINDINGS(testsuite_constants_interface_consts) {
     NativeConstantsInterface::staticInitializeConstants();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeConstantsInterface.hpp
+++ b/test-suite/generated-src/wasm/NativeConstantsInterface.hpp
@@ -28,4 +28,4 @@ struct NativeConstantsInterface : ::djinni::JsInterface<::testsuite::ConstantsIn
     static void staticInitializeConstants();
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeCppException.cpp
+++ b/test-suite/generated-src/wasm/NativeCppException.cpp
@@ -63,4 +63,4 @@ EMSCRIPTEN_BINDINGS(testsuite_cpp_exception) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeCppException.hpp
+++ b/test-suite/generated-src/wasm/NativeCppException.hpp
@@ -30,4 +30,4 @@ struct NativeCppException : ::djinni::JsInterface<::testsuite::CppException, Nat
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeDataRefTest.cpp
+++ b/test-suite/generated-src/wasm/NativeDataRefTest.cpp
@@ -117,4 +117,4 @@ EMSCRIPTEN_BINDINGS(testsuite_DataRefTest) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeDataRefTest.hpp
+++ b/test-suite/generated-src/wasm/NativeDataRefTest.hpp
@@ -35,4 +35,4 @@ struct NativeDataRefTest : ::djinni::JsInterface<::testsuite::DataRefTest, Nativ
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeDateRecord.cpp
+++ b/test-suite/generated-src/wasm/NativeDateRecord.cpp
@@ -15,4 +15,4 @@ auto NativeDateRecord::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeDateRecord.hpp
+++ b/test-suite/generated-src/wasm/NativeDateRecord.hpp
@@ -18,4 +18,4 @@ struct NativeDateRecord
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeEmptyFlags.cpp
+++ b/test-suite/generated-src/wasm/NativeEmptyFlags.cpp
@@ -27,4 +27,4 @@ EMSCRIPTEN_BINDINGS(testsuite_empty_flags) {
     NativeEmptyFlags::staticInitializeConstants();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeEmptyFlags.hpp
+++ b/test-suite/generated-src/wasm/NativeEmptyFlags.hpp
@@ -12,4 +12,4 @@ struct NativeEmptyFlags: ::djinni::WasmEnum<::testsuite::empty_flags> {
     static void staticInitializeConstants();
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeEmptyRecord.cpp
+++ b/test-suite/generated-src/wasm/NativeEmptyRecord.cpp
@@ -13,4 +13,4 @@ auto NativeEmptyRecord::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeEmptyRecord.hpp
+++ b/test-suite/generated-src/wasm/NativeEmptyRecord.hpp
@@ -18,4 +18,4 @@ struct NativeEmptyRecord
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeEnumUsageInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeEnumUsageInterface.cpp
@@ -105,4 +105,4 @@ EMSCRIPTEN_BINDINGS(testsuite_enum_usage_interface) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeEnumUsageInterface.hpp
+++ b/test-suite/generated-src/wasm/NativeEnumUsageInterface.hpp
@@ -39,4 +39,4 @@ struct NativeEnumUsageInterface : ::djinni::JsInterface<::testsuite::EnumUsageIn
     };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeEnumUsageRecord.cpp
+++ b/test-suite/generated-src/wasm/NativeEnumUsageRecord.cpp
@@ -23,4 +23,4 @@ auto NativeEnumUsageRecord::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeEnumUsageRecord.hpp
+++ b/test-suite/generated-src/wasm/NativeEnumUsageRecord.hpp
@@ -18,4 +18,4 @@ struct NativeEnumUsageRecord
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeExtendedRecord.cpp
+++ b/test-suite/generated-src/wasm/NativeExtendedRecord.cpp
@@ -37,4 +37,4 @@ EMSCRIPTEN_BINDINGS(testsuite_extended_record_consts) {
     NativeExtendedRecord::staticInitializeConstants();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeExtendedRecord.hpp
+++ b/test-suite/generated-src/wasm/NativeExtendedRecord.hpp
@@ -19,4 +19,4 @@ struct NativeExtendedRecord
     static void staticInitializeConstants();
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeExternInterface1.cpp
+++ b/test-suite/generated-src/wasm/NativeExternInterface1.cpp
@@ -44,4 +44,4 @@ EMSCRIPTEN_BINDINGS(_extern_interface_1) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeExternInterface1.hpp
+++ b/test-suite/generated-src/wasm/NativeExternInterface1.hpp
@@ -28,4 +28,4 @@ struct NativeExternInterface1 : ::djinni::JsInterface<::ExternInterface1, Native
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeExternInterface2.cpp
+++ b/test-suite/generated-src/wasm/NativeExternInterface2.cpp
@@ -21,4 +21,4 @@ EMSCRIPTEN_BINDINGS(_extern_interface_2) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeExternInterface2.hpp
+++ b/test-suite/generated-src/wasm/NativeExternInterface2.hpp
@@ -28,4 +28,4 @@ struct NativeExternInterface2 : ::djinni::JsInterface<::ExternInterface2, Native
     };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeExternRecordWithDerivings.cpp
+++ b/test-suite/generated-src/wasm/NativeExternRecordWithDerivings.cpp
@@ -18,4 +18,4 @@ auto NativeExternRecordWithDerivings::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeExternRecordWithDerivings.hpp
+++ b/test-suite/generated-src/wasm/NativeExternRecordWithDerivings.hpp
@@ -18,4 +18,4 @@ struct NativeExternRecordWithDerivings
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeFirstListener.cpp
+++ b/test-suite/generated-src/wasm/NativeFirstListener.cpp
@@ -13,4 +13,4 @@ EMSCRIPTEN_BINDINGS(testsuite_first_listener) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeFirstListener.hpp
+++ b/test-suite/generated-src/wasm/NativeFirstListener.hpp
@@ -24,4 +24,4 @@ struct NativeFirstListener : ::djinni::JsInterface<::testsuite::FirstListener, N
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeFlagRoundtrip.cpp
+++ b/test-suite/generated-src/wasm/NativeFlagRoundtrip.cpp
@@ -61,4 +61,4 @@ EMSCRIPTEN_BINDINGS(testsuite_flag_roundtrip) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeFlagRoundtrip.hpp
+++ b/test-suite/generated-src/wasm/NativeFlagRoundtrip.hpp
@@ -30,4 +30,4 @@ struct NativeFlagRoundtrip : ::djinni::JsInterface<::testsuite::FlagRoundtrip, N
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeInterfaceUsingExtendedRecord.cpp
+++ b/test-suite/generated-src/wasm/NativeInterfaceUsingExtendedRecord.cpp
@@ -58,4 +58,4 @@ EMSCRIPTEN_BINDINGS(testsuite_interface_using_extended_record_consts) {
     NativeInterfaceUsingExtendedRecord::staticInitializeConstants();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeInterfaceUsingExtendedRecord.hpp
+++ b/test-suite/generated-src/wasm/NativeInterfaceUsingExtendedRecord.hpp
@@ -28,4 +28,4 @@ struct NativeInterfaceUsingExtendedRecord : ::djinni::JsInterface<::testsuite::I
     static void staticInitializeConstants();
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeJavaOnlyListener.cpp
+++ b/test-suite/generated-src/wasm/NativeJavaOnlyListener.cpp
@@ -13,4 +13,4 @@ EMSCRIPTEN_BINDINGS(testsuite_java_only_listener) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeJavaOnlyListener.hpp
+++ b/test-suite/generated-src/wasm/NativeJavaOnlyListener.hpp
@@ -24,4 +24,4 @@ struct NativeJavaOnlyListener : ::djinni::JsInterface<::testsuite::JavaOnlyListe
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeListenerCaller.cpp
+++ b/test-suite/generated-src/wasm/NativeListenerCaller.cpp
@@ -52,4 +52,4 @@ EMSCRIPTEN_BINDINGS(testsuite_listener_caller) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeListenerCaller.hpp
+++ b/test-suite/generated-src/wasm/NativeListenerCaller.hpp
@@ -29,4 +29,4 @@ struct NativeListenerCaller : ::djinni::JsInterface<::testsuite::ListenerCaller,
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeMapDateRecord.cpp
+++ b/test-suite/generated-src/wasm/NativeMapDateRecord.cpp
@@ -15,4 +15,4 @@ auto NativeMapDateRecord::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeMapDateRecord.hpp
+++ b/test-suite/generated-src/wasm/NativeMapDateRecord.hpp
@@ -18,4 +18,4 @@ struct NativeMapDateRecord
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeMapListRecord.cpp
+++ b/test-suite/generated-src/wasm/NativeMapListRecord.cpp
@@ -14,4 +14,4 @@ auto NativeMapListRecord::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeMapListRecord.hpp
+++ b/test-suite/generated-src/wasm/NativeMapListRecord.hpp
@@ -18,4 +18,4 @@ struct NativeMapListRecord
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeMapRecord.cpp
+++ b/test-suite/generated-src/wasm/NativeMapRecord.cpp
@@ -16,4 +16,4 @@ auto NativeMapRecord::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeMapRecord.hpp
+++ b/test-suite/generated-src/wasm/NativeMapRecord.hpp
@@ -18,4 +18,4 @@ struct NativeMapRecord
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeNestedCollection.cpp
+++ b/test-suite/generated-src/wasm/NativeNestedCollection.cpp
@@ -14,4 +14,4 @@ auto NativeNestedCollection::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeNestedCollection.hpp
+++ b/test-suite/generated-src/wasm/NativeNestedCollection.hpp
@@ -18,4 +18,4 @@ struct NativeNestedCollection
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeNestedOutcome.cpp
+++ b/test-suite/generated-src/wasm/NativeNestedOutcome.cpp
@@ -15,4 +15,4 @@ auto NativeNestedOutcome::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeNestedOutcome.hpp
+++ b/test-suite/generated-src/wasm/NativeNestedOutcome.hpp
@@ -18,4 +18,4 @@ struct NativeNestedOutcome
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeObjcOnlyListener.cpp
+++ b/test-suite/generated-src/wasm/NativeObjcOnlyListener.cpp
@@ -13,4 +13,4 @@ EMSCRIPTEN_BINDINGS(testsuite_objc_only_listener) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeObjcOnlyListener.hpp
+++ b/test-suite/generated-src/wasm/NativeObjcOnlyListener.hpp
@@ -24,4 +24,4 @@ struct NativeObjcOnlyListener : ::djinni::JsInterface<::testsuite::ObjcOnlyListe
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativePrimitiveList.cpp
+++ b/test-suite/generated-src/wasm/NativePrimitiveList.cpp
@@ -14,4 +14,4 @@ auto NativePrimitiveList::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativePrimitiveList.hpp
+++ b/test-suite/generated-src/wasm/NativePrimitiveList.hpp
@@ -18,4 +18,4 @@ struct NativePrimitiveList
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeProtoTests.cpp
+++ b/test-suite/generated-src/wasm/NativeProtoTests.cpp
@@ -152,4 +152,4 @@ EMSCRIPTEN_BINDINGS(testsuite_proto_tests) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeProtoTests.hpp
+++ b/test-suite/generated-src/wasm/NativeProtoTests.hpp
@@ -39,4 +39,4 @@ struct NativeProtoTests : ::djinni::JsInterface<::testsuite::ProtoTests, NativeP
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeRecordUsingExtendedRecord.cpp
+++ b/test-suite/generated-src/wasm/NativeRecordUsingExtendedRecord.cpp
@@ -41,4 +41,4 @@ EMSCRIPTEN_BINDINGS(testsuite_record_using_extended_record_consts) {
     NativeRecordUsingExtendedRecord::staticInitializeConstants();
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeRecordUsingExtendedRecord.hpp
+++ b/test-suite/generated-src/wasm/NativeRecordUsingExtendedRecord.hpp
@@ -19,4 +19,4 @@ struct NativeRecordUsingExtendedRecord
     static void staticInitializeConstants();
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeRecordWithDerivings.cpp
+++ b/test-suite/generated-src/wasm/NativeRecordWithDerivings.cpp
@@ -28,4 +28,4 @@ auto NativeRecordWithDerivings::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeRecordWithDerivings.hpp
+++ b/test-suite/generated-src/wasm/NativeRecordWithDerivings.hpp
@@ -18,4 +18,4 @@ struct NativeRecordWithDerivings
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeRecordWithDurationAndDerivings.cpp
+++ b/test-suite/generated-src/wasm/NativeRecordWithDurationAndDerivings.cpp
@@ -15,4 +15,4 @@ auto NativeRecordWithDurationAndDerivings::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeRecordWithDurationAndDerivings.hpp
+++ b/test-suite/generated-src/wasm/NativeRecordWithDurationAndDerivings.hpp
@@ -18,4 +18,4 @@ struct NativeRecordWithDurationAndDerivings
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeRecordWithEmbeddedCppProto.cpp
+++ b/test-suite/generated-src/wasm/NativeRecordWithEmbeddedCppProto.cpp
@@ -14,4 +14,4 @@ auto NativeRecordWithEmbeddedCppProto::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeRecordWithEmbeddedCppProto.hpp
+++ b/test-suite/generated-src/wasm/NativeRecordWithEmbeddedCppProto.hpp
@@ -18,4 +18,4 @@ struct NativeRecordWithEmbeddedCppProto
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeRecordWithEmbeddedProto.cpp
+++ b/test-suite/generated-src/wasm/NativeRecordWithEmbeddedProto.cpp
@@ -14,4 +14,4 @@ auto NativeRecordWithEmbeddedProto::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeRecordWithEmbeddedProto.hpp
+++ b/test-suite/generated-src/wasm/NativeRecordWithEmbeddedProto.hpp
@@ -18,4 +18,4 @@ struct NativeRecordWithEmbeddedProto
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeRecordWithFlags.cpp
+++ b/test-suite/generated-src/wasm/NativeRecordWithFlags.cpp
@@ -15,4 +15,4 @@ auto NativeRecordWithFlags::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeRecordWithFlags.hpp
+++ b/test-suite/generated-src/wasm/NativeRecordWithFlags.hpp
@@ -18,4 +18,4 @@ struct NativeRecordWithFlags
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeRecordWithNestedDerivings.cpp
+++ b/test-suite/generated-src/wasm/NativeRecordWithNestedDerivings.cpp
@@ -17,4 +17,4 @@ auto NativeRecordWithNestedDerivings::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeRecordWithNestedDerivings.hpp
+++ b/test-suite/generated-src/wasm/NativeRecordWithNestedDerivings.hpp
@@ -18,4 +18,4 @@ struct NativeRecordWithNestedDerivings
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeReturnOne.cpp
+++ b/test-suite/generated-src/wasm/NativeReturnOne.cpp
@@ -40,4 +40,4 @@ EMSCRIPTEN_BINDINGS(testsuite_return_one) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeReturnOne.hpp
+++ b/test-suite/generated-src/wasm/NativeReturnOne.hpp
@@ -28,4 +28,4 @@ struct NativeReturnOne : ::djinni::JsInterface<::testsuite::ReturnOne, NativeRet
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeReturnTwo.cpp
+++ b/test-suite/generated-src/wasm/NativeReturnTwo.cpp
@@ -40,4 +40,4 @@ EMSCRIPTEN_BINDINGS(testsuite_return_two) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeReturnTwo.hpp
+++ b/test-suite/generated-src/wasm/NativeReturnTwo.hpp
@@ -28,4 +28,4 @@ struct NativeReturnTwo : ::djinni::JsInterface<::testsuite::ReturnTwo, NativeRet
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeReverseClientInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeReverseClientInterface.cpp
@@ -62,4 +62,4 @@ EMSCRIPTEN_BINDINGS(testsuite_reverse_client_interface) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeReverseClientInterface.hpp
+++ b/test-suite/generated-src/wasm/NativeReverseClientInterface.hpp
@@ -30,4 +30,4 @@ struct NativeReverseClientInterface : ::djinni::JsInterface<::testsuite::Reverse
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeSampleInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeSampleInterface.cpp
@@ -19,4 +19,4 @@ EMSCRIPTEN_BINDINGS(testsuite_sample_interface) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeSampleInterface.hpp
+++ b/test-suite/generated-src/wasm/NativeSampleInterface.hpp
@@ -26,4 +26,4 @@ struct NativeSampleInterface : ::djinni::JsInterface<::testsuite::SampleInterfac
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeSecondListener.cpp
+++ b/test-suite/generated-src/wasm/NativeSecondListener.cpp
@@ -13,4 +13,4 @@ EMSCRIPTEN_BINDINGS(testsuite_second_listener) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeSecondListener.hpp
+++ b/test-suite/generated-src/wasm/NativeSecondListener.hpp
@@ -24,4 +24,4 @@ struct NativeSecondListener : ::djinni::JsInterface<::testsuite::SecondListener,
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeSetRecord.cpp
+++ b/test-suite/generated-src/wasm/NativeSetRecord.cpp
@@ -16,4 +16,4 @@ auto NativeSetRecord::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeSetRecord.hpp
+++ b/test-suite/generated-src/wasm/NativeSetRecord.hpp
@@ -18,4 +18,4 @@ struct NativeSetRecord
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeSupportCopying.cpp
+++ b/test-suite/generated-src/wasm/NativeSupportCopying.cpp
@@ -14,4 +14,4 @@ auto NativeSupportCopying::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeSupportCopying.hpp
+++ b/test-suite/generated-src/wasm/NativeSupportCopying.hpp
@@ -18,4 +18,4 @@ struct NativeSupportCopying
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeTestArray.cpp
+++ b/test-suite/generated-src/wasm/NativeTestArray.cpp
@@ -60,4 +60,4 @@ EMSCRIPTEN_BINDINGS(testsuite_test_array) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeTestArray.hpp
+++ b/test-suite/generated-src/wasm/NativeTestArray.hpp
@@ -30,4 +30,4 @@ struct NativeTestArray : ::djinni::JsInterface<::testsuite::TestArray, NativeTes
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeTestDuration.cpp
+++ b/test-suite/generated-src/wasm/NativeTestDuration.cpp
@@ -220,4 +220,4 @@ EMSCRIPTEN_BINDINGS(testsuite_test_duration) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeTestDuration.hpp
+++ b/test-suite/generated-src/wasm/NativeTestDuration.hpp
@@ -46,4 +46,4 @@ struct NativeTestDuration : ::djinni::JsInterface<::testsuite::TestDuration, Nat
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeTestHelpers.cpp
+++ b/test-suite/generated-src/wasm/NativeTestHelpers.cpp
@@ -383,4 +383,4 @@ EMSCRIPTEN_BINDINGS(testsuite_test_helpers) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeTestHelpers.hpp
+++ b/test-suite/generated-src/wasm/NativeTestHelpers.hpp
@@ -62,4 +62,4 @@ struct NativeTestHelpers : ::djinni::JsInterface<::testsuite::TestHelpers, Nativ
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeTestOptionalExternInterfaceRecord.cpp
+++ b/test-suite/generated-src/wasm/NativeTestOptionalExternInterfaceRecord.cpp
@@ -15,4 +15,4 @@ auto NativeTestOptionalExternInterfaceRecord::fromCpp(const CppType& c) -> JsTyp
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeTestOptionalExternInterfaceRecord.hpp
+++ b/test-suite/generated-src/wasm/NativeTestOptionalExternInterfaceRecord.hpp
@@ -18,4 +18,4 @@ struct NativeTestOptionalExternInterfaceRecord
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeTestOutcome.cpp
+++ b/test-suite/generated-src/wasm/NativeTestOutcome.cpp
@@ -101,4 +101,4 @@ EMSCRIPTEN_BINDINGS(testsuite_test_outcome) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeTestOutcome.hpp
+++ b/test-suite/generated-src/wasm/NativeTestOutcome.hpp
@@ -34,4 +34,4 @@ struct NativeTestOutcome : ::djinni::JsInterface<::testsuite::TestOutcome, Nativ
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeTestStaticMethodLanguage.cpp
+++ b/test-suite/generated-src/wasm/NativeTestStaticMethodLanguage.cpp
@@ -19,4 +19,4 @@ EMSCRIPTEN_BINDINGS(testsuite_test_static_method_language) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeTestStaticMethodLanguage.hpp
+++ b/test-suite/generated-src/wasm/NativeTestStaticMethodLanguage.hpp
@@ -26,4 +26,4 @@ struct NativeTestStaticMethodLanguage : ::djinni::JsInterface<::testsuite::TestS
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeThrowingInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeThrowingInterface.cpp
@@ -18,4 +18,4 @@ EMSCRIPTEN_BINDINGS(testsuite_throwing_interface) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeThrowingInterface.hpp
+++ b/test-suite/generated-src/wasm/NativeThrowingInterface.hpp
@@ -28,4 +28,4 @@ struct NativeThrowingInterface : ::djinni::JsInterface<::testsuite::ThrowingInte
     };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeUserToken.cpp
+++ b/test-suite/generated-src/wasm/NativeUserToken.cpp
@@ -36,4 +36,4 @@ EMSCRIPTEN_BINDINGS(testsuite_user_token) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeUserToken.hpp
+++ b/test-suite/generated-src/wasm/NativeUserToken.hpp
@@ -31,4 +31,4 @@ struct NativeUserToken : ::djinni::JsInterface<::testsuite::UserToken, NativeUse
     };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeUsesSingleLanguageListeners.cpp
+++ b/test-suite/generated-src/wasm/NativeUsesSingleLanguageListeners.cpp
@@ -85,4 +85,4 @@ EMSCRIPTEN_BINDINGS(testsuite_uses_single_language_listeners) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeUsesSingleLanguageListeners.hpp
+++ b/test-suite/generated-src/wasm/NativeUsesSingleLanguageListeners.hpp
@@ -37,4 +37,4 @@ struct NativeUsesSingleLanguageListeners : ::djinni::JsInterface<::testsuite::Us
     };
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeVarnameInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeVarnameInterface.cpp
@@ -42,4 +42,4 @@ EMSCRIPTEN_BINDINGS(testsuite__varname_interface_) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeVarnameInterface.hpp
+++ b/test-suite/generated-src/wasm/NativeVarnameInterface.hpp
@@ -28,4 +28,4 @@ struct NativeVarnameInterface : ::djinni::JsInterface<::testsuite::VarnameInterf
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeVarnameRecord.cpp
+++ b/test-suite/generated-src/wasm/NativeVarnameRecord.cpp
@@ -14,4 +14,4 @@ auto NativeVarnameRecord::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeVarnameRecord.hpp
+++ b/test-suite/generated-src/wasm/NativeVarnameRecord.hpp
@@ -18,4 +18,4 @@ struct NativeVarnameRecord
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeVec2.cpp
+++ b/test-suite/generated-src/wasm/NativeVec2.cpp
@@ -16,4 +16,4 @@ auto NativeVec2::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeVec2.hpp
+++ b/test-suite/generated-src/wasm/NativeVec2.hpp
@@ -18,4 +18,4 @@ struct NativeVec2
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeWcharTestHelpers.cpp
+++ b/test-suite/generated-src/wasm/NativeWcharTestHelpers.cpp
@@ -60,4 +60,4 @@ EMSCRIPTEN_BINDINGS(testsuite_wchar_test_helpers) {
         ;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeWcharTestHelpers.hpp
+++ b/test-suite/generated-src/wasm/NativeWcharTestHelpers.hpp
@@ -30,4 +30,4 @@ struct NativeWcharTestHelpers : ::djinni::JsInterface<::testsuite::WcharTestHelp
 
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeWcharTestRec.cpp
+++ b/test-suite/generated-src/wasm/NativeWcharTestRec.cpp
@@ -14,4 +14,4 @@ auto NativeWcharTestRec::fromCpp(const CppType& c) -> JsType {
     return js;
 }
 
-}  // namespace djinni_generated
+} // namespace djinni_generated

--- a/test-suite/generated-src/wasm/NativeWcharTestRec.hpp
+++ b/test-suite/generated-src/wasm/NativeWcharTestRec.hpp
@@ -18,4 +18,4 @@ struct NativeWcharTestRec
     static JsType fromCpp(const CppType& c);
 };
 
-}  // namespace djinni_generated
+} // namespace djinni_generated


### PR DESCRIPTION
Using `namespace ns1::ns2::ns3 {` instead of `namespace ns1 { namespace ns2 { namespace ns3 {` which slightly simplifies codegen and makes the code conformant with [modernize-concat-nested-namespaces](https://clang.llvm.org/extra/clang-tidy/checks/modernize/concat-nested-namespaces.html) clang-tidy check.