### PR TITLE
Allow use of all 32 bits as enum flags for ObjC and C++

### DIFF
--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -65,7 +65,7 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
       refs.hpp.add("#include <functional>") // needed for std::hash
     }
 
-    val flagsType = "unsigned"
+    val flagsType = "int32_t"
     val enumType = "int"
     val underlyingType = if(e.flags) flagsType else enumType
 

--- a/src/source/CppMarshal.scala
+++ b/src/source/CppMarshal.scala
@@ -93,7 +93,7 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
       case e: Enum =>
         if (d.name != exclude) {
           if (forwardDeclareOnly) {
-            val underlyingType = if(e.flags) " : unsigned" else ""
+            val underlyingType = if(e.flags) " : int32_t" else ""
             List(DeclRef(s"enum class ${typename(d.name, d.body)}${underlyingType};", Some(spec.cppNamespace)))
           } else {
             List(ImportRef(include(d.name)))

--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -54,7 +54,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
     writeObjcFile(marshal.headerName(ident), origin, refs.header, w => {
       writeDoc(w, doc)
       w.wl(if(e.flags) {
-        s"typedef NS_OPTIONS(NSUInteger, $self)"
+        s"typedef NS_OPTIONS(NSInteger, $self)"
       } else {
         if (spec.objcClosedEnums) {
           s"typedef NS_CLOSED_ENUM(NSInteger, $self)"

--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -487,10 +487,17 @@ abstract class Generator(spec: Spec)
   }
 
   def writeEnumOptionAll(w: IndentWriter, e: Enum, ident: IdentConverter, delim: String = "=") {
-    for (o <- e.options.find(_.specialFlag == Some(Enum.SpecialFlag.AllFlags))) {
+    for (
+      o <- e.options.find(_.specialFlag.contains(Enum.SpecialFlag.AllFlags))
+    ) {
       writeDoc(w, o.doc)
       w.w(ident(o.ident.name) + s" $delim ")
-      w.wl(s"(1 << ${normalEnumOptions(e).size}) - 1,")
+      w.w(
+        normalEnumOptions(e)
+          .map(o => ident(o.ident.name))
+          .fold("0")((acc, o) => acc + " | " + o)
+      )
+      w.wl(",")
     }
   }
 

--- a/test-suite/generated-src/cpp/access_flags.hpp
+++ b/test-suite/generated-src/cpp/access_flags.hpp
@@ -7,7 +7,7 @@
 
 namespace testsuite {
 
-enum class access_flags : int_32 {
+enum class access_flags : int_32_t {
     NOBODY = 0,
     OWNER_READ = 1 << 0,
     OWNER_WRITE = 1 << 1,
@@ -21,25 +21,25 @@ enum class access_flags : int_32 {
     EVERYBODY = 0 | OWNER_READ | OWNER_WRITE | OWNER_EXECUTE | GROUP_READ | GROUP_WRITE | GROUP_EXECUTE | SYSTEM_READ | SYSTEM_WRITE | SYSTEM_EXECUTE,
 };
 constexpr access_flags operator|(access_flags lhs, access_flags rhs) noexcept {
-    return static_cast<access_flags>(static_cast<unsigned>(lhs) | static_cast<unsigned>(rhs));
+    return static_cast<access_flags>(static_cast<int32_t>(lhs) | static_cast<int32_t>(rhs));
 }
 constexpr access_flags& operator|=(access_flags& lhs, access_flags rhs) noexcept {
     return lhs = lhs | rhs;
 }
 constexpr access_flags operator&(access_flags lhs, access_flags rhs) noexcept {
-    return static_cast<access_flags>(static_cast<unsigned>(lhs) & static_cast<unsigned>(rhs));
+    return static_cast<access_flags>(static_cast<int32_t>(lhs) & static_cast<int32_t>(rhs));
 }
 constexpr access_flags& operator&=(access_flags& lhs, access_flags rhs) noexcept {
     return lhs = lhs & rhs;
 }
 constexpr access_flags operator^(access_flags lhs, access_flags rhs) noexcept {
-    return static_cast<access_flags>(static_cast<unsigned>(lhs) ^ static_cast<unsigned>(rhs));
+    return static_cast<access_flags>(static_cast<int32_t>(lhs) ^ static_cast<int32_t>(rhs));
 }
 constexpr access_flags& operator^=(access_flags& lhs, access_flags rhs) noexcept {
     return lhs = lhs ^ rhs;
 }
 constexpr access_flags operator~(access_flags x) noexcept {
-    return static_cast<access_flags>(~static_cast<unsigned>(x));
+    return static_cast<access_flags>(~static_cast<int32_t>(x));
 }
 
 } // namespace testsuite
@@ -49,7 +49,7 @@ namespace std {
 template <>
 struct hash<::testsuite::access_flags> {
     size_t operator()(::testsuite::access_flags type) const {
-        return std::hash<unsigned>()(static_cast<unsigned>(type));
+        return std::hash<int32_t>()(static_cast<int32_t>(type));
     }
 };
 

--- a/test-suite/generated-src/cpp/access_flags.hpp
+++ b/test-suite/generated-src/cpp/access_flags.hpp
@@ -7,7 +7,7 @@
 
 namespace testsuite {
 
-enum class access_flags : int_32_t {
+enum class access_flags : int32_t {
     NOBODY = 0,
     OWNER_READ = 1 << 0,
     OWNER_WRITE = 1 << 1,

--- a/test-suite/generated-src/cpp/access_flags.hpp
+++ b/test-suite/generated-src/cpp/access_flags.hpp
@@ -7,7 +7,7 @@
 
 namespace testsuite {
 
-enum class access_flags : unsigned {
+enum class access_flags : int_32 {
     NOBODY = 0,
     OWNER_READ = 1 << 0,
     OWNER_WRITE = 1 << 1,
@@ -18,7 +18,7 @@ enum class access_flags : unsigned {
     SYSTEM_READ = 1 << 6,
     SYSTEM_WRITE = 1 << 7,
     SYSTEM_EXECUTE = 1 << 8,
-    EVERYBODY = (1 << 9) - 1,
+    EVERYBODY = 0 | OWNER_READ | OWNER_WRITE | OWNER_EXECUTE | GROUP_READ | GROUP_WRITE | GROUP_EXECUTE | SYSTEM_READ | SYSTEM_WRITE | SYSTEM_EXECUTE,
 };
 constexpr access_flags operator|(access_flags lhs, access_flags rhs) noexcept {
     return static_cast<access_flags>(static_cast<unsigned>(lhs) | static_cast<unsigned>(rhs));

--- a/test-suite/generated-src/cpp/empty_flags.hpp
+++ b/test-suite/generated-src/cpp/empty_flags.hpp
@@ -7,9 +7,9 @@
 
 namespace testsuite {
 
-enum class empty_flags : unsigned {
+enum class empty_flags : int32_t {
     NONE = 0,
-    ALL = (1 << 0) - 1,
+    ALL = 0,
 };
 constexpr empty_flags operator|(empty_flags lhs, empty_flags rhs) noexcept {
     return static_cast<empty_flags>(static_cast<unsigned>(lhs) | static_cast<unsigned>(rhs));

--- a/test-suite/generated-src/cpp/empty_flags.hpp
+++ b/test-suite/generated-src/cpp/empty_flags.hpp
@@ -12,25 +12,25 @@ enum class empty_flags : int32_t {
     ALL = 0,
 };
 constexpr empty_flags operator|(empty_flags lhs, empty_flags rhs) noexcept {
-    return static_cast<empty_flags>(static_cast<unsigned>(lhs) | static_cast<unsigned>(rhs));
+    return static_cast<empty_flags>(static_cast<int32_t>(lhs) | static_cast<int32_t>(rhs));
 }
 constexpr empty_flags& operator|=(empty_flags& lhs, empty_flags rhs) noexcept {
     return lhs = lhs | rhs;
 }
 constexpr empty_flags operator&(empty_flags lhs, empty_flags rhs) noexcept {
-    return static_cast<empty_flags>(static_cast<unsigned>(lhs) & static_cast<unsigned>(rhs));
+    return static_cast<empty_flags>(static_cast<int32_t>(lhs) & static_cast<int32_t>(rhs));
 }
 constexpr empty_flags& operator&=(empty_flags& lhs, empty_flags rhs) noexcept {
     return lhs = lhs & rhs;
 }
 constexpr empty_flags operator^(empty_flags lhs, empty_flags rhs) noexcept {
-    return static_cast<empty_flags>(static_cast<unsigned>(lhs) ^ static_cast<unsigned>(rhs));
+    return static_cast<empty_flags>(static_cast<int32_t>(lhs) ^ static_cast<int32_t>(rhs));
 }
 constexpr empty_flags& operator^=(empty_flags& lhs, empty_flags rhs) noexcept {
     return lhs = lhs ^ rhs;
 }
 constexpr empty_flags operator~(empty_flags x) noexcept {
-    return static_cast<empty_flags>(~static_cast<unsigned>(x));
+    return static_cast<empty_flags>(~static_cast<int32_t>(x));
 }
 
 } // namespace testsuite
@@ -40,7 +40,7 @@ namespace std {
 template <>
 struct hash<::testsuite::empty_flags> {
     size_t operator()(::testsuite::empty_flags type) const {
-        return std::hash<unsigned>()(static_cast<unsigned>(type));
+        return std::hash<int32_t>()(static_cast<int32_t>(type));
     }
 };
 

--- a/test-suite/generated-src/cpp/flag_roundtrip.hpp
+++ b/test-suite/generated-src/cpp/flag_roundtrip.hpp
@@ -7,8 +7,8 @@
 
 namespace testsuite {
 
-enum class access_flags : unsigned;
-enum class empty_flags : unsigned;
+enum class access_flags : int32_t;
+enum class empty_flags : int32_t;
 
 class FlagRoundtrip {
 public:

--- a/test-suite/generated-src/objc/DBAccessFlags.h
+++ b/test-suite/generated-src/objc/DBAccessFlags.h
@@ -3,7 +3,7 @@
 
 #import <Foundation/Foundation.h>
 
-typedef NS_OPTIONS(NSUInteger, DBAccessFlags)
+typedef NS_OPTIONS(NSInteger, DBAccessFlags)
 {
     DBAccessFlagsNobody = 0,
     DBAccessFlagsOwnerRead = 1 << 0,
@@ -15,5 +15,5 @@ typedef NS_OPTIONS(NSUInteger, DBAccessFlags)
     DBAccessFlagsSystemRead = 1 << 6,
     DBAccessFlagsSystemWrite = 1 << 7,
     DBAccessFlagsSystemExecute = 1 << 8,
-    DBAccessFlagsEverybody = (1 << 9) - 1,
+    DBAccessFlagsEverybody = 0 | DBAccessFlagsOwnerRead | DBAccessFlagsOwnerWrite | DBAccessFlagsOwnerExecute | DBAccessFlagsGroupRead | DBAccessFlagsGroupWrite | DBAccessFlagsGroupExecute | DBAccessFlagsSystemRead | DBAccessFlagsSystemWrite | DBAccessFlagsSystemExecute,
 };

--- a/test-suite/generated-src/objc/DBEmptyFlags.h
+++ b/test-suite/generated-src/objc/DBEmptyFlags.h
@@ -3,8 +3,8 @@
 
 #import <Foundation/Foundation.h>
 
-typedef NS_OPTIONS(NSUInteger, DBEmptyFlags)
+typedef NS_OPTIONS(NSInteger, DBEmptyFlags)
 {
     DBEmptyFlagsNone = 0,
-    DBEmptyFlagsAll = (1 << 0) - 1,
+    DBEmptyFlagsAll = 0,
 };

--- a/test-suite/generated-src/ts/test.ts
+++ b/test-suite/generated-src/ts/test.ts
@@ -130,12 +130,12 @@ export enum AccessFlags {
     SYSTEM_READ = 1 << 6,
     SYSTEM_WRITE = 1 << 7,
     SYSTEM_EXECUTE = 1 << 8,
-    EVERYBODY = (1 << 9) - 1,
+    EVERYBODY = 0 | OWNER_READ | OWNER_WRITE | OWNER_EXECUTE | GROUP_READ | GROUP_WRITE | GROUP_EXECUTE | SYSTEM_READ | SYSTEM_WRITE | SYSTEM_EXECUTE,
 }
 
 export enum EmptyFlags {
     NONE = 0,
-    ALL = (1 << 0) - 1,
+    ALL = 0,
 }
 
 export interface FlagRoundtrip {

--- a/test-suite/generated-src/wasm/NativeAccessFlags.cpp
+++ b/test-suite/generated-src/wasm/NativeAccessFlags.cpp
@@ -19,7 +19,7 @@ namespace {
             SYSTEM_READ : 1 << 6,
             SYSTEM_WRITE : 1 << 7,
             SYSTEM_EXECUTE : 1 << 8,
-            EVERYBODY : (1 << 9) - 1,
+            EVERYBODY : 0 | OWNER_READ | OWNER_WRITE | OWNER_EXECUTE | GROUP_READ | GROUP_WRITE | GROUP_EXECUTE | SYSTEM_READ | SYSTEM_WRITE | SYSTEM_EXECUTE,
         }
     })
 }

--- a/test-suite/generated-src/wasm/NativeEmptyFlags.cpp
+++ b/test-suite/generated-src/wasm/NativeEmptyFlags.cpp
@@ -10,7 +10,7 @@ namespace {
     EM_JS(void, djinni_init_testsuite_empty_flags_consts, (), {
         Module.testsuite_EmptyFlags =  {
             NONE : 0,
-            ALL : (1 << 0) - 1,
+            ALL : 0,
         }
     })
 }


### PR DESCRIPTION
- Allow use of all 32 bits as enum flags for ObjC and C++
- Re-design 'ALL' flag's value calculation base on bitwise operation instead of subtraction
- As enum flag type is used int32_t (for C++) to emphasize memory usage and do not have a platform dependency(unlike int)
- As enum flag type for ObjC is used signed integer: NSInteger