### PR TITLE
Fix JNI marshalling of zero-length protobuf objects from native->Java

### DIFF
--- a/test-suite/handwritten-src/java/com/dropbox/djinni/test/ProtoTest.java
+++ b/test-suite/handwritten-src/java/com/dropbox/djinni/test/ProtoTest.java
@@ -25,6 +25,11 @@ public class ProtoTest extends TestCase {
         assertEquals(proto.getPeopleList().get(1).getName(), "jerry");
     }
 
+    public void testZeroSizeNativeToJava() {
+        AddressBook proto = ProtoTests.stringsToProto(new ArrayList<String>());
+        assertEquals(proto.getSerializedSize(), 0);
+    }
+
     public void testEmbeddedProto() {
         Person p = Person.newBuilder().setName("tom").setId(1).build();
         RecordWithEmbeddedProto rec = new RecordWithEmbeddedProto(p);


### PR DESCRIPTION
Protobuf objects that contain only empty or default values take up zero bytes on the wire. In this case the JNI fromCpp() marshaller will try to map a DirectByteBuffer onto a zero-length nullptr C++ buffer, which is forbidden (https://docs.oracle.com/en/java/javase/20/docs/specs/jni/functions.html#newdirectbytebuffer).

On my Android installation with -Xcheck:jni enabled, it will abort with the error "JNI ERROR: non-nullable address is NULL". In other cases the behaviour is undefined.

Fix: check for zero-length C++ buffer and in that case use an empty Java array-backed ByteBuffer to pass to the Java deserializer.