### PR TITLE
support future<void>

### DIFF
--- a/src/source/CppMarshal.scala
+++ b/src/source/CppMarshal.scala
@@ -123,6 +123,7 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
     case p: MProtobuf =>
       List(ImportRef(p.body.cpp.header))
     case p: MParam => List()
+    case MVoid => List()
   }
 
   def resolveExtCppHdr(path: String) = {
@@ -196,6 +197,7 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
       }
       case p: MParam => idCpp.typeParam(p.name)
       case p: MProtobuf => withNs(Some(p.body.cpp.ns), p.name)
+      case MVoid => "void"
     }
     def expr(tm: MExpr): String = {
       spec.cppNnType match {

--- a/src/source/JNIMarshal.scala
+++ b/src/source/JNIMarshal.scala
@@ -106,6 +106,7 @@ class JNIMarshal(spec: Spec) extends Marshal(spec) {
       case MSet => "Ljava/util/HashSet;"
       case MMap => "Ljava/util/HashMap;"
       case MArray => s"[${javaTypeSignature(tm.args.head)}"
+      case MVoid => "Ljava/lang/Void;"
     }
     case e: MExtern => e.jni.typeSignature
     case MParam(_) => "Ljava/lang/Object;"
@@ -164,6 +165,7 @@ class JNIMarshal(spec: Spec) extends Marshal(spec) {
       case d: MDef => throw new AssertionError("unreachable")
       case e: MExtern => throw new AssertionError("unreachable")
       case p: MParam => throw new AssertionError("not applicable")
+      case MVoid => "Void"
     })
   }
 

--- a/src/source/JavaMarshal.scala
+++ b/src/source/JavaMarshal.scala
@@ -133,6 +133,7 @@ class JavaMarshal(spec: Spec) extends Marshal(spec) {
             case e: MExtern => throw new AssertionError("unreachable")
             case e: MProtobuf => throw new AssertionError("unreachable")
             case p: MParam => idJava.typeParam(p.name)
+            case MVoid => "Void"
           }
           base + args(tm)
       }

--- a/src/source/ObjcMarshal.scala
+++ b/src/source/ObjcMarshal.scala
@@ -185,6 +185,7 @@ class ObjcMarshal(spec: Spec) extends Marshal(spec) {
               case None => (p.body.cpp.ns + "::" + p.name, true)
             }
             case p: MParam => throw new AssertionError("Parameter should not happen at Obj-C top level")
+            case MVoid => ("NSNull", true)
           }
           base
       }

--- a/src/source/ObjcppMarshal.scala
+++ b/src/source/ObjcppMarshal.scala
@@ -120,6 +120,7 @@ class ObjcppMarshal(spec: Spec) extends Marshal(spec) {
       case e: MExtern => throw new AssertionError("unreachable")
       case p: MParam => throw new AssertionError("not applicable")
       case p: MProtobuf => throw new AssertionError("not applicable")
+      case MVoid => "Void"
     })
   }
 

--- a/src/source/TsGenerator.scala
+++ b/src/source/TsGenerator.scala
@@ -100,6 +100,7 @@ class TsGenerator(spec: Spec) extends Generator(spec) {
             case e: MExtern => throw new AssertionError("unreachable")
             case e: MProtobuf => throw new AssertionError("unreachable")
             case p: MParam => idJs.typeParam(p.name)
+            case MVoid => "void"
           }
           base + args(tm)
       }

--- a/src/source/WasmGenerator.scala
+++ b/src/source/WasmGenerator.scala
@@ -64,6 +64,7 @@ class WasmGenerator(spec: Spec) extends Generator(spec) {
       case d: MDef => throw new AssertionError("unreachable")
       case e: MExtern => throw new AssertionError("unreachable")
       case p: MParam => throw new AssertionError("not applicable")
+      case MVoid => "Void"
     })
   }
   private def helperTemplates(tm: MExpr): String = {

--- a/src/source/meta.scala
+++ b/src/source/meta.scala
@@ -102,6 +102,7 @@ case object MList extends MOpaque { val numParams = 1; val idlName = "list" }
 case object MSet extends MOpaque { val numParams = 1; val idlName = "set" }
 case object MMap extends MOpaque { val numParams = 2; val idlName = "map" }
 case object MArray extends MOpaque { val numParams = 1; val idlName = "array"}
+case object MVoid extends MOpaque { val numParams = 0; val idlName = "void"}
 
 val defaults: Map[String,MOpaque] = immutable.HashMap(
   ("i8",   MPrimitive("i8",   "byte",    "jbyte",    "int8_t",  "Byte",    "B", "int8_t",  "NSNumber")),
@@ -118,7 +119,8 @@ val defaults: Map[String,MOpaque] = immutable.HashMap(
   ("list", MList),
   ("set", MSet),
   ("map", MMap),
-  ("array", MArray))
+  ("array", MArray),
+  ("void", MVoid))
 
 def isInterface(ty: MExpr): Boolean = {
   ty.base match {

--- a/src/source/parser.scala
+++ b/src/source/parser.scala
@@ -188,7 +188,12 @@ private object IdlParser extends RegexParsers {
     case "" => false
   }
   def method: Parser[Interface.Method] = doc ~ staticLabel ~ constLabel ~ ident ~ parens(repsepend(field, ",")) ~ opt(ret) ~ supportLang ^^ {
-    case doc~staticLabel~constLabel~ ident~params~ret~ext => Interface.Method(ident, params, ret, doc, staticLabel, constLabel, ext)
+    case doc~staticLabel~constLabel~ ident~params~ret~ext => {
+      ret match {
+        case Some(r) if (r.expr.ident.name == "void") => Interface.Method(ident, params, None, doc, staticLabel, constLabel, ext)
+        case _ => Interface.Method(ident, params, ret, doc, staticLabel, constLabel, ext)
+      }
+    }
   }
   def ret: Parser[TypeRef] = ":" ~> typeRef
 

--- a/support-lib/java/com/snapchat/djinni/SharedState.java
+++ b/support-lib/java/com/snapchat/djinni/SharedState.java
@@ -28,8 +28,9 @@ class SharedState<T> {
     public T value;
     public Throwable exception;
     public Continuation<T> handler;
+    public boolean ready = false;
 
     public boolean isReady() {
-        return (value != null) || (exception != null);
+        return ready || (exception != null);
     }
 }

--- a/support-lib/jni/Future_jni.hpp
+++ b/support-lib/jni/Future_jni.hpp
@@ -20,8 +20,6 @@
 #include "Marshal.hpp"
 #include "../cpp/Future.hpp"
 
-#include <iostream>
-
 namespace djinni {
 
 struct PromiseJniInfo {
@@ -105,7 +103,6 @@ public:
                 reinterpret_cast<NativePromiseType*>(nativePromise)
             };
             if (jex == nullptr) {
-                // promise->setValue(RESULT::Boxed::toCpp(jniEnv, static_cast<typename RESULT::Boxed::JniType>(jres)));
                 SetResult<RESULT>::setCppResult(jniEnv, *promise, static_cast<typename RESULT::Boxed::JniType>(jres));
             } else {
                 const auto& throwableJniInfo = JniClass<ThrowableJniInfo>::get();

--- a/support-lib/jni/Marshal.hpp
+++ b/support-lib/jni/Marshal.hpp
@@ -764,4 +764,12 @@ namespace djinni
             return jniEnv->NewDoubleArray(size);
         }
     };
+
+    struct Void
+    {
+        using CppType = void;
+        using JniType = jobject;
+
+        using Boxed = Void;
+    };
 } // namespace djinni

--- a/support-lib/objc/DJFuture.h
+++ b/support-lib/objc/DJFuture.h
@@ -41,5 +41,7 @@
 // `setValue` or `setException` can only be called once on a promise. After
 // which the internal state becomes invalid.
 - (void)setValue:(nullable DJValue)val;
+// for NSNull* (void)
+- (void)setValue;
 - (void)setException:(nonnull NSException *)exception;
 @end

--- a/support-lib/objc/DJIMarshal+Private.h
+++ b/support-lib/objc/DJIMarshal+Private.h
@@ -427,4 +427,12 @@ public:
     }
 };
 
+struct Void
+{
+    using CppType = void;
+    using ObjcType = NSNull*;
+    
+    using Boxed = Void;
+};
+
 } // namespace djinni

--- a/support-lib/wasm/djinni_wasm.hpp
+++ b/support-lib/wasm/djinni_wasm.hpp
@@ -385,6 +385,13 @@ struct Array<F64> : PrimitiveArray<F64> {
     }
 };
 
+class Void {
+public:
+    using CppType = void;
+    using JsType = em::val;
+    using Boxed = Void;
+};
+
 class CppResolveHandlerBase {
 public:
     virtual ~CppResolveHandlerBase() = default;

--- a/test-suite/djinni/test.djinni
+++ b/test-suite/djinni/test.djinni
@@ -51,6 +51,7 @@ test_helpers = interface +c {
     static get_async_result(): future<i32>;
     static future_roundtrip(f: future<i32>): future<string>;
     static async_early_throw(): future<i32>;
+    static void_async_method(f: future<void>): future<void>;
 
     static check_async_interface(i: async_interface): future<string>;
     static check_async_composition(i: async_interface): future<string>;

--- a/test-suite/generated-src/cpp/test_helpers.hpp
+++ b/test-suite/generated-src/cpp/test_helpers.hpp
@@ -96,6 +96,8 @@ public:
 
     static ::djinni::Future<int32_t> async_early_throw();
 
+    static ::djinni::Future<void> void_async_method(::djinni::Future<void> f);
+
     static ::djinni::Future<std::string> check_async_interface(const /*not-null*/ std::shared_ptr<AsyncInterface> & i);
 
     static ::djinni::Future<std::string> check_async_composition(const /*not-null*/ std::shared_ptr<AsyncInterface> & i);

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
@@ -95,6 +95,9 @@ public abstract class TestHelpers {
     public static native com.snapchat.djinni.Future<Integer> asyncEarlyThrow();
 
     @Nonnull
+    public static native com.snapchat.djinni.Future<Void> voidAsyncMethod(@Nonnull com.snapchat.djinni.Future<Void> f);
+
+    @Nonnull
     public static native com.snapchat.djinni.Future<String> checkAsyncInterface(@CheckForNull AsyncInterface i);
 
     @Nonnull

--- a/test-suite/generated-src/jni/NativeTestHelpers.cpp
+++ b/test-suite/generated-src/jni/NativeTestHelpers.cpp
@@ -246,6 +246,14 @@ CJNIEXPORT ::djinni::FutureAdaptor<::djinni::I32>::JniType JNICALL Java_com_drop
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT ::djinni::FutureAdaptor<::djinni::Void>::JniType JNICALL Java_com_dropbox_djinni_test_TestHelpers_voidAsyncMethod(JNIEnv* jniEnv, jobject /*this*/, ::djinni::FutureAdaptor<::djinni::Void>::JniType j_f)
+{
+    try {
+        auto r = ::testsuite::TestHelpers::void_async_method(::djinni::FutureAdaptor<::djinni::Void>::toCpp(jniEnv, j_f));
+        return ::djinni::release(::djinni::FutureAdaptor<::djinni::Void>::fromCpp(jniEnv, std::move(r)));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 CJNIEXPORT ::djinni::FutureAdaptor<::djinni::String>::JniType JNICALL Java_com_dropbox_djinni_test_TestHelpers_checkAsyncInterface(JNIEnv* jniEnv, jobject /*this*/, jobject j_i)
 {
     try {

--- a/test-suite/generated-src/objc/DBTestHelpers+Private.mm
+++ b/test-suite/generated-src/objc/DBTestHelpers+Private.mm
@@ -231,6 +231,13 @@ static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for th
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }
 
++ (nonnull DJFuture<NSNull *> *)voidAsyncMethod:(nonnull DJFuture<NSNull *> *)f {
+    try {
+        auto objcpp_result_ = ::testsuite::TestHelpers::void_async_method(::djinni::FutureAdaptor<::djinni::Void>::toCpp(f));
+        return ::djinni::FutureAdaptor<::djinni::Void>::fromCpp(std::move(objcpp_result_));
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
 + (nonnull DJFuture<NSString *> *)checkAsyncInterface:(nullable id<DBAsyncInterface>)i {
     try {
         auto objcpp_result_ = ::testsuite::TestHelpers::check_async_interface(::djinni_generated::AsyncInterface::toCpp(i));

--- a/test-suite/generated-src/objc/DBTestHelpers.h
+++ b/test-suite/generated-src/objc/DBTestHelpers.h
@@ -85,6 +85,8 @@
 
 + (nonnull DJFuture<NSNumber *> *)asyncEarlyThrow;
 
++ (nonnull DJFuture<NSNull *> *)voidAsyncMethod:(nonnull DJFuture<NSNull *> *)f;
+
 + (nonnull DJFuture<NSString *> *)checkAsyncInterface:(nullable id<DBAsyncInterface>)i;
 
 + (nonnull DJFuture<NSString *> *)checkAsyncComposition:(nullable id<DBAsyncInterface>)i;

--- a/test-suite/generated-src/ts/test.ts
+++ b/test-suite/generated-src/ts/test.ts
@@ -450,6 +450,7 @@ export interface TestHelpers_statics {
     getAsyncResult(): Promise<number>;
     futureRoundtrip(f: Promise<number>): Promise<string>;
     asyncEarlyThrow(): Promise<number>;
+    voidAsyncMethod(f: Promise<void>): Promise<void>;
     checkAsyncInterface(i: AsyncInterface): Promise<string>;
     checkAsyncComposition(i: AsyncInterface): Promise<string>;
     getOptionalList(): Array<string>;

--- a/test-suite/generated-src/wasm/NativeTestHelpers.cpp
+++ b/test-suite/generated-src/wasm/NativeTestHelpers.cpp
@@ -267,6 +267,15 @@ em::val NativeTestHelpers::async_early_throw() {
         return djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::I32>>::handleNativeException(e);
     }
 }
+em::val NativeTestHelpers::void_async_method(const em::val& w_f) {
+    try {
+        auto r = ::testsuite::TestHelpers::void_async_method(::djinni::FutureAdaptor<::djinni::Void>::toCpp(w_f));
+        return ::djinni::FutureAdaptor<::djinni::Void>::fromCpp(std::move(r));
+    }
+    catch(const std::exception& e) {
+        return djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::Void>>::handleNativeException(e);
+    }
+}
 em::val NativeTestHelpers::check_async_interface(const em::val& w_i) {
     try {
         auto r = ::testsuite::TestHelpers::check_async_interface(::djinni_generated::NativeAsyncInterface::toCpp(w_i));
@@ -372,6 +381,7 @@ EMSCRIPTEN_BINDINGS(testsuite_test_helpers) {
         .class_function("getAsyncResult", NativeTestHelpers::get_async_result)
         .class_function("futureRoundtrip", NativeTestHelpers::future_roundtrip)
         .class_function("asyncEarlyThrow", NativeTestHelpers::async_early_throw)
+        .class_function("voidAsyncMethod", NativeTestHelpers::void_async_method)
         .class_function("checkAsyncInterface", NativeTestHelpers::check_async_interface)
         .class_function("checkAsyncComposition", NativeTestHelpers::check_async_composition)
         .class_function("getOptionalList", NativeTestHelpers::get_optional_list)

--- a/test-suite/generated-src/wasm/NativeTestHelpers.hpp
+++ b/test-suite/generated-src/wasm/NativeTestHelpers.hpp
@@ -51,6 +51,7 @@ struct NativeTestHelpers : ::djinni::JsInterface<::testsuite::TestHelpers, Nativ
     static em::val get_async_result();
     static em::val future_roundtrip(const em::val& w_f);
     static em::val async_early_throw();
+    static em::val void_async_method(const em::val& w_f);
     static em::val check_async_interface(const em::val& w_i);
     static em::val check_async_composition(const em::val& w_i);
     static em::val get_optional_list();

--- a/test-suite/handwritten-src/cpp/test_helpers.cpp
+++ b/test-suite/handwritten-src/cpp/test_helpers.cpp
@@ -257,7 +257,11 @@ djinni::Future<std::string> TestHelpers::check_async_composition(const std::shar
 }
 
 ::djinni::Future<void> TestHelpers::void_async_method(djinni::Future<void> f) {
+#ifdef DJINNI_FUTURE_HAS_COROUTINE_SUPPORT
+    co_return co_await f;
+#else
     return f;
+#endif
 }
 
 std::vector<std::experimental::optional<std::string>> TestHelpers::get_optional_list() {

--- a/test-suite/handwritten-src/cpp/test_helpers.cpp
+++ b/test-suite/handwritten-src/cpp/test_helpers.cpp
@@ -256,6 +256,10 @@ djinni::Future<std::string> TestHelpers::check_async_composition(const std::shar
 #endif
 }
 
+::djinni::Future<void> TestHelpers::void_async_method(djinni::Future<void> f) {
+    return f;
+}
+
 std::vector<std::experimental::optional<std::string>> TestHelpers::get_optional_list() {
     return {std::experimental::nullopt, std::string("hello")};
 }

--- a/test-suite/handwritten-src/java/com/dropbox/djinni/test/AsyncTest.java
+++ b/test-suite/handwritten-src/java/com/dropbox/djinni/test/AsyncTest.java
@@ -36,6 +36,14 @@ public class AsyncTest extends TestCase {
         assertEquals(f3.get(), "36");
     }
 
+    public void testVoidRoundtrip() throws Throwable {
+        final Promise<Void> p = new Promise();
+        p.setValue();
+        Future<Void> f = p.getFuture();
+        Future<Void> f1 = TestHelpers.voidAsyncMethod(f);
+        f1.get();
+    }
+
     public void testFutureRoundtripWithException() throws Throwable {
         final Promise<String> p = new Promise<String>();
         Future<String> f = p.getFuture();

--- a/test-suite/handwritten-src/objc/tests/DBAsyncTest.m
+++ b/test-suite/handwritten-src/objc/tests/DBAsyncTest.m
@@ -81,4 +81,12 @@
     XCTAssertEqualObjects([s get], @"42");
 }
 
+- (void) testVoidRoundTrip {
+    DJPromise<NSNull *> *p = [[DJPromise alloc] init];
+    [p setValue];
+    DJFuture<NSNull *>* f = [p getFuture];
+    DJFuture<NSNull *>* f1 = [DBTestHelpers voidAsyncMethod:f];
+    [f1 get];
+}
+
 @end

--- a/test-suite/handwritten-src/ts/AsyncTest.ts
+++ b/test-suite/handwritten-src/ts/AsyncTest.ts
@@ -1,7 +1,7 @@
 import {TestCase, allTests, assertEq, assertTrue} from "./testutils"
 import * as test from "../../generated-src/ts/test";
 
-function sleep(ms: number) {
+function sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
@@ -43,6 +43,10 @@ class AsyncTest extends TestCase {
         const r = parseInt(s);
         assertEq(r, 36);
     }
+
+  async testVoidRountTrip() {
+    await this.m.testsuite.TestHelpers.voidAsyncMethod(sleep(10));
+  }
 
     async testFutureRoundtripWithException() {
         var s = null;


### PR DESCRIPTION
This addresses
https://github.com/Snapchat/djinni/issues/75

Type mapping of future<void>:
* C++,  `Future<void>`
* Java, `Future<Void>`
* ObjC, `DJFuture<NSNull *>`
* Javascript/Typescript, `Promise<void>`

The void type can only be used as the type parameter of futures.  The void type's `toCpp` and `fromCpp` methods are not implemented so trying to pass void objects as actual data will no work (compilation will fail).  There is a special case in the parser to allow writing `:void` as the return type, and this will be ignored. 