### PR TITLE
Fix missing :: prefix for djinni namespace to avoid possible name lookup issues

### DIFF
--- a/examples/generated-src/wasm/NativeSortItems.cpp
+++ b/examples/generated-src/wasm/NativeSortItems.cpp
@@ -21,7 +21,7 @@ void NativeSortItems::sort(const CppType& self, int32_t w_order,const em::val& w
              ::djinni_generated::NativeItemList::toCpp(w_items));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 em::val NativeSortItems::create_with_listener(const em::val& w_listener) {
@@ -30,7 +30,7 @@ em::val NativeSortItems::create_with_listener(const em::val& w_listener) {
         return ::djinni_generated::NativeSortItems::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeSortItems>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeSortItems>::handleNativeException(e);
     }
 }
 em::val NativeSortItems::run_sort(const em::val& w_items) {
@@ -39,7 +39,7 @@ em::val NativeSortItems::run_sort(const em::val& w_items) {
         return ::djinni_generated::NativeItemList::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeItemList>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeItemList>::handleNativeException(e);
     }
 }
 

--- a/examples/generated-src/wasm/NativeSortItems.hpp
+++ b/examples/generated-src/wasm/NativeSortItems.hpp
@@ -17,7 +17,7 @@ struct NativeSortItems : ::djinni::JsInterface<::textsort::SortItems, NativeSort
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeSortItems::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeSortItems::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/examples/generated-src/wasm/NativeTextboxListener.hpp
+++ b/examples/generated-src/wasm/NativeTextboxListener.hpp
@@ -17,7 +17,7 @@ struct NativeTextboxListener : ::djinni::JsInterface<::textsort::TextboxListener
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeTextboxListener::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeTextboxListener::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/perftest/generated-src/wasm/NativeDjinniPerfBenchmark.cpp
+++ b/perftest/generated-src/wasm/NativeDjinniPerfBenchmark.cpp
@@ -47,7 +47,7 @@ em::val NativeDjinniPerfBenchmark::getInstance() {
         return ::djinni_generated::NativeDjinniPerfBenchmark::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeDjinniPerfBenchmark>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeDjinniPerfBenchmark>::handleNativeException(e);
     }
 }
 int64_t NativeDjinniPerfBenchmark::cppTests(const CppType& self) {
@@ -56,7 +56,7 @@ int64_t NativeDjinniPerfBenchmark::cppTests(const CppType& self) {
         return ::djinni::I64::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::I64>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::I64>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::baseline(const CppType& self) {
@@ -64,7 +64,7 @@ void NativeDjinniPerfBenchmark::baseline(const CppType& self) {
         self->baseline();
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argString(const CppType& self, const std::string& w_s) {
@@ -72,7 +72,7 @@ void NativeDjinniPerfBenchmark::argString(const CppType& self, const std::string
         self->argString(::djinni::String::toCpp(w_s));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argBinary(const CppType& self, const em::val& w_b) {
@@ -80,7 +80,7 @@ void NativeDjinniPerfBenchmark::argBinary(const CppType& self, const em::val& w_
         self->argBinary(::djinni::Binary::toCpp(w_b));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argDataRef(const CppType& self, const em::val& w_r) {
@@ -88,7 +88,7 @@ void NativeDjinniPerfBenchmark::argDataRef(const CppType& self, const em::val& w
         self->argDataRef(::djinni::NativeDataRef::toCpp(w_r));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argDataView(const CppType& self, const em::val& w_d) {
@@ -96,7 +96,7 @@ void NativeDjinniPerfBenchmark::argDataView(const CppType& self, const em::val& 
         self->argDataView(::djinni::NativeDataView::toCpp(w_d));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argEnumSixValue(const CppType& self, int32_t w_e) {
@@ -104,7 +104,7 @@ void NativeDjinniPerfBenchmark::argEnumSixValue(const CppType& self, int32_t w_e
         self->argEnumSixValue(::djinni_generated::NativeEnumSixValue::toCpp(w_e));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argRecordSixInt(const CppType& self, const em::val& w_r) {
@@ -112,7 +112,7 @@ void NativeDjinniPerfBenchmark::argRecordSixInt(const CppType& self, const em::v
         self->argRecordSixInt(::djinni_generated::NativeRecordSixInt::toCpp(w_r));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argListInt(const CppType& self, const em::val& w_v) {
@@ -120,7 +120,7 @@ void NativeDjinniPerfBenchmark::argListInt(const CppType& self, const em::val& w
         self->argListInt(::djinni::List<::djinni::I64>::toCpp(w_v));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argArrayInt(const CppType& self, const em::val& w_v) {
@@ -128,7 +128,7 @@ void NativeDjinniPerfBenchmark::argArrayInt(const CppType& self, const em::val& 
         self->argArrayInt(::djinni::Array<::djinni::I64>::toCpp(w_v));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argObject(const CppType& self, const em::val& w_c) {
@@ -136,7 +136,7 @@ void NativeDjinniPerfBenchmark::argObject(const CppType& self, const em::val& w_
         self->argObject(::djinni_generated::NativeObjectPlatform::toCpp(w_c));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argListObject(const CppType& self, const em::val& w_l) {
@@ -144,7 +144,7 @@ void NativeDjinniPerfBenchmark::argListObject(const CppType& self, const em::val
         self->argListObject(::djinni::List<::djinni_generated::NativeObjectPlatform>::toCpp(w_l));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argListRecord(const CppType& self, const em::val& w_l) {
@@ -152,7 +152,7 @@ void NativeDjinniPerfBenchmark::argListRecord(const CppType& self, const em::val
         self->argListRecord(::djinni::List<::djinni_generated::NativeRecordSixInt>::toCpp(w_l));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeDjinniPerfBenchmark::argArrayRecord(const CppType& self, const em::val& w_a) {
@@ -160,7 +160,7 @@ void NativeDjinniPerfBenchmark::argArrayRecord(const CppType& self, const em::va
         self->argArrayRecord(::djinni::List<::djinni_generated::NativeRecordSixInt>::toCpp(w_a));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 int64_t NativeDjinniPerfBenchmark::returnInt(const CppType& self, int64_t w_i) {
@@ -169,7 +169,7 @@ int64_t NativeDjinniPerfBenchmark::returnInt(const CppType& self, int64_t w_i) {
         return ::djinni::I64::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::I64>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::I64>::handleNativeException(e);
     }
 }
 std::string NativeDjinniPerfBenchmark::returnString(const CppType& self, int32_t w_size) {
@@ -178,7 +178,7 @@ std::string NativeDjinniPerfBenchmark::returnString(const CppType& self, int32_t
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 em::val NativeDjinniPerfBenchmark::returnBinary(const CppType& self, int32_t w_size) {
@@ -187,7 +187,7 @@ em::val NativeDjinniPerfBenchmark::returnBinary(const CppType& self, int32_t w_s
         return ::djinni::Binary::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Binary>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Binary>::handleNativeException(e);
     }
 }
 em::val NativeDjinniPerfBenchmark::returnObject(const CppType& self) {
@@ -196,7 +196,7 @@ em::val NativeDjinniPerfBenchmark::returnObject(const CppType& self) {
         return ::djinni_generated::NativeObjectNative::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeObjectNative>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeObjectNative>::handleNativeException(e);
     }
 }
 em::val NativeDjinniPerfBenchmark::returnListInt(const CppType& self, int32_t w_size) {
@@ -205,7 +205,7 @@ em::val NativeDjinniPerfBenchmark::returnListInt(const CppType& self, int32_t w_
         return ::djinni::List<::djinni::I64>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni::I64>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::List<::djinni::I64>>::handleNativeException(e);
     }
 }
 em::val NativeDjinniPerfBenchmark::returnArrayInt(const CppType& self, int32_t w_size) {
@@ -214,7 +214,7 @@ em::val NativeDjinniPerfBenchmark::returnArrayInt(const CppType& self, int32_t w
         return ::djinni::Array<::djinni::I64>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Array<::djinni::I64>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Array<::djinni::I64>>::handleNativeException(e);
     }
 }
 em::val NativeDjinniPerfBenchmark::returnListObject(const CppType& self, int32_t w_size) {
@@ -223,7 +223,7 @@ em::val NativeDjinniPerfBenchmark::returnListObject(const CppType& self, int32_t
         return ::djinni::List<::djinni_generated::NativeObjectNative>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni_generated::NativeObjectNative>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::List<::djinni_generated::NativeObjectNative>>::handleNativeException(e);
     }
 }
 em::val NativeDjinniPerfBenchmark::returnListRecord(const CppType& self, int32_t w_size) {
@@ -232,7 +232,7 @@ em::val NativeDjinniPerfBenchmark::returnListRecord(const CppType& self, int32_t
         return ::djinni::List<::djinni_generated::NativeRecordSixInt>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni_generated::NativeRecordSixInt>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::List<::djinni_generated::NativeRecordSixInt>>::handleNativeException(e);
     }
 }
 em::val NativeDjinniPerfBenchmark::returnArrayRecord(const CppType& self, int32_t w_size) {
@@ -241,7 +241,7 @@ em::val NativeDjinniPerfBenchmark::returnArrayRecord(const CppType& self, int32_
         return ::djinni::List<::djinni_generated::NativeRecordSixInt>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni_generated::NativeRecordSixInt>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::List<::djinni_generated::NativeRecordSixInt>>::handleNativeException(e);
     }
 }
 std::string NativeDjinniPerfBenchmark::roundTripString(const CppType& self, const std::string& w_s) {
@@ -250,7 +250,7 @@ std::string NativeDjinniPerfBenchmark::roundTripString(const CppType& self, cons
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 

--- a/perftest/generated-src/wasm/NativeDjinniPerfBenchmark.hpp
+++ b/perftest/generated-src/wasm/NativeDjinniPerfBenchmark.hpp
@@ -17,7 +17,7 @@ struct NativeDjinniPerfBenchmark : ::djinni::JsInterface<::snapchat::djinni::ben
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeDjinniPerfBenchmark::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeDjinniPerfBenchmark::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/perftest/generated-src/wasm/NativeObjectNative.cpp
+++ b/perftest/generated-src/wasm/NativeObjectNative.cpp
@@ -17,7 +17,7 @@ void NativeObjectNative::baseline(const CppType& self) {
         self->baseline();
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 

--- a/perftest/generated-src/wasm/NativeObjectNative.hpp
+++ b/perftest/generated-src/wasm/NativeObjectNative.hpp
@@ -17,7 +17,7 @@ struct NativeObjectNative : ::djinni::JsInterface<::snapchat::djinni::benchmark:
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeObjectNative::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeObjectNative::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/perftest/generated-src/wasm/NativeObjectPlatform.hpp
+++ b/perftest/generated-src/wasm/NativeObjectPlatform.hpp
@@ -17,7 +17,7 @@ struct NativeObjectPlatform : ::djinni::JsInterface<::snapchat::djinni::benchmar
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeObjectPlatform::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeObjectPlatform::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/src/source/WasmGenerator.scala
+++ b/src/source/WasmGenerator.scala
@@ -297,7 +297,7 @@ class WasmGenerator(spec: Spec) extends Generator(spec) {
         w.wl("static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }")
         w.w("static JsType fromCpp(const CppType& c)").braced {
           if (spec.cppNnType.isEmpty) {
-            w.wl(s"""djinni::checkForNull(c.get(), "$helper::fromCpp");""")
+            w.wl(s"""::djinni::checkForNull(c.get(), "$helper::fromCpp");""")
           }
           w.wl("return fromCppOpt(c);")
         }
@@ -377,7 +377,7 @@ class WasmGenerator(spec: Spec) extends Generator(spec) {
             }
             w.w("catch(const std::exception& e)").braced {
               val helper = if (!m.ret.isEmpty) helperClass(m.ret.get.resolved) else "void"
-              w.wl(s"return djinni::ExceptionHandlingTraits<${helper}>::handleNativeException(e);");
+              w.wl(s"return ::djinni::ExceptionHandlingTraits<${helper}>::handleNativeException(e);");
             }
           }
         }

--- a/test-suite/generated-src/wasm/NativeAsyncInterface.hpp
+++ b/test-suite/generated-src/wasm/NativeAsyncInterface.hpp
@@ -17,7 +17,7 @@ struct NativeAsyncInterface : ::djinni::JsInterface<::testsuite::AsyncInterface,
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeAsyncInterface::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeAsyncInterface::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeClientInterface.hpp
+++ b/test-suite/generated-src/wasm/NativeClientInterface.hpp
@@ -17,7 +17,7 @@ struct NativeClientInterface : ::djinni::JsInterface<::testsuite::ClientInterfac
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeClientInterface::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeClientInterface::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeConflict.hpp
+++ b/test-suite/generated-src/wasm/NativeConflict.hpp
@@ -17,7 +17,7 @@ struct NativeConflict : ::djinni::JsInterface<::testsuite::Conflict, NativeConfl
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeConflict::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeConflict::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeConflictUser.cpp
+++ b/test-suite/generated-src/wasm/NativeConflictUser.cpp
@@ -20,7 +20,7 @@ em::val NativeConflictUser::Conflict(const CppType& self) {
         return ::djinni_generated::NativeConflict::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeConflict>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeConflict>::handleNativeException(e);
     }
 }
 bool NativeConflictUser::conflict_arg(const CppType& self, const em::val& w_cs) {
@@ -29,7 +29,7 @@ bool NativeConflictUser::conflict_arg(const CppType& self, const em::val& w_cs) 
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeConflictUser.hpp
+++ b/test-suite/generated-src/wasm/NativeConflictUser.hpp
@@ -17,7 +17,7 @@ struct NativeConflictUser : ::djinni::JsInterface<::testsuite::ConflictUser, Nat
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeConflictUser::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeConflictUser::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeConstantInterfaceWithEnum.hpp
+++ b/test-suite/generated-src/wasm/NativeConstantInterfaceWithEnum.hpp
@@ -17,7 +17,7 @@ struct NativeConstantInterfaceWithEnum : ::djinni::JsInterface<::testsuite::Cons
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeConstantInterfaceWithEnum::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeConstantInterfaceWithEnum::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeConstantsInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeConstantsInterface.cpp
@@ -18,7 +18,7 @@ void NativeConstantsInterface::dummy(const CppType& self) {
         self->dummy();
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeConstantsInterface.hpp
+++ b/test-suite/generated-src/wasm/NativeConstantsInterface.hpp
@@ -17,7 +17,7 @@ struct NativeConstantsInterface : ::djinni::JsInterface<::testsuite::ConstantsIn
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeConstantsInterface::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeConstantsInterface::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeCppException.cpp
+++ b/test-suite/generated-src/wasm/NativeCppException.cpp
@@ -21,7 +21,7 @@ int32_t NativeCppException::throw_an_exception(const CppType& self) {
         return ::djinni::I32::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::I32>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::I32>::handleNativeException(e);
     }
 }
 int32_t NativeCppException::call_throwing_interface(const CppType& self, const em::val& w_cb) {
@@ -30,7 +30,7 @@ int32_t NativeCppException::call_throwing_interface(const CppType& self, const e
         return ::djinni::I32::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::I32>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::I32>::handleNativeException(e);
     }
 }
 std::string NativeCppException::call_throwing_and_catch(const CppType& self, const em::val& w_cb) {
@@ -39,7 +39,7 @@ std::string NativeCppException::call_throwing_and_catch(const CppType& self, con
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 em::val NativeCppException::get() {
@@ -48,7 +48,7 @@ em::val NativeCppException::get() {
         return ::djinni_generated::NativeCppException::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeCppException>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeCppException>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeCppException.hpp
+++ b/test-suite/generated-src/wasm/NativeCppException.hpp
@@ -17,7 +17,7 @@ struct NativeCppException : ::djinni::JsInterface<::testsuite::CppException, Nat
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeCppException::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeCppException::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeDataRefTest.cpp
+++ b/test-suite/generated-src/wasm/NativeDataRefTest.cpp
@@ -26,7 +26,7 @@ void NativeDataRefTest::sendData(const CppType& self, const em::val& w_data) {
         self->sendData(::djinni::NativeDataRef::toCpp(w_data));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 em::val NativeDataRefTest::retriveAsBin(const CppType& self) {
@@ -35,7 +35,7 @@ em::val NativeDataRefTest::retriveAsBin(const CppType& self) {
         return ::djinni::Binary::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Binary>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Binary>::handleNativeException(e);
     }
 }
 void NativeDataRefTest::sendMutableData(const CppType& self, const em::val& w_data) {
@@ -43,7 +43,7 @@ void NativeDataRefTest::sendMutableData(const CppType& self, const em::val& w_da
         self->sendMutableData(::djinni::NativeDataRef::toCpp(w_data));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 em::val NativeDataRefTest::generateData(const CppType& self) {
@@ -52,7 +52,7 @@ em::val NativeDataRefTest::generateData(const CppType& self) {
         return ::djinni::NativeDataRef::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::NativeDataRef>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::NativeDataRef>::handleNativeException(e);
     }
 }
 em::val NativeDataRefTest::dataFromVec(const CppType& self) {
@@ -61,7 +61,7 @@ em::val NativeDataRefTest::dataFromVec(const CppType& self) {
         return ::djinni::NativeDataRef::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::NativeDataRef>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::NativeDataRef>::handleNativeException(e);
     }
 }
 em::val NativeDataRefTest::dataFromStr(const CppType& self) {
@@ -70,7 +70,7 @@ em::val NativeDataRefTest::dataFromStr(const CppType& self) {
         return ::djinni::NativeDataRef::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::NativeDataRef>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::NativeDataRef>::handleNativeException(e);
     }
 }
 em::val NativeDataRefTest::sendDataView(const CppType& self, const em::val& w_data) {
@@ -79,7 +79,7 @@ em::val NativeDataRefTest::sendDataView(const CppType& self, const em::val& w_da
         return ::djinni::Binary::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Binary>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Binary>::handleNativeException(e);
     }
 }
 em::val NativeDataRefTest::recvDataView(const CppType& self) {
@@ -88,7 +88,7 @@ em::val NativeDataRefTest::recvDataView(const CppType& self) {
         return ::djinni::NativeDataView::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::NativeDataView>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::NativeDataView>::handleNativeException(e);
     }
 }
 em::val NativeDataRefTest::create() {
@@ -97,7 +97,7 @@ em::val NativeDataRefTest::create() {
         return ::djinni_generated::NativeDataRefTest::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeDataRefTest>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeDataRefTest>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeDataRefTest.hpp
+++ b/test-suite/generated-src/wasm/NativeDataRefTest.hpp
@@ -17,7 +17,7 @@ struct NativeDataRefTest : ::djinni::JsInterface<::testsuite::DataRefTest, Nativ
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeDataRefTest::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeDataRefTest::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeEnumUsageInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeEnumUsageInterface.cpp
@@ -23,7 +23,7 @@ int32_t NativeEnumUsageInterface::e(const CppType& self, int32_t w_e) {
         return ::djinni_generated::NativeColor::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeColor>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeColor>::handleNativeException(e);
     }
 }
 em::val NativeEnumUsageInterface::o(const CppType& self, const em::val& w_o) {
@@ -32,7 +32,7 @@ em::val NativeEnumUsageInterface::o(const CppType& self, const em::val& w_o) {
         return ::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeColor>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeColor>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeColor>>::handleNativeException(e);
     }
 }
 em::val NativeEnumUsageInterface::l(const CppType& self, const em::val& w_l) {
@@ -41,7 +41,7 @@ em::val NativeEnumUsageInterface::l(const CppType& self, const em::val& w_l) {
         return ::djinni::List<::djinni_generated::NativeColor>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni_generated::NativeColor>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::List<::djinni_generated::NativeColor>>::handleNativeException(e);
     }
 }
 em::val NativeEnumUsageInterface::s(const CppType& self, const em::val& w_s) {
@@ -50,7 +50,7 @@ em::val NativeEnumUsageInterface::s(const CppType& self, const em::val& w_s) {
         return ::djinni::Set<::djinni_generated::NativeColor>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Set<::djinni_generated::NativeColor>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Set<::djinni_generated::NativeColor>>::handleNativeException(e);
     }
 }
 em::val NativeEnumUsageInterface::m(const CppType& self, const em::val& w_m) {
@@ -59,7 +59,7 @@ em::val NativeEnumUsageInterface::m(const CppType& self, const em::val& w_m) {
         return ::djinni::Map<::djinni_generated::NativeColor, ::djinni_generated::NativeColor>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Map<::djinni_generated::NativeColor, ::djinni_generated::NativeColor>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Map<::djinni_generated::NativeColor, ::djinni_generated::NativeColor>>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeEnumUsageInterface.hpp
+++ b/test-suite/generated-src/wasm/NativeEnumUsageInterface.hpp
@@ -17,7 +17,7 @@ struct NativeEnumUsageInterface : ::djinni::JsInterface<::testsuite::EnumUsageIn
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeEnumUsageInterface::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeEnumUsageInterface::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeExternInterface1.cpp
+++ b/test-suite/generated-src/wasm/NativeExternInterface1.cpp
@@ -22,7 +22,7 @@ em::val NativeExternInterface1::foo(const CppType& self, const em::val& w_i) {
         return ::djinni_generated::NativeClientReturnedRecord::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeClientReturnedRecord>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeClientReturnedRecord>::handleNativeException(e);
     }
 }
 int32_t NativeExternInterface1::bar(const CppType& self, int32_t w_e) {
@@ -31,7 +31,7 @@ int32_t NativeExternInterface1::bar(const CppType& self, int32_t w_e) {
         return ::djinni_generated::NativeColor::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeColor>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeColor>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeExternInterface1.hpp
+++ b/test-suite/generated-src/wasm/NativeExternInterface1.hpp
@@ -17,7 +17,7 @@ struct NativeExternInterface1 : ::djinni::JsInterface<::ExternInterface1, Native
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeExternInterface1::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeExternInterface1::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeExternInterface2.hpp
+++ b/test-suite/generated-src/wasm/NativeExternInterface2.hpp
@@ -17,7 +17,7 @@ struct NativeExternInterface2 : ::djinni::JsInterface<::ExternInterface2, Native
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeExternInterface2::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeExternInterface2::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeFirstListener.hpp
+++ b/test-suite/generated-src/wasm/NativeFirstListener.hpp
@@ -17,7 +17,7 @@ struct NativeFirstListener : ::djinni::JsInterface<::testsuite::FirstListener, N
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeFirstListener::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeFirstListener::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeFlagRoundtrip.cpp
+++ b/test-suite/generated-src/wasm/NativeFlagRoundtrip.cpp
@@ -19,7 +19,7 @@ int32_t NativeFlagRoundtrip::roundtrip_access(int32_t w_flag) {
         return ::djinni_generated::NativeAccessFlags::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeAccessFlags>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeAccessFlags>::handleNativeException(e);
     }
 }
 int32_t NativeFlagRoundtrip::roundtrip_empty(int32_t w_flag) {
@@ -28,7 +28,7 @@ int32_t NativeFlagRoundtrip::roundtrip_empty(int32_t w_flag) {
         return ::djinni_generated::NativeEmptyFlags::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeEmptyFlags>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeEmptyFlags>::handleNativeException(e);
     }
 }
 em::val NativeFlagRoundtrip::roundtrip_access_boxed(const em::val& w_flag) {
@@ -37,7 +37,7 @@ em::val NativeFlagRoundtrip::roundtrip_access_boxed(const em::val& w_flag) {
         return ::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeAccessFlags>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeAccessFlags>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeAccessFlags>>::handleNativeException(e);
     }
 }
 em::val NativeFlagRoundtrip::roundtrip_empty_boxed(const em::val& w_flag) {
@@ -46,7 +46,7 @@ em::val NativeFlagRoundtrip::roundtrip_empty_boxed(const em::val& w_flag) {
         return ::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeEmptyFlags>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeEmptyFlags>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeEmptyFlags>>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeFlagRoundtrip.hpp
+++ b/test-suite/generated-src/wasm/NativeFlagRoundtrip.hpp
@@ -17,7 +17,7 @@ struct NativeFlagRoundtrip : ::djinni::JsInterface<::testsuite::FlagRoundtrip, N
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeFlagRoundtrip::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeFlagRoundtrip::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeInterfaceUsingExtendedRecord.cpp
+++ b/test-suite/generated-src/wasm/NativeInterfaceUsingExtendedRecord.cpp
@@ -20,7 +20,7 @@ em::val NativeInterfaceUsingExtendedRecord::meth(const CppType& self, const em::
         return ::djinni_generated::NativeExtendedRecord::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeExtendedRecord>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeExtendedRecord>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeInterfaceUsingExtendedRecord.hpp
+++ b/test-suite/generated-src/wasm/NativeInterfaceUsingExtendedRecord.hpp
@@ -17,7 +17,7 @@ struct NativeInterfaceUsingExtendedRecord : ::djinni::JsInterface<::testsuite::I
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeInterfaceUsingExtendedRecord::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeInterfaceUsingExtendedRecord::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeJavaOnlyListener.hpp
+++ b/test-suite/generated-src/wasm/NativeJavaOnlyListener.hpp
@@ -17,7 +17,7 @@ struct NativeJavaOnlyListener : ::djinni::JsInterface<::testsuite::JavaOnlyListe
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeJavaOnlyListener::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeJavaOnlyListener::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeListenerCaller.cpp
+++ b/test-suite/generated-src/wasm/NativeListenerCaller.cpp
@@ -22,7 +22,7 @@ em::val NativeListenerCaller::init(const em::val& w_first_l,const em::val& w_sec
         return ::djinni_generated::NativeListenerCaller::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeListenerCaller>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeListenerCaller>::handleNativeException(e);
     }
 }
 void NativeListenerCaller::callFirst(const CppType& self) {
@@ -30,7 +30,7 @@ void NativeListenerCaller::callFirst(const CppType& self) {
         self->callFirst();
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeListenerCaller::callSecond(const CppType& self) {
@@ -38,7 +38,7 @@ void NativeListenerCaller::callSecond(const CppType& self) {
         self->callSecond();
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeListenerCaller.hpp
+++ b/test-suite/generated-src/wasm/NativeListenerCaller.hpp
@@ -17,7 +17,7 @@ struct NativeListenerCaller : ::djinni::JsInterface<::testsuite::ListenerCaller,
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeListenerCaller::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeListenerCaller::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeObjcOnlyListener.hpp
+++ b/test-suite/generated-src/wasm/NativeObjcOnlyListener.hpp
@@ -17,7 +17,7 @@ struct NativeObjcOnlyListener : ::djinni::JsInterface<::testsuite::ObjcOnlyListe
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeObjcOnlyListener::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeObjcOnlyListener::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeProtoTests.cpp
+++ b/test-suite/generated-src/wasm/NativeProtoTests.cpp
@@ -20,7 +20,7 @@ em::val NativeProtoTests::protoToStrings(const em::val& w_x) {
         return ::djinni::List<::djinni::String>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni::String>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::List<::djinni::String>>::handleNativeException(e);
     }
 }
 em::val NativeProtoTests::stringsToProto(const em::val& w_x) {
@@ -29,7 +29,7 @@ em::val NativeProtoTests::stringsToProto(const em::val& w_x) {
         return ::djinni::Protobuf<::djinni::test::AddressBook, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','A','d','d','r','e','s','s','B','o','o','k'>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Protobuf<::djinni::test::AddressBook, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','A','d','d','r','e','s','s','B','o','o','k'>>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Protobuf<::djinni::test::AddressBook, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','A','d','d','r','e','s','s','B','o','o','k'>>>::handleNativeException(e);
     }
 }
 std::string NativeProtoTests::embeddedProtoToString(const em::val& w_x) {
@@ -38,7 +38,7 @@ std::string NativeProtoTests::embeddedProtoToString(const em::val& w_x) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 em::val NativeProtoTests::stringToEmbeddedProto(const std::string& w_x) {
@@ -47,7 +47,7 @@ em::val NativeProtoTests::stringToEmbeddedProto(const std::string& w_x) {
         return ::djinni_generated::NativeRecordWithEmbeddedProto::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeRecordWithEmbeddedProto>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeRecordWithEmbeddedProto>::handleNativeException(e);
     }
 }
 std::string NativeProtoTests::cppProtoToString(const em::val& w_x) {
@@ -56,7 +56,7 @@ std::string NativeProtoTests::cppProtoToString(const em::val& w_x) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 em::val NativeProtoTests::stringToCppProto(const std::string& w_x) {
@@ -65,7 +65,7 @@ em::val NativeProtoTests::stringToCppProto(const std::string& w_x) {
         return ::djinni::Protobuf<::djinni::test2::PersistingState, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','2','.','P','e','r','s','i','s','t','i','n','g','S','t','a','t','e'>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Protobuf<::djinni::test2::PersistingState, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','2','.','P','e','r','s','i','s','t','i','n','g','S','t','a','t','e'>>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Protobuf<::djinni::test2::PersistingState, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','2','.','P','e','r','s','i','s','t','i','n','g','S','t','a','t','e'>>>::handleNativeException(e);
     }
 }
 std::string NativeProtoTests::embeddedCppProtoToString(const em::val& w_x) {
@@ -74,7 +74,7 @@ std::string NativeProtoTests::embeddedCppProtoToString(const em::val& w_x) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 em::val NativeProtoTests::stringToEmbeddedCppProto(const std::string& w_x) {
@@ -83,7 +83,7 @@ em::val NativeProtoTests::stringToEmbeddedCppProto(const std::string& w_x) {
         return ::djinni_generated::NativeRecordWithEmbeddedCppProto::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeRecordWithEmbeddedCppProto>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeRecordWithEmbeddedCppProto>::handleNativeException(e);
     }
 }
 em::val NativeProtoTests::protoListToStrings(const em::val& w_x) {
@@ -92,7 +92,7 @@ em::val NativeProtoTests::protoListToStrings(const em::val& w_x) {
         return ::djinni::List<::djinni::String>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni::String>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::List<::djinni::String>>::handleNativeException(e);
     }
 }
 em::val NativeProtoTests::stringsToProtoList(const em::val& w_x) {
@@ -101,7 +101,7 @@ em::val NativeProtoTests::stringsToProtoList(const em::val& w_x) {
         return ::djinni::List<::djinni::Protobuf<::djinni::test::Person, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','P','e','r','s','o','n'>>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni::Protobuf<::djinni::test::Person, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','P','e','r','s','o','n'>>>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::List<::djinni::Protobuf<::djinni::test::Person, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','P','e','r','s','o','n'>>>>::handleNativeException(e);
     }
 }
 std::string NativeProtoTests::optionalProtoToString(const em::val& w_x) {
@@ -110,7 +110,7 @@ std::string NativeProtoTests::optionalProtoToString(const em::val& w_x) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 em::val NativeProtoTests::stringToOptionalProto(const std::string& w_x) {
@@ -119,7 +119,7 @@ em::val NativeProtoTests::stringToOptionalProto(const std::string& w_x) {
         return ::djinni::Optional<std::experimental::optional, ::djinni::Protobuf<::djinni::test::Person, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','P','e','r','s','o','n'>>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni::Protobuf<::djinni::test::Person, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','P','e','r','s','o','n'>>>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni::Protobuf<::djinni::test::Person, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','P','e','r','s','o','n'>>>>::handleNativeException(e);
     }
 }
 em::val NativeProtoTests::stringToProtoOutcome(const std::string& w_x) {
@@ -128,7 +128,7 @@ em::val NativeProtoTests::stringToProtoOutcome(const std::string& w_x) {
         return ::djinni::Outcome<::djinni::Protobuf<::djinni::test::Person, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','P','e','r','s','o','n'>>, ::djinni::I32>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Outcome<::djinni::Protobuf<::djinni::test::Person, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','P','e','r','s','o','n'>>, ::djinni::I32>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Outcome<::djinni::Protobuf<::djinni::test::Person, ::djinni::JsClassName<'p','r','o','t','o','t','e','s','t','.','P','e','r','s','o','n'>>, ::djinni::I32>>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeProtoTests.hpp
+++ b/test-suite/generated-src/wasm/NativeProtoTests.hpp
@@ -17,7 +17,7 @@ struct NativeProtoTests : ::djinni::JsInterface<::testsuite::ProtoTests, NativeP
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeProtoTests::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeProtoTests::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeReturnOne.cpp
+++ b/test-suite/generated-src/wasm/NativeReturnOne.cpp
@@ -18,7 +18,7 @@ em::val NativeReturnOne::get_instance() {
         return ::djinni_generated::NativeReturnOne::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeReturnOne>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeReturnOne>::handleNativeException(e);
     }
 }
 int8_t NativeReturnOne::return_one(const CppType& self) {
@@ -27,7 +27,7 @@ int8_t NativeReturnOne::return_one(const CppType& self) {
         return ::djinni::I8::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::I8>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::I8>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeReturnOne.hpp
+++ b/test-suite/generated-src/wasm/NativeReturnOne.hpp
@@ -17,7 +17,7 @@ struct NativeReturnOne : ::djinni::JsInterface<::testsuite::ReturnOne, NativeRet
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeReturnOne::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeReturnOne::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeReturnTwo.cpp
+++ b/test-suite/generated-src/wasm/NativeReturnTwo.cpp
@@ -18,7 +18,7 @@ em::val NativeReturnTwo::get_instance() {
         return ::djinni_generated::NativeReturnTwo::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeReturnTwo>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeReturnTwo>::handleNativeException(e);
     }
 }
 int8_t NativeReturnTwo::return_two(const CppType& self) {
@@ -27,7 +27,7 @@ int8_t NativeReturnTwo::return_two(const CppType& self) {
         return ::djinni::I8::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::I8>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::I8>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeReturnTwo.hpp
+++ b/test-suite/generated-src/wasm/NativeReturnTwo.hpp
@@ -17,7 +17,7 @@ struct NativeReturnTwo : ::djinni::JsInterface<::testsuite::ReturnTwo, NativeRet
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeReturnTwo::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeReturnTwo::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeReverseClientInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeReverseClientInterface.cpp
@@ -20,7 +20,7 @@ std::string NativeReverseClientInterface::return_str(const CppType& self) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 std::string NativeReverseClientInterface::meth_taking_interface(const CppType& self, const em::val& w_i) {
@@ -29,7 +29,7 @@ std::string NativeReverseClientInterface::meth_taking_interface(const CppType& s
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 std::string NativeReverseClientInterface::meth_taking_optional_interface(const CppType& self, const em::val& w_i) {
@@ -38,7 +38,7 @@ std::string NativeReverseClientInterface::meth_taking_optional_interface(const C
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 em::val NativeReverseClientInterface::create() {
@@ -47,7 +47,7 @@ em::val NativeReverseClientInterface::create() {
         return ::djinni_generated::NativeReverseClientInterface::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeReverseClientInterface>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeReverseClientInterface>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeReverseClientInterface.hpp
+++ b/test-suite/generated-src/wasm/NativeReverseClientInterface.hpp
@@ -17,7 +17,7 @@ struct NativeReverseClientInterface : ::djinni::JsInterface<::testsuite::Reverse
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeReverseClientInterface::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeReverseClientInterface::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeSampleInterface.hpp
+++ b/test-suite/generated-src/wasm/NativeSampleInterface.hpp
@@ -17,7 +17,7 @@ struct NativeSampleInterface : ::djinni::JsInterface<::testsuite::SampleInterfac
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeSampleInterface::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeSampleInterface::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeSecondListener.hpp
+++ b/test-suite/generated-src/wasm/NativeSecondListener.hpp
@@ -17,7 +17,7 @@ struct NativeSecondListener : ::djinni::JsInterface<::testsuite::SecondListener,
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeSecondListener::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeSecondListener::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeTestArray.cpp
+++ b/test-suite/generated-src/wasm/NativeTestArray.cpp
@@ -18,7 +18,7 @@ em::val NativeTestArray::testStringArray(const em::val& w_a) {
         return ::djinni::Array<::djinni::String>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Array<::djinni::String>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Array<::djinni::String>>::handleNativeException(e);
     }
 }
 em::val NativeTestArray::testIntArray(const em::val& w_a) {
@@ -27,7 +27,7 @@ em::val NativeTestArray::testIntArray(const em::val& w_a) {
         return ::djinni::Array<::djinni::I32>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Array<::djinni::I32>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Array<::djinni::I32>>::handleNativeException(e);
     }
 }
 em::val NativeTestArray::testRecordArray(const em::val& w_a) {
@@ -36,7 +36,7 @@ em::val NativeTestArray::testRecordArray(const em::val& w_a) {
         return ::djinni::Array<::djinni_generated::NativeVec2>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Array<::djinni_generated::NativeVec2>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Array<::djinni_generated::NativeVec2>>::handleNativeException(e);
     }
 }
 em::val NativeTestArray::testArrayOfArray(const em::val& w_a) {
@@ -45,7 +45,7 @@ em::val NativeTestArray::testArrayOfArray(const em::val& w_a) {
         return ::djinni::Array<::djinni::Array<::djinni::I32>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Array<::djinni::Array<::djinni::I32>>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Array<::djinni::Array<::djinni::I32>>>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeTestArray.hpp
+++ b/test-suite/generated-src/wasm/NativeTestArray.hpp
@@ -17,7 +17,7 @@ struct NativeTestArray : ::djinni::JsInterface<::testsuite::TestArray, NativeTes
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeTestArray::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeTestArray::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeTestDuration.cpp
+++ b/test-suite/generated-src/wasm/NativeTestDuration.cpp
@@ -18,7 +18,7 @@ std::string NativeTestDuration::hoursString(const em::val& w_dt) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 std::string NativeTestDuration::minutesString(const em::val& w_dt) {
@@ -27,7 +27,7 @@ std::string NativeTestDuration::minutesString(const em::val& w_dt) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 std::string NativeTestDuration::secondsString(const em::val& w_dt) {
@@ -36,7 +36,7 @@ std::string NativeTestDuration::secondsString(const em::val& w_dt) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 std::string NativeTestDuration::millisString(const em::val& w_dt) {
@@ -45,7 +45,7 @@ std::string NativeTestDuration::millisString(const em::val& w_dt) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 std::string NativeTestDuration::microsString(const em::val& w_dt) {
@@ -54,7 +54,7 @@ std::string NativeTestDuration::microsString(const em::val& w_dt) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 std::string NativeTestDuration::nanosString(const em::val& w_dt) {
@@ -63,7 +63,7 @@ std::string NativeTestDuration::nanosString(const em::val& w_dt) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::hours(int32_t w_count) {
@@ -72,7 +72,7 @@ em::val NativeTestDuration::hours(int32_t w_count) {
         return ::djinni::Duration<::djinni::I32, ::djinni::Duration_h>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_h>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_h>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::minutes(int32_t w_count) {
@@ -81,7 +81,7 @@ em::val NativeTestDuration::minutes(int32_t w_count) {
         return ::djinni::Duration<::djinni::I32, ::djinni::Duration_min>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_min>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_min>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::seconds(int32_t w_count) {
@@ -90,7 +90,7 @@ em::val NativeTestDuration::seconds(int32_t w_count) {
         return ::djinni::Duration<::djinni::I32, ::djinni::Duration_s>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_s>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_s>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::millis(int32_t w_count) {
@@ -99,7 +99,7 @@ em::val NativeTestDuration::millis(int32_t w_count) {
         return ::djinni::Duration<::djinni::I32, ::djinni::Duration_ms>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_ms>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_ms>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::micros(int32_t w_count) {
@@ -108,7 +108,7 @@ em::val NativeTestDuration::micros(int32_t w_count) {
         return ::djinni::Duration<::djinni::I32, ::djinni::Duration_us>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_us>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_us>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::nanos(int32_t w_count) {
@@ -117,7 +117,7 @@ em::val NativeTestDuration::nanos(int32_t w_count) {
         return ::djinni::Duration<::djinni::I32, ::djinni::Duration_ns>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_ns>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::I32, ::djinni::Duration_ns>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::hoursf(double w_count) {
@@ -126,7 +126,7 @@ em::val NativeTestDuration::hoursf(double w_count) {
         return ::djinni::Duration<::djinni::F64, ::djinni::Duration_h>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_h>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_h>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::minutesf(double w_count) {
@@ -135,7 +135,7 @@ em::val NativeTestDuration::minutesf(double w_count) {
         return ::djinni::Duration<::djinni::F64, ::djinni::Duration_min>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_min>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_min>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::secondsf(double w_count) {
@@ -144,7 +144,7 @@ em::val NativeTestDuration::secondsf(double w_count) {
         return ::djinni::Duration<::djinni::F64, ::djinni::Duration_s>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_s>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_s>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::millisf(double w_count) {
@@ -153,7 +153,7 @@ em::val NativeTestDuration::millisf(double w_count) {
         return ::djinni::Duration<::djinni::F64, ::djinni::Duration_ms>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_ms>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_ms>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::microsf(double w_count) {
@@ -162,7 +162,7 @@ em::val NativeTestDuration::microsf(double w_count) {
         return ::djinni::Duration<::djinni::F64, ::djinni::Duration_us>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_us>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_us>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::nanosf(double w_count) {
@@ -171,7 +171,7 @@ em::val NativeTestDuration::nanosf(double w_count) {
         return ::djinni::Duration<::djinni::F64, ::djinni::Duration_ns>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_ns>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Duration<::djinni::F64, ::djinni::Duration_ns>>::handleNativeException(e);
     }
 }
 em::val NativeTestDuration::box(int64_t w_count) {
@@ -180,7 +180,7 @@ em::val NativeTestDuration::box(int64_t w_count) {
         return ::djinni::Optional<std::experimental::optional, ::djinni::Duration<::djinni::I64, ::djinni::Duration_s>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni::Duration<::djinni::I64, ::djinni::Duration_s>>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni::Duration<::djinni::I64, ::djinni::Duration_s>>>::handleNativeException(e);
     }
 }
 int64_t NativeTestDuration::unbox(const em::val& w_dt) {
@@ -189,7 +189,7 @@ int64_t NativeTestDuration::unbox(const em::val& w_dt) {
         return ::djinni::I64::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::I64>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::I64>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeTestDuration.hpp
+++ b/test-suite/generated-src/wasm/NativeTestDuration.hpp
@@ -17,7 +17,7 @@ struct NativeTestDuration : ::djinni::JsInterface<::testsuite::TestDuration, Nat
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeTestDuration::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeTestDuration::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeTestHelpers.cpp
+++ b/test-suite/generated-src/wasm/NativeTestHelpers.cpp
@@ -27,7 +27,7 @@ em::val NativeTestHelpers::get_set_record() {
         return ::djinni_generated::NativeSetRecord::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeSetRecord>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeSetRecord>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_set_record(const em::val& w_rec) {
@@ -36,7 +36,7 @@ bool NativeTestHelpers::check_set_record(const em::val& w_rec) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_primitive_list() {
@@ -45,7 +45,7 @@ em::val NativeTestHelpers::get_primitive_list() {
         return ::djinni_generated::NativePrimitiveList::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativePrimitiveList>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativePrimitiveList>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_primitive_list(const em::val& w_pl) {
@@ -54,7 +54,7 @@ bool NativeTestHelpers::check_primitive_list(const em::val& w_pl) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_nested_collection() {
@@ -63,7 +63,7 @@ em::val NativeTestHelpers::get_nested_collection() {
         return ::djinni_generated::NativeNestedCollection::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeNestedCollection>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeNestedCollection>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_nested_collection(const em::val& w_nc) {
@@ -72,7 +72,7 @@ bool NativeTestHelpers::check_nested_collection(const em::val& w_nc) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_map() {
@@ -81,7 +81,7 @@ em::val NativeTestHelpers::get_map() {
         return ::djinni::Map<::djinni::String, ::djinni::I64>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Map<::djinni::String, ::djinni::I64>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Map<::djinni::String, ::djinni::I64>>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_map(const em::val& w_m) {
@@ -90,7 +90,7 @@ bool NativeTestHelpers::check_map(const em::val& w_m) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_empty_map() {
@@ -99,7 +99,7 @@ em::val NativeTestHelpers::get_empty_map() {
         return ::djinni::Map<::djinni::String, ::djinni::I64>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Map<::djinni::String, ::djinni::I64>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Map<::djinni::String, ::djinni::I64>>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_empty_map(const em::val& w_m) {
@@ -108,7 +108,7 @@ bool NativeTestHelpers::check_empty_map(const em::val& w_m) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_map_list_record() {
@@ -117,7 +117,7 @@ em::val NativeTestHelpers::get_map_list_record() {
         return ::djinni_generated::NativeMapListRecord::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeMapListRecord>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeMapListRecord>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_map_list_record(const em::val& w_m) {
@@ -126,7 +126,7 @@ bool NativeTestHelpers::check_map_list_record(const em::val& w_m) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 void NativeTestHelpers::check_client_interface_ascii(const em::val& w_i) {
@@ -134,7 +134,7 @@ void NativeTestHelpers::check_client_interface_ascii(const em::val& w_i) {
         ::testsuite::TestHelpers::check_client_interface_ascii(::djinni_generated::NativeClientInterface::toCpp(w_i));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeTestHelpers::check_client_interface_nonascii(const em::val& w_i) {
@@ -142,7 +142,7 @@ void NativeTestHelpers::check_client_interface_nonascii(const em::val& w_i) {
         ::testsuite::TestHelpers::check_client_interface_nonascii(::djinni_generated::NativeClientInterface::toCpp(w_i));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeTestHelpers::check_client_interface_args(const em::val& w_i) {
@@ -150,7 +150,7 @@ void NativeTestHelpers::check_client_interface_args(const em::val& w_i) {
         ::testsuite::TestHelpers::check_client_interface_args(::djinni_generated::NativeClientInterface::toCpp(w_i));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeTestHelpers::check_enum_map(const em::val& w_m) {
@@ -158,7 +158,7 @@ void NativeTestHelpers::check_enum_map(const em::val& w_m) {
         ::testsuite::TestHelpers::check_enum_map(::djinni::Map<::djinni_generated::NativeColor, ::djinni::String>::toCpp(w_m));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 void NativeTestHelpers::check_enum(int32_t w_c) {
@@ -166,7 +166,7 @@ void NativeTestHelpers::check_enum(int32_t w_c) {
         ::testsuite::TestHelpers::check_enum(::djinni_generated::NativeColor::toCpp(w_c));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::token_id(const em::val& w_t) {
@@ -175,7 +175,7 @@ em::val NativeTestHelpers::token_id(const em::val& w_t) {
         return ::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeUserToken>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeUserToken>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni_generated::NativeUserToken>>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::create_cpp_token() {
@@ -184,7 +184,7 @@ em::val NativeTestHelpers::create_cpp_token() {
         return ::djinni_generated::NativeUserToken::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeUserToken>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeUserToken>::handleNativeException(e);
     }
 }
 void NativeTestHelpers::check_cpp_token(const em::val& w_t) {
@@ -192,7 +192,7 @@ void NativeTestHelpers::check_cpp_token(const em::val& w_t) {
         ::testsuite::TestHelpers::check_cpp_token(::djinni_generated::NativeUserToken::toCpp(w_t));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 int64_t NativeTestHelpers::cpp_token_id(const em::val& w_t) {
@@ -201,7 +201,7 @@ int64_t NativeTestHelpers::cpp_token_id(const em::val& w_t) {
         return ::djinni::I64::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::I64>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::I64>::handleNativeException(e);
     }
 }
 void NativeTestHelpers::check_token_type(const em::val& w_t,const std::string& w_type) {
@@ -210,7 +210,7 @@ void NativeTestHelpers::check_token_type(const em::val& w_t,const std::string& w
                          ::djinni::String::toCpp(w_type));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::return_none() {
@@ -219,7 +219,7 @@ em::val NativeTestHelpers::return_none() {
         return ::djinni::Optional<std::experimental::optional, ::djinni::I32>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni::I32>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Optional<std::experimental::optional, ::djinni::I32>>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::assorted_primitives_id(const em::val& w_i) {
@@ -228,7 +228,7 @@ em::val NativeTestHelpers::assorted_primitives_id(const em::val& w_i) {
         return ::djinni_generated::NativeAssortedPrimitives::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeAssortedPrimitives>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeAssortedPrimitives>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::id_binary(const em::val& w_b) {
@@ -237,7 +237,7 @@ em::val NativeTestHelpers::id_binary(const em::val& w_b) {
         return ::djinni::Binary::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Binary>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Binary>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_async_result() {
@@ -246,7 +246,7 @@ em::val NativeTestHelpers::get_async_result() {
         return ::djinni::FutureAdaptor<::djinni::I32>::fromCpp(std::move(r));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::I32>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::I32>>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::future_roundtrip(const em::val& w_f) {
@@ -255,7 +255,7 @@ em::val NativeTestHelpers::future_roundtrip(const em::val& w_f) {
         return ::djinni::FutureAdaptor<::djinni::String>::fromCpp(std::move(r));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::String>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::String>>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::async_early_throw() {
@@ -264,7 +264,7 @@ em::val NativeTestHelpers::async_early_throw() {
         return ::djinni::FutureAdaptor<::djinni::I32>::fromCpp(std::move(r));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::I32>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::I32>>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::void_async_method(const em::val& w_f) {
@@ -273,7 +273,7 @@ em::val NativeTestHelpers::void_async_method(const em::val& w_f) {
         return ::djinni::FutureAdaptor<::djinni::Void>::fromCpp(std::move(r));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::Void>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::Void>>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::check_async_interface(const em::val& w_i) {
@@ -282,7 +282,7 @@ em::val NativeTestHelpers::check_async_interface(const em::val& w_i) {
         return ::djinni::FutureAdaptor<::djinni::String>::fromCpp(std::move(r));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::String>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::String>>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::check_async_composition(const em::val& w_i) {
@@ -291,7 +291,7 @@ em::val NativeTestHelpers::check_async_composition(const em::val& w_i) {
         return ::djinni::FutureAdaptor<::djinni::String>::fromCpp(std::move(r));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::String>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::String>>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_optional_list() {
@@ -300,7 +300,7 @@ em::val NativeTestHelpers::get_optional_list() {
         return ::djinni::List<::djinni::Optional<std::experimental::optional, ::djinni::String>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::List<::djinni::Optional<std::experimental::optional, ::djinni::String>>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::List<::djinni::Optional<std::experimental::optional, ::djinni::String>>>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_optional_list(const em::val& w_ol) {
@@ -309,7 +309,7 @@ bool NativeTestHelpers::check_optional_list(const em::val& w_ol) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_optional_set() {
@@ -318,7 +318,7 @@ em::val NativeTestHelpers::get_optional_set() {
         return ::djinni::Set<::djinni::Optional<std::experimental::optional, ::djinni::String>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Set<::djinni::Optional<std::experimental::optional, ::djinni::String>>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Set<::djinni::Optional<std::experimental::optional, ::djinni::String>>>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_optional_set(const em::val& w_os) {
@@ -327,7 +327,7 @@ bool NativeTestHelpers::check_optional_set(const em::val& w_os) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 em::val NativeTestHelpers::get_optional_map() {
@@ -336,7 +336,7 @@ em::val NativeTestHelpers::get_optional_map() {
         return ::djinni::Map<::djinni::Optional<std::experimental::optional, ::djinni::String>, ::djinni::Optional<std::experimental::optional, ::djinni::String>>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Map<::djinni::Optional<std::experimental::optional, ::djinni::String>, ::djinni::Optional<std::experimental::optional, ::djinni::String>>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Map<::djinni::Optional<std::experimental::optional, ::djinni::String>, ::djinni::Optional<std::experimental::optional, ::djinni::String>>>::handleNativeException(e);
     }
 }
 bool NativeTestHelpers::check_optional_map(const em::val& w_om) {
@@ -345,7 +345,7 @@ bool NativeTestHelpers::check_optional_map(const em::val& w_om) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeTestHelpers.hpp
+++ b/test-suite/generated-src/wasm/NativeTestHelpers.hpp
@@ -17,7 +17,7 @@ struct NativeTestHelpers : ::djinni::JsInterface<::testsuite::TestHelpers, Nativ
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeTestHelpers::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeTestHelpers::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeTestOutcome.cpp
+++ b/test-suite/generated-src/wasm/NativeTestOutcome.cpp
@@ -19,7 +19,7 @@ em::val NativeTestOutcome::getSuccessOutcome() {
         return ::djinni::Outcome<::djinni::String, ::djinni::I32>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Outcome<::djinni::String, ::djinni::I32>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Outcome<::djinni::String, ::djinni::I32>>::handleNativeException(e);
     }
 }
 em::val NativeTestOutcome::getErrorOutcome() {
@@ -28,7 +28,7 @@ em::val NativeTestOutcome::getErrorOutcome() {
         return ::djinni::Outcome<::djinni::String, ::djinni::I32>::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Outcome<::djinni::String, ::djinni::I32>>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Outcome<::djinni::String, ::djinni::I32>>::handleNativeException(e);
     }
 }
 std::string NativeTestOutcome::putSuccessOutcome(const em::val& w_x) {
@@ -37,7 +37,7 @@ std::string NativeTestOutcome::putSuccessOutcome(const em::val& w_x) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 int32_t NativeTestOutcome::putErrorOutcome(const em::val& w_x) {
@@ -46,7 +46,7 @@ int32_t NativeTestOutcome::putErrorOutcome(const em::val& w_x) {
         return ::djinni::I32::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::I32>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::I32>::handleNativeException(e);
     }
 }
 em::val NativeTestOutcome::getNestedSuccessOutcome() {
@@ -55,7 +55,7 @@ em::val NativeTestOutcome::getNestedSuccessOutcome() {
         return ::djinni_generated::NativeNestedOutcome::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeNestedOutcome>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeNestedOutcome>::handleNativeException(e);
     }
 }
 em::val NativeTestOutcome::getNestedErrorOutcome() {
@@ -64,7 +64,7 @@ em::val NativeTestOutcome::getNestedErrorOutcome() {
         return ::djinni_generated::NativeNestedOutcome::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeNestedOutcome>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeNestedOutcome>::handleNativeException(e);
     }
 }
 int32_t NativeTestOutcome::putNestedSuccessOutcome(const em::val& w_x) {
@@ -73,7 +73,7 @@ int32_t NativeTestOutcome::putNestedSuccessOutcome(const em::val& w_x) {
         return ::djinni::I32::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::I32>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::I32>::handleNativeException(e);
     }
 }
 std::string NativeTestOutcome::putNestedErrorOutcome(const em::val& w_x) {
@@ -82,7 +82,7 @@ std::string NativeTestOutcome::putNestedErrorOutcome(const em::val& w_x) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeTestOutcome.hpp
+++ b/test-suite/generated-src/wasm/NativeTestOutcome.hpp
@@ -17,7 +17,7 @@ struct NativeTestOutcome : ::djinni::JsInterface<::testsuite::TestOutcome, Nativ
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeTestOutcome::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeTestOutcome::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeTestStaticMethodLanguage.hpp
+++ b/test-suite/generated-src/wasm/NativeTestStaticMethodLanguage.hpp
@@ -17,7 +17,7 @@ struct NativeTestStaticMethodLanguage : ::djinni::JsInterface<::testsuite::TestS
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeTestStaticMethodLanguage::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeTestStaticMethodLanguage::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeThrowingInterface.hpp
+++ b/test-suite/generated-src/wasm/NativeThrowingInterface.hpp
@@ -17,7 +17,7 @@ struct NativeThrowingInterface : ::djinni::JsInterface<::testsuite::ThrowingInte
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeThrowingInterface::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeThrowingInterface::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeUserToken.cpp
+++ b/test-suite/generated-src/wasm/NativeUserToken.cpp
@@ -18,7 +18,7 @@ std::string NativeUserToken::whoami(const CppType& self) {
         return ::djinni::String::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::String>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeUserToken.hpp
+++ b/test-suite/generated-src/wasm/NativeUserToken.hpp
@@ -17,7 +17,7 @@ struct NativeUserToken : ::djinni::JsInterface<::testsuite::UserToken, NativeUse
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeUserToken::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeUserToken::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeUsesSingleLanguageListeners.cpp
+++ b/test-suite/generated-src/wasm/NativeUsesSingleLanguageListeners.cpp
@@ -22,7 +22,7 @@ void NativeUsesSingleLanguageListeners::callForObjC(const CppType& self, const e
         self->callForObjC(::djinni_generated::NativeObjcOnlyListener::toCpp(w_l));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 em::val NativeUsesSingleLanguageListeners::returnForObjC(const CppType& self) {
@@ -31,7 +31,7 @@ em::val NativeUsesSingleLanguageListeners::returnForObjC(const CppType& self) {
         return ::djinni_generated::NativeObjcOnlyListener::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeObjcOnlyListener>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeObjcOnlyListener>::handleNativeException(e);
     }
 }
 void NativeUsesSingleLanguageListeners::callForJava(const CppType& self, const em::val& w_l) {
@@ -39,7 +39,7 @@ void NativeUsesSingleLanguageListeners::callForJava(const CppType& self, const e
         self->callForJava(::djinni_generated::NativeJavaOnlyListener::toCpp(w_l));
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<void>::handleNativeException(e);
     }
 }
 em::val NativeUsesSingleLanguageListeners::returnForJava(const CppType& self) {
@@ -48,7 +48,7 @@ em::val NativeUsesSingleLanguageListeners::returnForJava(const CppType& self) {
         return ::djinni_generated::NativeJavaOnlyListener::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeJavaOnlyListener>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeJavaOnlyListener>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeUsesSingleLanguageListeners.hpp
+++ b/test-suite/generated-src/wasm/NativeUsesSingleLanguageListeners.hpp
@@ -17,7 +17,7 @@ struct NativeUsesSingleLanguageListeners : ::djinni::JsInterface<::testsuite::Us
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeUsesSingleLanguageListeners::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeUsesSingleLanguageListeners::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeVarnameInterface.cpp
+++ b/test-suite/generated-src/wasm/NativeVarnameInterface.cpp
@@ -20,7 +20,7 @@ em::val NativeVarnameInterface::_rmethod_(const CppType& self, const em::val& w_
         return ::djinni_generated::NativeVarnameRecord::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeVarnameRecord>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeVarnameRecord>::handleNativeException(e);
     }
 }
 em::val NativeVarnameInterface::_imethod_(const CppType& self, const em::val& w__i_arg_) {
@@ -29,7 +29,7 @@ em::val NativeVarnameInterface::_imethod_(const CppType& self, const em::val& w_
         return ::djinni_generated::NativeVarnameInterface::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeVarnameInterface>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeVarnameInterface>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeVarnameInterface.hpp
+++ b/test-suite/generated-src/wasm/NativeVarnameInterface.hpp
@@ -17,7 +17,7 @@ struct NativeVarnameInterface : ::djinni::JsInterface<::testsuite::VarnameInterf
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeVarnameInterface::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeVarnameInterface::fromCpp");
         return fromCppOpt(c);
     }
 

--- a/test-suite/generated-src/wasm/NativeWcharTestHelpers.cpp
+++ b/test-suite/generated-src/wasm/NativeWcharTestHelpers.cpp
@@ -18,7 +18,7 @@ em::val NativeWcharTestHelpers::get_record() {
         return ::djinni_generated::NativeWcharTestRec::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni_generated::NativeWcharTestRec>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni_generated::NativeWcharTestRec>::handleNativeException(e);
     }
 }
 std::wstring NativeWcharTestHelpers::get_string() {
@@ -27,7 +27,7 @@ std::wstring NativeWcharTestHelpers::get_string() {
         return ::djinni::WString::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::WString>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::WString>::handleNativeException(e);
     }
 }
 bool NativeWcharTestHelpers::check_string(const std::wstring& w_str) {
@@ -36,7 +36,7 @@ bool NativeWcharTestHelpers::check_string(const std::wstring& w_str) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 bool NativeWcharTestHelpers::check_record(const em::val& w_rec) {
@@ -45,7 +45,7 @@ bool NativeWcharTestHelpers::check_record(const em::val& w_rec) {
         return ::djinni::Bool::fromCpp(r);
     }
     catch(const std::exception& e) {
-        return djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
+        return ::djinni::ExceptionHandlingTraits<::djinni::Bool>::handleNativeException(e);
     }
 }
 

--- a/test-suite/generated-src/wasm/NativeWcharTestHelpers.hpp
+++ b/test-suite/generated-src/wasm/NativeWcharTestHelpers.hpp
@@ -17,7 +17,7 @@ struct NativeWcharTestHelpers : ::djinni::JsInterface<::testsuite::WcharTestHelp
     static CppType toCpp(JsType j) { return _fromJs(j); }
     static JsType fromCppOpt(const CppOptType& c) { return {_toJs(c)}; }
     static JsType fromCpp(const CppType& c) {
-        djinni::checkForNull(c.get(), "NativeWcharTestHelpers::fromCpp");
+        ::djinni::checkForNull(c.get(), "NativeWcharTestHelpers::fromCpp");
         return fromCppOpt(c);
     }
 


### PR DESCRIPTION
A few calls to the supporting lib were missing global :: prefix in the WASM generator.