### PR TITLE
Use of all 32 bits for flags -> enum mapping of C++/ObjC - #112

### DIFF
--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -487,10 +487,17 @@ abstract class Generator(spec: Spec)
   }
 
   def writeEnumOptionAll(w: IndentWriter, e: Enum, ident: IdentConverter, delim: String = "=") {
-    for (o <- e.options.find(_.specialFlag == Some(Enum.SpecialFlag.AllFlags))) {
+    for (
+      o <- e.options.find(_.specialFlag.contains(Enum.SpecialFlag.AllFlags))
+    ) {
       writeDoc(w, o.doc)
       w.w(ident(o.ident.name) + s" $delim ")
-      w.wl(s"(1u << ${normalEnumOptions(e).size}) - 1,")
+      w.w(
+        normalEnumOptions(e)
+          .map(o => ident(o.ident.name))
+          .fold("0")((acc, o) => acc + " | " + o)
+      )
+      w.wl(",")
     }
   }
 

--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -490,7 +490,7 @@ abstract class Generator(spec: Spec)
     for (o <- e.options.find(_.specialFlag == Some(Enum.SpecialFlag.AllFlags))) {
       writeDoc(w, o.doc)
       w.w(ident(o.ident.name) + s" $delim ")
-      w.wl(s"(1 << ${normalEnumOptions(e).size}) - 1,")
+      w.wl(s"(1u << ${normalEnumOptions(e).size}) - 1,")
     }
   }
 

--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -481,7 +481,7 @@ abstract class Generator(spec: Spec)
     var shift = 0
     for (o <- normalEnumOptions(e)) {
       writeDoc(w, o.doc)
-      w.wl(ident(o.ident.name) + (if(e.flags) s" $delim 1 << $shift" else s" $delim $shift") + ",")
+      w.wl(ident(o.ident.name) + (if(e.flags) s" $delim 1u << $shift" else s" $delim $shift") + ",")
       shift += 1
     }
   }

--- a/test-suite/generated-src/cpp/access_flags.hpp
+++ b/test-suite/generated-src/cpp/access_flags.hpp
@@ -18,7 +18,7 @@ enum class access_flags : unsigned {
     SYSTEM_READ = 1u << 6,
     SYSTEM_WRITE = 1u << 7,
     SYSTEM_EXECUTE = 1u << 8,
-    EVERYBODY = (1u << 9) - 1,
+    EVERYBODY = 0 | OWNER_READ | OWNER_WRITE | OWNER_EXECUTE | GROUP_READ | GROUP_WRITE | GROUP_EXECUTE | SYSTEM_READ | SYSTEM_WRITE | SYSTEM_EXECUTE,
 };
 constexpr access_flags operator|(access_flags lhs, access_flags rhs) noexcept {
     return static_cast<access_flags>(static_cast<unsigned>(lhs) | static_cast<unsigned>(rhs));

--- a/test-suite/generated-src/cpp/access_flags.hpp
+++ b/test-suite/generated-src/cpp/access_flags.hpp
@@ -9,16 +9,16 @@ namespace testsuite {
 
 enum class access_flags : unsigned {
     NOBODY = 0,
-    OWNER_READ = 1 << 0,
-    OWNER_WRITE = 1 << 1,
-    OWNER_EXECUTE = 1 << 2,
-    GROUP_READ = 1 << 3,
-    GROUP_WRITE = 1 << 4,
-    GROUP_EXECUTE = 1 << 5,
-    SYSTEM_READ = 1 << 6,
-    SYSTEM_WRITE = 1 << 7,
-    SYSTEM_EXECUTE = 1 << 8,
-    EVERYBODY = (1 << 9) - 1,
+    OWNER_READ = 1u << 0,
+    OWNER_WRITE = 1u << 1,
+    OWNER_EXECUTE = 1u << 2,
+    GROUP_READ = 1u << 3,
+    GROUP_WRITE = 1u << 4,
+    GROUP_EXECUTE = 1u << 5,
+    SYSTEM_READ = 1u << 6,
+    SYSTEM_WRITE = 1u << 7,
+    SYSTEM_EXECUTE = 1u << 8,
+    EVERYBODY = (1u << 9) - 1,
 };
 constexpr access_flags operator|(access_flags lhs, access_flags rhs) noexcept {
     return static_cast<access_flags>(static_cast<unsigned>(lhs) | static_cast<unsigned>(rhs));

--- a/test-suite/generated-src/cpp/empty_flags.hpp
+++ b/test-suite/generated-src/cpp/empty_flags.hpp
@@ -9,7 +9,7 @@ namespace testsuite {
 
 enum class empty_flags : unsigned {
     NONE = 0,
-    ALL = (1 << 0) - 1,
+    ALL = (1u << 0) - 1,
 };
 constexpr empty_flags operator|(empty_flags lhs, empty_flags rhs) noexcept {
     return static_cast<empty_flags>(static_cast<unsigned>(lhs) | static_cast<unsigned>(rhs));

--- a/test-suite/generated-src/cpp/empty_flags.hpp
+++ b/test-suite/generated-src/cpp/empty_flags.hpp
@@ -9,7 +9,7 @@ namespace testsuite {
 
 enum class empty_flags : unsigned {
     NONE = 0,
-    ALL = (1u << 0) - 1,
+    ALL = 0,
 };
 constexpr empty_flags operator|(empty_flags lhs, empty_flags rhs) noexcept {
     return static_cast<empty_flags>(static_cast<unsigned>(lhs) | static_cast<unsigned>(rhs));

--- a/test-suite/generated-src/objc/DBEmptyFlags.h
+++ b/test-suite/generated-src/objc/DBEmptyFlags.h
@@ -6,5 +6,5 @@
 typedef NS_OPTIONS(NSUInteger, DBEmptyFlags)
 {
     DBEmptyFlagsNone = 0,
-    DBEmptyFlagsAll = (1 << 0) - 1,
+    DBEmptyFlagsAll = (1u << 0) - 1,
 };

--- a/test-suite/generated-src/objc/DBEmptyFlags.h
+++ b/test-suite/generated-src/objc/DBEmptyFlags.h
@@ -6,5 +6,5 @@
 typedef NS_OPTIONS(NSUInteger, DBEmptyFlags)
 {
     DBEmptyFlagsNone = 0,
-    DBEmptyFlagsAll = (1u << 0) - 1,
+    DBEmptyFlagsAll = 0,
 };


### PR DESCRIPTION
Allow use of all 32 bits for definition of enum flags as '1<<31' leads to overflow as it considered i32 shift.
Instead '1u<<31' should be used which will not consider the upper bit as signed bit