### PR TITLE
[Wasm] Propagate stack traces for djinni Futures

### DIFF
--- a/support-lib/wasm/Future_wasm.hpp
+++ b/support-lib/wasm/Future_wasm.hpp
@@ -39,7 +39,7 @@ public:
         if (err.isNull() || err.isUndefined()) {
             pNativePromise->setValue(RESULT::Boxed::toCpp(res));
         } else {
-            pNativePromise->setException(std::runtime_error(err["message"].as<std::string>()));
+            pNativePromise->setException(JsException(err));
         }
         delete pNativePromise;
     }


### PR DESCRIPTION
Follow up to https://github.com/Snapchat/djinni/pull/72. We currently are dropping the JS error stack traces when using Futures. A mechanism was added to carry along the info, we're just not using it for futures.

PTAL @LiFengSC 