### PR TITLE
Allow functions that return Futures to become coroutines

### DIFF
--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -29,11 +29,13 @@
     #include <coroutine>
     namespace djinni::detail {
         template <typename Promise = void> using CoroutineHandle = std::coroutine_handle<Promise>;
+        using SuspendNever = std::suspend_never;
     }
 #elif __has_include(<experimental/coroutine>)
     #include <experimental/coroutine>
     namespace djinni::detail {
         template <typename Promise = void> using CoroutineHandle = std::experimental::coroutine_handle<Promise>;
+        using SuspendNever = std::experimental::suspend_never;
     }
 #endif
 #endif
@@ -360,8 +362,8 @@ public:
     struct PromiseTypeBase {
         Promise<T> _promise;
 
-        std::experimental::suspend_never initial_suspend() { return {}; }
-        std::experimental::suspend_never final_suspend() noexcept { return {}; }
+        detail::SuspendNever initial_suspend() { return {}; }
+        detail::SuspendNever final_suspend() noexcept { return {}; }
 
         Future<T> get_return_object() noexcept {
             return _promise.getFuture();

--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -356,6 +356,35 @@ public:
         });
         return true;
     }
+
+    struct PromiseTypeBase {
+        Promise<T> _promise;
+
+        std::experimental::suspend_never initial_suspend() { return {}; }
+        std::experimental::suspend_never final_suspend() noexcept { return {}; }
+
+        Future<T> get_return_object() noexcept {
+            return _promise.getFuture();
+        }
+        void unhandled_exception() {
+            _promise.setException(std::current_exception());
+        }
+    };
+    template <typename U>
+    struct PromiseType: PromiseTypeBase{
+        template <typename V>
+        void return_value(V&& value) {
+            this->_promise.setValue(std::forward<V>(value));
+        }
+    };
+    template <>
+    struct PromiseType<void>: PromiseTypeBase {
+        void return_void() {
+            this->_promise.setValue();
+        }
+    };
+    using promise_type = PromiseType<T>;
+
 private:
     detail::SharedStatePtr<T> _coroState;
 #endif

--- a/test-suite/handwritten-src/cpp/test_helpers.cpp
+++ b/test-suite/handwritten-src/cpp/test_helpers.cpp
@@ -194,9 +194,14 @@ djinni::Future<int32_t> TestHelpers::async_early_throw() {
 }
 
 djinni::Future<std::string> TestHelpers::future_roundtrip(djinni::Future<int32_t> f) {
+#ifdef DJINNI_FUTURE_COROUTINE_SUPPORT
+    auto i = co_await f;
+    co_return std::to_string(i);
+#else
     return f.then([] (djinni::Future<int32_t> f) {
         return std::to_string(f.get());
     });
+#endif
 }
 
 djinni::Future<std::string> TestHelpers::check_async_interface(const std::shared_ptr<AsyncInterface> & i) {
@@ -230,9 +235,14 @@ djinni::Future<std::string> TestHelpers::check_async_composition(const std::shar
     p1.setValue("36");
     p2.setValue("36");
     
+#ifdef DJINNI_FUTURE_COROUTINE_SUPPORT
+    co_await djinni::whenAll(futures);
+    co_return std::string("42");
+#else
     return djinni::whenAll(futures).then([] (auto f) {
         return std::string("42");
     });
+#endif
 }
 
 std::vector<std::experimental::optional<std::string>> TestHelpers::get_optional_list() {


### PR DESCRIPTION
This improves the existing coroutine support to make it fully bidirectional.  Now it can turn any function that returns a djinni::Future<> into a coroutine.  I modified a few test functions to exercise this new feature. 