### PR TITLE
Add bazel c_opt flag: -str=c90

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -15,5 +15,5 @@ done
 base_dir=$(cd "$(dirname "$loc")" && pwd)
 
 pushd "$base_dir"
-${BAZEL_EXECUTABLE:-bazel} build //src:djinni
+${BAZEL_EXECUTABLE:-bazel} build //src:djinni --host_conlyopt=-std=c90
 popd


### PR DESCRIPTION
I haven't tried Djinni for a while and decided to build a project that was working fine the last year.

However I got the following error:

```
ERROR: /Users/hello/Developer/bazel/third_party/zlib/BUILD:39:19: Compiling third_party/zlib/gzlib.c [for tool] failed: (Exit 1): wrapped_clang failed: error executing command (from target //third_party/zlib:zlib_checked_in) external/local_config_cc/wrapped_clang ‘-D_FORTIFY_SOURCE=1’ -fstack-protector -fcolor-diagnostics -Wall -Wthread-safety -Wself-assign -fno-omit-frame-pointer -g0 -O2 -DNDEBUG ‘-DNS_BLOCK_ASSERTIONS=1’ ... (remaining 34 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
third_party/zlib/gzlib.c:254:9: error: call to undeclared function ‘lseek’; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        LSEEK(state->fd, 0, SEEK_END);  /* so gzoffset() is correct */
        ^
third_party/zlib/gzlib.c:14:17: note: expanded from macro ‘LSEEK’
#  define LSEEK lseek
                ^
third_party/zlib/gzlib.c:254:9: note: did you mean ‘fseek’?
third_party/zlib/gzlib.c:14:17: note: expanded from macro ‘LSEEK’
#  define LSEEK lseek
                ^
/Applications/Xcode-14.3.0-RC2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/usr/include/stdio.h:162:6: note: ‘fseek’ declared here
int      fseek(FILE *, long, int);
         ^
third_party/zlib/gzlib.c:260:24: error: call to undeclared function ‘lseek’; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        state->start = LSEEK(state->fd, 0, SEEK_CUR);
                       ^
third_party/zlib/gzlib.c:14:17: note: expanded from macro ‘LSEEK’
#  define LSEEK lseek
                ^
third_party/zlib/gzlib.c:361:9: error: call to undeclared function ‘lseek’; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    if (LSEEK(state->fd, state->start, SEEK_SET) == -1)
        ^
third_party/zlib/gzlib.c:14:17: note: expanded from macro ‘LSEEK’
#  define LSEEK lseek
                ^
third_party/zlib/gzlib.c:402:15: error: call to undeclared function ‘lseek’; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        ret = LSEEK(state->fd, offset - (z_off64_t)state->x.have, SEEK_CUR);
              ^
third_party/zlib/gzlib.c:14:17: note: expanded from macro ‘LSEEK’
#  define LSEEK lseek
                ^
third_party/zlib/gzlib.c:498:14: error: call to undeclared function ‘lseek’; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    offset = LSEEK(state->fd, 0, SEEK_CUR);
             ^
third_party/zlib/gzlib.c:14:17: note: expanded from macro ‘LSEEK’
#  define LSEEK lseek
                ^
5 errors generated.
```

I'm using macOS Ventura 13.2.1 (22D68) && Xcode 14.3 (14E222b).

This seems to be a bazel issue which is discussed here:
https://github.com/bazelbuild/bazel/issues/17956#issuecomment-1506813427

I've added recommended flag `--host_conlyopt=-std=c90` to `src/build.sh` script and Djinni is working good now.