### PR TITLE
Fix TS compilation error on tsc 4.5.4

### DIFF
--- a/test-suite/djinni/vendor/third-party/proto/ts/test.ts
+++ b/test-suite/djinni/vendor/third-party/proto/ts/test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import { util, configure, Writer, Reader } from "protobufjs/minimal";
-import * as Long from "long";
+import Long from "long";
 
 export const protobufPackage = "djinni.test";
 

--- a/test-suite/djinni/vendor/third-party/proto/ts/test2.ts
+++ b/test-suite/djinni/vendor/third-party/proto/ts/test2.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import { util, configure, Writer, Reader } from "protobufjs/minimal";
-import * as Long from "long";
+import Long from "long";
 
 export const protobufPackage = "djinni.test2";
 

--- a/test-suite/handwritten-src/ts/tsconfig.json
+++ b/test-suite/handwritten-src/ts/tsconfig.json
@@ -5,6 +5,7 @@
         "paths": {
             "@djinni_support/*": ["../../../support-lib/ts/*"]
         },
+	"esModuleInterop": true,
         "strict": true,
     },
     "include": ["./*.ts"],


### PR DESCRIPTION
Fixes  for error when running `bazel run //test-suite:server-ts` -

```
../../djinni/vendor/third-party/proto/ts/test.ts:3:23 - error TS2497: This module can only be referenced with ECMAScript imports/exports by turning on the 'esModuleInterop' flag and referencing its default export.

3 import * as Long from "long";
                        ~~~~~~

../../djinni/vendor/third-party/proto/ts/test2.ts:3:23 - error TS2497: This module can only be referenced with ECMAScript imports/exports by turning on the 'esModuleInterop' flag and referencing its default export.

3 import * as Long from "long";
```
