### PR TITLE
[Wasm] Clean up promise rejection code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
         run: ./ci/generate.sh
 
       - name: Test
-        run: bazel test //test-suite:djinni-java-tests  //test-suite:djinni-objc-tests
+        run: bazel test --test_output=all //test-suite:djinni-java-tests  //test-suite:djinni-objc-tests
 
       - name: External Test
         working-directory: external-test

--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -174,6 +174,9 @@ protected:
     }
     template <typename E>
     void setException(const E& ex) {
+        // Let's try to prevent throwing non-exception types.
+        static_assert(std::is_convertible_v<E, std::exception>, "setException() called with type that is not convertible to std::exception");
+
         setException(std::make_exception_ptr(ex));
     }
     void setException(std::exception_ptr ex) {

--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -172,7 +172,6 @@ protected:
             sharedState->value = std::move(val);
         });
     }
-
     template <typename E>
     void setException(const E& ex) {
         setException(std::make_exception_ptr(ex));

--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -173,9 +173,8 @@ protected:
         });
     }
 
-    // Lock down to std::exception as a base class, as otherwise make_exception_ptr will happily take other
-    // pointers, and we don't want to encourage rejecting a promise with something other than an exception object.
-    void setException(const std::exception& ex) {
+    template <typename E>
+    void setException(const E& ex) {
         setException(std::make_exception_ptr(ex));
     }
     void setException(std::exception_ptr ex) {

--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -172,8 +172,10 @@ protected:
             sharedState->value = std::move(val);
         });
     }
-    template <typename E>
-    void setException(const E& ex) {
+
+    // Lock down to std::exception as a base class, as otherwise make_exception_ptr will happily take other
+    // pointers, and we don't want to encourage rejecting a promise with something other than an exception object.
+    void setException(const std::exception& ex) {
         setException(std::make_exception_ptr(ex));
     }
     void setException(std::exception_ptr ex) {

--- a/support-lib/wasm/djinni_wasm.cpp
+++ b/support-lib/wasm/djinni_wasm.cpp
@@ -151,12 +151,12 @@ EM_JS(void, djinni_init_wasm, (), {
 
         Module.makeNativePromiseResolver = function(func, pNativePromise) {
             return function(res) {
-                Module.resolveNativePromise(func, pNativePromise, res, null);
+                Module.resolveNativePromise(func, pNativePromise, res);
             };
         };
         Module.makeNativePromiseRejecter = function(func, pNativePromise) {
             return function(err) {
-                Module.resolveNativePromise(func, pNativePromise, null, err);
+                Module.rejectNativePromise(func, pNativePromise, err);
             };
         };
 
@@ -216,6 +216,7 @@ EMSCRIPTEN_BINDINGS(djinni_wasm) {
     em::function("allocateWasmBuffer", &allocateWasmBuffer);
     em::function("initCppResolveHandler", &CppResolveHandlerBase::initInstance);
     em::function("resolveNativePromise", &CppResolveHandlerBase::resolveNativePromise);
+    em::function("rejectNativePromise", &CppResolveHandlerBase::rejectNativePromise);
 }
 
 }

--- a/support-lib/wasm/djinni_wasm.hpp
+++ b/support-lib/wasm/djinni_wasm.hpp
@@ -402,34 +402,43 @@ public:
         handler->init(resolveFunc, rejectFunc);
     }
     
-    static void resolveNativePromise(int func, int context, em::val res, em::val err) {
-        typedef void (*ResolveNativePromiseFunc)(int context, em::val res, em::val err);
+    static void resolveNativePromise(int func, int context, em::val res) {
+        typedef void (*ResolveNativePromiseFunc)(int context, em::val res);
         auto resolveNativePromiseFunc = reinterpret_cast<ResolveNativePromiseFunc>(func);
-        resolveNativePromiseFunc(context, res, err);
+        resolveNativePromiseFunc(context, res);
+    }
+
+    static void rejectNativePromise(int func, int context, em::val err) {
+        typedef void (*RejectNativePromiseFunc)(int context, em::val err);
+        auto rejectNativePromiseFunc = reinterpret_cast<RejectNativePromiseFunc>(func);
+        rejectNativePromiseFunc(context, err);
     }
 };
 
 using JsProxyId = uint64_t;
 
-// The stack property is non-standard, but well supported in browsers
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack#browser_compatibility
-// It also seems to include the name and message properties, so no need to access them separately
-//
-// >>> function doThrow() { throw new Error("foo")}
-// >>> try { doThrow() } catch (e) { console.log(e.stack) }
-// Error: foo
-//     at doThrow (<anonymous>:1:25)
-//     at <anonymous>:1:7
-// >>> try { doThrow() } catch (e) { console.log(e.name) }
-// Error
-// >>> try { doThrow() } catch (e) { console.log(e.message) }
-// foo
 class JsException : public std::runtime_error {
 public:
+    // Input must be an instanceof an Error Type
     JsException(const em::val& e):
-        std::runtime_error(e["stack"].as<std::string>()),
+        std::runtime_error(resolveCppErrorString(e)),
         _jsEx(e)
     {}
+
+    static std::string resolveCppErrorString(const em::val& e) {
+        // The stack property is non-standard, but well supported in browsers
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack#browser_compatibility
+        // It also seems to include the name and message properties, so no need to access them separately
+        // However, DOMExceptions tend not to include the stack as they originate from C++ inside the browser engine, so
+        // check for presence, and fallback if necessary.
+        if (e["stack"].isString()) {
+            return e["stack"].as<std::string>();
+        }
+
+        // toString() will include the name and message, but not the stack. All wasm browsers support this.
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/toString
+        return e.call<std::string>("toString");
+    }
 
     const em::val& cause() const { return _jsEx; }
 private:

--- a/test-suite/djinni/test.djinni
+++ b/test-suite/djinni/test.djinni
@@ -55,6 +55,8 @@ test_helpers = interface +c {
     # If the input is empty, returns back an empty future.
     # If the input is non-empty, returns back the value plus one.
     static add_one_if_present(f: future<optional<i32>>): future<optional<i32>>;
+    # try-catches the future f, and accesses the error message, and returns as a string.
+    static return_exception_string(f: future<i32>): future<string>;
 
     static check_async_interface(i: async_interface): future<string>;
     static check_async_composition(i: async_interface): future<string>;

--- a/test-suite/generated-src/cpp/test_helpers.hpp
+++ b/test-suite/generated-src/cpp/test_helpers.hpp
@@ -104,6 +104,9 @@ public:
      */
     static ::djinni::Future<std::experimental::optional<int32_t>> add_one_if_present(::djinni::Future<std::experimental::optional<int32_t>> f);
 
+    /** try-catches the future f, and accesses the error message, and returns as a string. */
+    static ::djinni::Future<std::string> return_exception_string(::djinni::Future<int32_t> f);
+
     static ::djinni::Future<std::string> check_async_interface(const /*not-null*/ std::shared_ptr<AsyncInterface> & i);
 
     static ::djinni::Future<std::string> check_async_composition(const /*not-null*/ std::shared_ptr<AsyncInterface> & i);

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/TestHelpers.java
@@ -104,6 +104,10 @@ public abstract class TestHelpers {
     @Nonnull
     public static native com.snapchat.djinni.Future<Integer> addOneIfPresent(@Nonnull com.snapchat.djinni.Future<Integer> f);
 
+    /** try-catches the future f, and accesses the error message, and returns as a string. */
+    @Nonnull
+    public static native com.snapchat.djinni.Future<String> returnExceptionString(@Nonnull com.snapchat.djinni.Future<Integer> f);
+
     @Nonnull
     public static native com.snapchat.djinni.Future<String> checkAsyncInterface(@CheckForNull AsyncInterface i);
 

--- a/test-suite/generated-src/jni/NativeTestHelpers.cpp
+++ b/test-suite/generated-src/jni/NativeTestHelpers.cpp
@@ -262,6 +262,14 @@ CJNIEXPORT ::djinni::FutureAdaptor<::djinni::Optional<std::experimental::optiona
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT ::djinni::FutureAdaptor<::djinni::String>::JniType JNICALL Java_com_dropbox_djinni_test_TestHelpers_returnExceptionString(JNIEnv* jniEnv, jobject /*this*/, ::djinni::FutureAdaptor<::djinni::I32>::JniType j_f)
+{
+    try {
+        auto r = ::testsuite::TestHelpers::return_exception_string(::djinni::FutureAdaptor<::djinni::I32>::toCpp(jniEnv, j_f));
+        return ::djinni::release(::djinni::FutureAdaptor<::djinni::String>::fromCpp(jniEnv, std::move(r)));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 CJNIEXPORT ::djinni::FutureAdaptor<::djinni::String>::JniType JNICALL Java_com_dropbox_djinni_test_TestHelpers_checkAsyncInterface(JNIEnv* jniEnv, jobject /*this*/, jobject j_i)
 {
     try {

--- a/test-suite/generated-src/objc/DBTestHelpers+Private.mm
+++ b/test-suite/generated-src/objc/DBTestHelpers+Private.mm
@@ -245,6 +245,13 @@ static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for th
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }
 
++ (nonnull DJFuture<NSString *> *)returnExceptionString:(nonnull DJFuture<NSNumber *> *)f {
+    try {
+        auto objcpp_result_ = ::testsuite::TestHelpers::return_exception_string(::djinni::FutureAdaptor<::djinni::I32>::toCpp(f));
+        return ::djinni::FutureAdaptor<::djinni::String>::fromCpp(std::move(objcpp_result_));
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
 + (nonnull DJFuture<NSString *> *)checkAsyncInterface:(nullable id<DBAsyncInterface>)i {
     try {
         auto objcpp_result_ = ::testsuite::TestHelpers::check_async_interface(::djinni_generated::AsyncInterface::toCpp(i));

--- a/test-suite/generated-src/objc/DBTestHelpers.h
+++ b/test-suite/generated-src/objc/DBTestHelpers.h
@@ -93,6 +93,9 @@
  */
 + (nonnull DJFuture<NSNumber *> *)addOneIfPresent:(nonnull DJFuture<NSNumber *> *)f;
 
+/** try-catches the future f, and accesses the error message, and returns as a string. */
++ (nonnull DJFuture<NSString *> *)returnExceptionString:(nonnull DJFuture<NSNumber *> *)f;
+
 + (nonnull DJFuture<NSString *> *)checkAsyncInterface:(nullable id<DBAsyncInterface>)i;
 
 + (nonnull DJFuture<NSString *> *)checkAsyncComposition:(nullable id<DBAsyncInterface>)i;

--- a/test-suite/generated-src/ts/test.ts
+++ b/test-suite/generated-src/ts/test.ts
@@ -456,6 +456,8 @@ export interface TestHelpers_statics {
      * If the input is non-empty, returns back the value plus one.
      */
     addOneIfPresent(f: Promise<number | undefined>): Promise<number | undefined>;
+    /** try-catches the future f, and accesses the error message, and returns as a string. */
+    returnExceptionString(f: Promise<number>): Promise<string>;
     checkAsyncInterface(i: AsyncInterface): Promise<string>;
     checkAsyncComposition(i: AsyncInterface): Promise<string>;
     getOptionalList(): Array<string | undefined>;

--- a/test-suite/generated-src/wasm/NativeTestHelpers.cpp
+++ b/test-suite/generated-src/wasm/NativeTestHelpers.cpp
@@ -285,6 +285,15 @@ em::val NativeTestHelpers::add_one_if_present(const em::val& w_f) {
         return ::djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::Optional<std::experimental::optional, ::djinni::I32>>>::handleNativeException(e);
     }
 }
+em::val NativeTestHelpers::return_exception_string(const em::val& w_f) {
+    try {
+        auto r = ::testsuite::TestHelpers::return_exception_string(::djinni::FutureAdaptor<::djinni::I32>::toCpp(w_f));
+        return ::djinni::FutureAdaptor<::djinni::String>::fromCpp(std::move(r));
+    }
+    catch(const std::exception& e) {
+        return ::djinni::ExceptionHandlingTraits<::djinni::FutureAdaptor<::djinni::String>>::handleNativeException(e);
+    }
+}
 em::val NativeTestHelpers::check_async_interface(const em::val& w_i) {
     try {
         auto r = ::testsuite::TestHelpers::check_async_interface(::djinni_generated::NativeAsyncInterface::toCpp(w_i));
@@ -392,6 +401,7 @@ EMSCRIPTEN_BINDINGS(testsuite_test_helpers) {
         .class_function("asyncEarlyThrow", NativeTestHelpers::async_early_throw)
         .class_function("voidAsyncMethod", NativeTestHelpers::void_async_method)
         .class_function("addOneIfPresent", NativeTestHelpers::add_one_if_present)
+        .class_function("returnExceptionString", NativeTestHelpers::return_exception_string)
         .class_function("checkAsyncInterface", NativeTestHelpers::check_async_interface)
         .class_function("checkAsyncComposition", NativeTestHelpers::check_async_composition)
         .class_function("getOptionalList", NativeTestHelpers::get_optional_list)

--- a/test-suite/generated-src/wasm/NativeTestHelpers.hpp
+++ b/test-suite/generated-src/wasm/NativeTestHelpers.hpp
@@ -53,6 +53,7 @@ struct NativeTestHelpers : ::djinni::JsInterface<::testsuite::TestHelpers, Nativ
     static em::val async_early_throw();
     static em::val void_async_method(const em::val& w_f);
     static em::val add_one_if_present(const em::val& w_f);
+    static em::val return_exception_string(const em::val& w_f);
     static em::val check_async_interface(const em::val& w_i);
     static em::val check_async_composition(const em::val& w_i);
     static em::val get_optional_list();

--- a/test-suite/handwritten-src/cpp/test_helpers.cpp
+++ b/test-suite/handwritten-src/cpp/test_helpers.cpp
@@ -276,6 +276,26 @@ djinni::Future<std::string> TestHelpers::check_async_composition(const std::shar
 #endif
 }
 
+::djinni::Future<std::string> TestHelpers::return_exception_string(::djinni::Future<int32_t> f) {
+#ifdef DJINNI_FUTURE_HAS_COROUTINE_SUPPORT
+    try {
+        co_await f;
+        co_return std::string("failed");
+    } catch (const std::exception& e) {
+        co_return std::string(e.what());
+    }
+#else
+    return f.then([](auto incoming) {
+        try {
+            incoming.get();
+            return std::string("failed");
+        } catch (const std::exception& e) {
+            return std::string(e.what());
+        }
+    });
+#endif
+}
+
 std::vector<std::experimental::optional<std::string>> TestHelpers::get_optional_list() {
     return {std::experimental::nullopt, std::string("hello")};
 }

--- a/test-suite/handwritten-src/js/AsyncTest.js
+++ b/test-suite/handwritten-src/js/AsyncTest.js
@@ -38,6 +38,18 @@ class AsyncTest {
         assertEq(r, 36);
     }
 
+    async testVoidRoundTrip() {
+        await this.m.testsuite.TestHelpers.voidAsyncMethod(sleep(10));
+    }
+
+    async testOptionalFutureUnsetValue() {
+        assertUndefined(await this.m.testsuite.TestHelpers.addOneIfPresent(Promise.resolve(undefined)));
+    }
+
+    async testOptionalFutureSetValue() {
+        assertEq(await this.m.testsuite.TestHelpers.addOneIfPresent(Promise.resolve(10)), 11);
+    }
+
     async testFutureRoundtripWithException() {
         var s = null;
         try {
@@ -69,7 +81,22 @@ class AsyncTest {
         } catch (e) {
             s = e.message;
         }
-        assertEq(s, "error");
+        assertEq(s, "C++: error");
+    }
+
+    async testReturnExceptionString_valid() {
+        const result = await this.module.testsuite.TestHelpers.returnExceptionString(Promise.reject(new Error("hello")));
+        assertTrue(result.startsWith("Error: hello"));
+    }
+
+    async testReturnExceptionString_null() {
+        const result = await this.module.testsuite.TestHelpers.returnExceptionString(Promise.reject(null));
+        assertEq(result, "JS promise rejected with non-error type");
+    }
+
+    async testReturnExceptionString_undefined() {
+        const result = await this.module.testsuite.TestHelpers.returnExceptionString(Promise.reject(undefined));
+        assertEq(result, "JS promise rejected with non-error type");
     }
 }
 


### PR DESCRIPTION
We've seen some issues that manifest from rejecting a JS promise with a null value, or with a DOMException that does not have a stack property. In both cases we made some assumptions that aren't always true, so let's guard against them.

PTAL @LiFengSC 

