### PR TITLE
Fix Promise optional in typescript

### DIFF
--- a/src/source/TsGenerator.scala
+++ b/src/source/TsGenerator.scala
@@ -72,7 +72,7 @@ class TsGenerator(spec: Spec) extends Generator(spec) {
   }
 
   def toTsType(tm: MExpr, addNullability: Boolean = true): String = {
-    def args(tm: MExpr) = if (tm.args.isEmpty) "" else tm.args.map(f).mkString("<", ", ", ">")
+    def args(tm: MExpr) = if (tm.args.isEmpty) "" else tm.args.map(arg => toTsType(arg, addNullability)).mkString("<", ", ", ">")
     def f(tm: MExpr): String = {
       tm.base match {
         case MOptional =>

--- a/test-suite/djinni/test.djinni
+++ b/test-suite/djinni/test.djinni
@@ -52,6 +52,9 @@ test_helpers = interface +c {
     static future_roundtrip(f: future<i32>): future<string>;
     static async_early_throw(): future<i32>;
     static void_async_method(f: future<void>): future<void>;
+    # If the input is empty, returns back an empty future.
+    # If the input is non-empty, returns back the value plus one.
+    static add_one_if_present(f: future<optional<i32>>): future<optional<i32>>;
 
     static check_async_interface(i: async_interface): future<string>;
     static check_async_composition(i: async_interface): future<string>;

--- a/test-suite/generated-src/cpp/test_helpers.hpp
+++ b/test-suite/generated-src/cpp/test_helpers.hpp
@@ -98,6 +98,12 @@ public:
 
     static ::djinni::Future<void> void_async_method(::djinni::Future<void> f);
 
+    /**
+     * If the input is empty, returns back an empty future.
+     * If the input is non-empty, returns back the value plus one.
+     */
+    static ::djinni::Future<std::experimental::optional<int32_t>> add_one_if_present(::djinni::Future<std::experimental::optional<int32_t>> f);
+
     static ::djinni::Future<std::string> check_async_interface(const /*not-null*/ std::shared_ptr<AsyncInterface> & i);
 
     static ::djinni::Future<std::string> check_async_composition(const /*not-null*/ std::shared_ptr<AsyncInterface> & i);

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
@@ -97,6 +97,13 @@ public abstract class TestHelpers {
     @Nonnull
     public static native com.snapchat.djinni.Future<Void> voidAsyncMethod(@Nonnull com.snapchat.djinni.Future<Void> f);
 
+    /**
+     * If the input is empty, returns back an empty future.
+     * If the input is non-empty, returns back the value plus one.
+     */
+    @Nonnull
+    public static native com.snapchat.djinni.Future<Integer> addOneIfPresent(@Nonnull com.snapchat.djinni.Future<Integer> f);
+
     @Nonnull
     public static native com.snapchat.djinni.Future<String> checkAsyncInterface(@CheckForNull AsyncInterface i);
 

--- a/test-suite/generated-src/jni/NativeTestHelpers.cpp
+++ b/test-suite/generated-src/jni/NativeTestHelpers.cpp
@@ -254,6 +254,14 @@ CJNIEXPORT ::djinni::FutureAdaptor<::djinni::Void>::JniType JNICALL Java_com_dro
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT ::djinni::FutureAdaptor<::djinni::Optional<std::experimental::optional, ::djinni::I32>>::JniType JNICALL Java_com_dropbox_djinni_test_TestHelpers_addOneIfPresent(JNIEnv* jniEnv, jobject /*this*/, ::djinni::FutureAdaptor<::djinni::Optional<std::experimental::optional, ::djinni::I32>>::JniType j_f)
+{
+    try {
+        auto r = ::testsuite::TestHelpers::add_one_if_present(::djinni::FutureAdaptor<::djinni::Optional<std::experimental::optional, ::djinni::I32>>::toCpp(jniEnv, j_f));
+        return ::djinni::release(::djinni::FutureAdaptor<::djinni::Optional<std::experimental::optional, ::djinni::I32>>::fromCpp(jniEnv, std::move(r)));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 CJNIEXPORT ::djinni::FutureAdaptor<::djinni::String>::JniType JNICALL Java_com_dropbox_djinni_test_TestHelpers_checkAsyncInterface(JNIEnv* jniEnv, jobject /*this*/, jobject j_i)
 {
     try {

--- a/test-suite/generated-src/objc/DBTestHelpers+Private.mm
+++ b/test-suite/generated-src/objc/DBTestHelpers+Private.mm
@@ -238,6 +238,13 @@ static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for th
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }
 
++ (nonnull DJFuture<NSNumber *> *)addOneIfPresent:(nonnull DJFuture<NSNumber *> *)f {
+    try {
+        auto objcpp_result_ = ::testsuite::TestHelpers::add_one_if_present(::djinni::FutureAdaptor<::djinni::Optional<std::experimental::optional, ::djinni::I32>>::toCpp(f));
+        return ::djinni::FutureAdaptor<::djinni::Optional<std::experimental::optional, ::djinni::I32>>::fromCpp(std::move(objcpp_result_));
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
 + (nonnull DJFuture<NSString *> *)checkAsyncInterface:(nullable id<DBAsyncInterface>)i {
     try {
         auto objcpp_result_ = ::testsuite::TestHelpers::check_async_interface(::djinni_generated::AsyncInterface::toCpp(i));

--- a/test-suite/generated-src/objc/DBTestHelpers.h
+++ b/test-suite/generated-src/objc/DBTestHelpers.h
@@ -87,6 +87,12 @@
 
 + (nonnull DJFuture<NSNull *> *)voidAsyncMethod:(nonnull DJFuture<NSNull *> *)f;
 
+/**
+ * If the input is empty, returns back an empty future.
+ * If the input is non-empty, returns back the value plus one.
+ */
++ (nonnull DJFuture<NSNumber *> *)addOneIfPresent:(nonnull DJFuture<NSNumber *> *)f;
+
 + (nonnull DJFuture<NSString *> *)checkAsyncInterface:(nullable id<DBAsyncInterface>)i;
 
 + (nonnull DJFuture<NSString *> *)checkAsyncComposition:(nullable id<DBAsyncInterface>)i;

--- a/test-suite/generated-src/ts/test.ts
+++ b/test-suite/generated-src/ts/test.ts
@@ -451,6 +451,11 @@ export interface TestHelpers_statics {
     futureRoundtrip(f: Promise<number>): Promise<string>;
     asyncEarlyThrow(): Promise<number>;
     voidAsyncMethod(f: Promise<void>): Promise<void>;
+    /**
+     * If the input is empty, returns back an empty future.
+     * If the input is non-empty, returns back the value plus one.
+     */
+    addOneIfPresent(f: Promise<number | undefined>): Promise<number | undefined>;
     checkAsyncInterface(i: AsyncInterface): Promise<string>;
     checkAsyncComposition(i: AsyncInterface): Promise<string>;
     getOptionalList(): Array<string | undefined>;

--- a/test-suite/generated-src/ts/test.ts
+++ b/test-suite/generated-src/ts/test.ts
@@ -453,12 +453,12 @@ export interface TestHelpers_statics {
     voidAsyncMethod(f: Promise<void>): Promise<void>;
     checkAsyncInterface(i: AsyncInterface): Promise<string>;
     checkAsyncComposition(i: AsyncInterface): Promise<string>;
-    getOptionalList(): Array<string>;
-    checkOptionalList(ol: Array<string>): boolean;
-    getOptionalSet(): Set<string>;
-    checkOptionalSet(os: Set<string>): boolean;
-    getOptionalMap(): Map<string, string>;
-    checkOptionalMap(om: Map<string, string>): boolean;
+    getOptionalList(): Array<string | undefined>;
+    checkOptionalList(ol: Array<string | undefined>): boolean;
+    getOptionalSet(): Set<string | undefined>;
+    checkOptionalSet(os: Set<string | undefined>): boolean;
+    getOptionalMap(): Map<string | undefined, string | undefined>;
+    checkOptionalMap(om: Map<string | undefined, string | undefined>): boolean;
 }
 
 /**

--- a/test-suite/generated-src/wasm/NativeTestHelpers.cpp
+++ b/test-suite/generated-src/wasm/NativeTestHelpers.cpp
@@ -276,6 +276,15 @@ em::val NativeTestHelpers::void_async_method(const em::val& w_f) {
         return djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::Void>>::handleNativeException(e);
     }
 }
+em::val NativeTestHelpers::add_one_if_present(const em::val& w_f) {
+    try {
+        auto r = ::testsuite::TestHelpers::add_one_if_present(::djinni::FutureAdaptor<::djinni::Optional<std::experimental::optional, ::djinni::I32>>::toCpp(w_f));
+        return ::djinni::FutureAdaptor<::djinni::Optional<std::experimental::optional, ::djinni::I32>>::fromCpp(std::move(r));
+    }
+    catch(const std::exception& e) {
+        return djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::Optional<std::experimental::optional, ::djinni::I32>>>::handleNativeException(e);
+    }
+}
 em::val NativeTestHelpers::check_async_interface(const em::val& w_i) {
     try {
         auto r = ::testsuite::TestHelpers::check_async_interface(::djinni_generated::NativeAsyncInterface::toCpp(w_i));
@@ -382,6 +391,7 @@ EMSCRIPTEN_BINDINGS(testsuite_test_helpers) {
         .class_function("futureRoundtrip", NativeTestHelpers::future_roundtrip)
         .class_function("asyncEarlyThrow", NativeTestHelpers::async_early_throw)
         .class_function("voidAsyncMethod", NativeTestHelpers::void_async_method)
+        .class_function("addOneIfPresent", NativeTestHelpers::add_one_if_present)
         .class_function("checkAsyncInterface", NativeTestHelpers::check_async_interface)
         .class_function("checkAsyncComposition", NativeTestHelpers::check_async_composition)
         .class_function("getOptionalList", NativeTestHelpers::get_optional_list)

--- a/test-suite/generated-src/wasm/NativeTestHelpers.hpp
+++ b/test-suite/generated-src/wasm/NativeTestHelpers.hpp
@@ -52,6 +52,7 @@ struct NativeTestHelpers : ::djinni::JsInterface<::testsuite::TestHelpers, Nativ
     static em::val future_roundtrip(const em::val& w_f);
     static em::val async_early_throw();
     static em::val void_async_method(const em::val& w_f);
+    static em::val add_one_if_present(const em::val& w_f);
     static em::val check_async_interface(const em::val& w_i);
     static em::val check_async_composition(const em::val& w_i);
     static em::val get_optional_list();

--- a/test-suite/handwritten-src/cpp/test_helpers.cpp
+++ b/test-suite/handwritten-src/cpp/test_helpers.cpp
@@ -264,6 +264,18 @@ djinni::Future<std::string> TestHelpers::check_async_composition(const std::shar
 #endif
 }
 
+::djinni::Future<std::experimental::optional<int32_t>> TestHelpers::add_one_if_present(djinni::Future<std::experimental::optional<int32_t>> f) {
+#ifdef DJINNI_FUTURE_HAS_COROUTINE_SUPPORT
+    auto val = co_await f;
+    co_return val ? std::experimental::optional<int32_t>(*val + 1) : std::experimental::nullopt;
+#else
+    return f.then([](auto incoming) {
+        auto val = incoming.get();
+        return val ? std::experimental::optional<int32_t>(*val + 1) : std::experimental::nullopt;
+    });
+#endif
+}
+
 std::vector<std::experimental::optional<std::string>> TestHelpers::get_optional_list() {
     return {std::experimental::nullopt, std::string("hello")};
 }

--- a/test-suite/handwritten-src/java/com/dropbox/djinni/test/AsyncTest.java
+++ b/test-suite/handwritten-src/java/com/dropbox/djinni/test/AsyncTest.java
@@ -85,7 +85,7 @@ public class AsyncTest extends TestCase {
         Promise<Integer> input = new Promise();
         input.setValue(10);
         Future<Integer> output = TestHelpers.addOneIfPresent(input.getFuture());
-        assertEquals(output.get(), 11);
+        assertEquals(output.get().intValue(), 11);
     }
 
     public void testRx() throws Throwable {

--- a/test-suite/handwritten-src/java/com/dropbox/djinni/test/AsyncTest.java
+++ b/test-suite/handwritten-src/java/com/dropbox/djinni/test/AsyncTest.java
@@ -74,6 +74,20 @@ public class AsyncTest extends TestCase {
         assertEquals(s.get(), "42");
     }
 
+    public void testOptionalFutureUnsetValue() throws Throwable {
+        Promise<Integer> input = new Promise();
+        input.setValue(null);
+        Future<Integer> output = TestHelpers.addOneIfPresent(input.getFuture());
+        assertNull(output.get());
+    }
+
+    public void testOptionalFutureSetValue() throws Throwable {
+        Promise<Integer> input = new Promise();
+        input.setValue(10);
+        Future<Integer> output = TestHelpers.addOneIfPresent(input.getFuture());
+        assertEquals(output.get(), 11);
+    }
+
     public void testRx() throws Throwable {
         Future<Integer> f = TestHelpers.getAsyncResult();
         Single<Integer> s = Single.create(o -> f.then((i) -> {

--- a/test-suite/handwritten-src/objc/tests/DBAsyncTest.m
+++ b/test-suite/handwritten-src/objc/tests/DBAsyncTest.m
@@ -89,4 +89,22 @@
     [f1 get];
 }
 
+- (void) testOptionalFuture_unset {
+    DJPromise<NSNumber *> *p = [[DJPromise alloc] init];
+    [p setValue:nil];
+    DJFuture<NSNumber *>* f = [p getFuture];
+    DJFuture<NSNumber *>* f1 = [DBTestHelpers addOneIfPresent:f];
+    NSNumber * result = [f1 get];
+    XCTAssertNil(result);
+}
+
+- (void) testOptionalFuture_isSet {
+    DJPromise<NSNumber *> *p = [[DJPromise alloc] init];
+    [p setValue:@(10)];
+    DJFuture<NSNumber *>* f = [p getFuture];
+    DJFuture<NSNumber *>* f1 = [DBTestHelpers addOneIfPresent:f];
+    NSNumber * result = [f1 get];
+    XCTAssertEqual([result intValue], 11);
+}
+
 @end

--- a/test-suite/handwritten-src/ts/AsyncTest.ts
+++ b/test-suite/handwritten-src/ts/AsyncTest.ts
@@ -1,4 +1,4 @@
-import {TestCase, allTests, assertEq, assertTrue} from "./testutils"
+import { TestCase, allTests, assertEq, assertTrue, assertUndefined } from "./testutils"
 import * as test from "../../generated-src/ts/test";
 
 function sleep(ms: number): Promise<void> {
@@ -44,9 +44,17 @@ class AsyncTest extends TestCase {
         assertEq(r, 36);
     }
 
-  async testVoidRountTrip() {
-    await this.m.testsuite.TestHelpers.voidAsyncMethod(sleep(10));
-  }
+    async testVoidRoundTrip() {
+        await this.m.testsuite.TestHelpers.voidAsyncMethod(sleep(10));
+    }
+
+    async testOptionalFutureUnsetValue() {
+        assertUndefined(await this.m.testsuite.TestHelpers.addOneIfPresent(Promise.resolve(undefined)));
+    }
+
+    async testOptionalFutureSetValue() {
+        assertEq(await this.m.testsuite.TestHelpers.addOneIfPresent(Promise.resolve(10)), 11);
+    }
 
     async testFutureRoundtripWithException() {
         var s = null;


### PR DESCRIPTION
We currently have a bug where we don't support futures with optionals for Typescript codegen. In particular, 
`foo: future<optional<int>>` generates a Typescript signature of `Promise<number>`.

This may have been omitted at the beginning with external types in general. However it works fine to have optional types in ES6 containers like Array/Set/Map ([example](https://www.typescriptlang.org/play?#code/MYewdgzgLgBAtgTwMoFNYF4ZhQdxqqAHmgCcBLMAcxgB8YBXMAExQDMKUmA+ACgG0ARExCUBAGgbM2HJgF0AlAChQkWIgCCJEgEMEMTNjyadCYlHJVaklu2zceA1iBDjr0uxIEAjbSQHyAbmVwaHgEAFltAAcARn0sXBhIqLMLajpGGxkJUgp0t1tOXj5FGDKYQScXTx8-WTFS8r5M904a3wF6xQUglVDEZIAmeMMk6NS8qxbCphzzSYypGeLGssrnV2mZLvKKrY8C7YaexWDIEAAbFAA6C5EeRAJAs4hLm7vKB4RjXWe+t9u9wG0RifxCAI+XyGzyAA)).

In this PR we update the codegen to take into account the nullability in the TS generator, then add a new test across the languages. CC @LiFengSC 