### PR TITLE
Mention @extern in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Example:
 Use `@extern` directive to include support of `outcome` type to your `idl` file.
 
 ```
-@extern "../submodules/djinni/support-lib/outcome.yaml"
+@extern "../djinni/support-lib/outcome.yaml"
 
 my_interface = interface +c {
     query(): outcome<string, i32>;

--- a/README.md
+++ b/README.md
@@ -143,6 +143,18 @@ In C++, the `outcome<>` type maps to the template class `djinni::expected<>`.
 In Java, it maps to the generic class `com.snapchat.djinni.Outcome<>`. In ObjC,
 it maps to the generic class `DJOutcome<>`.
 
+Example:
+
+Use `@extern` directive to include support of `outcome` type to your `idl` file.
+
+```
+@extern "../submodules/djinni/support-lib/outcome.yaml"
+
+my_interface = interface +c {
+    query(): outcome<string, i32>;
+}
+```
+
 ### Use Protobuf types in Djinni
 
 We support using Protobuf types directly in Djinni IDL. In order to use Protobuf
@@ -311,7 +323,11 @@ Foo = interface {
 
 We can now write:
 
+(use `@extern` directive to include support of `future` type to your `idl` file)
+
 ```
+@extern "../djinni/support-lib/future.yaml"
+
 Foo = interface {
   bar(): future<i32>;
 }


### PR DESCRIPTION
Hey guys! I'd been using Djinni back in 2015 and I'm glad that I found that it's still maintained!

So I just wanted to add my 2 cents to this awesome project!

Spent like an hour trying to figure out how to actually *use* `outcome` and `future` types. Eventually in the docs of some other fork I found that I actually had to add `@extern` line at the top of the file and it was never mentioned in the Snapchat fork docs. So I decided to put this information here too.

What do you think?