### PR TITLE
Allow code generation without android SDK/NDK

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,9 +9,10 @@ djinni_setup_deps()
 
 # --- Everything below is only used for examples and tests
 
-# android_sdk_repository fails to find build_tools if we don't explicitly set a version.
-android_sdk_repository(name = "androidsdk")
-android_ndk_repository(name = "androidndk", api_level = 21)
+load("//bzl:android_configure.bzl", "android_configure")
+android_configure(name = "local_config_android")
+load("@local_config_android//:android_configure.bzl", "android_workspace")
+android_workspace()
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/bzl/android_configure.bzl
+++ b/bzl/android_configure.bzl
@@ -1,0 +1,58 @@
+"""Repository rule for Android SDK and NDK autoconfiguration.
+
+This rule is a no-op unless the required android environment variables are set.
+"""
+
+# Based on: https://github.com/envoyproxy/envoy-mobile/pull/2039/
+# And: https://github.com/tensorflow/tensorflow/tree/34c03ed67692eb76cb3399cebca50ea8bcde064c/third_party/android
+# Workaround for https://github.com/bazelbuild/bazel/issues/14260
+
+_ANDROID_NDK_HOME = "ANDROID_NDK_HOME"
+_ANDROID_SDK_HOME = "ANDROID_HOME"
+
+def _android_autoconf_impl(repository_ctx):
+    sdk_home = repository_ctx.os.environ.get(_ANDROID_SDK_HOME)
+    ndk_home = repository_ctx.os.environ.get(_ANDROID_NDK_HOME)
+
+    if sdk_home == "" or ndk_home == "":
+        print("ANDROID_HOME or ANDROID_NDK_HOME not set. Building android examples will fail.")
+
+    sdk_rule = ""
+    if sdk_home:
+        sdk_rule = """
+    native.android_sdk_repository(
+        name="androidsdk",
+        path="{}",
+        api_level=30,
+        build_tools_version="30.0.2",
+    )
+""".format(sdk_home)
+
+    ndk_rule = ""
+    if ndk_home:
+        ndk_rule = """
+    native.android_ndk_repository(
+        name="androidndk",
+        path="{}",
+        api_level=21,
+    )
+""".format(ndk_home)
+
+    if ndk_rule == "" and sdk_rule == "":
+        sdk_rule = "pass"
+
+    repository_ctx.file("BUILD.bazel", "")
+    repository_ctx.file("android_configure.bzl", """
+    
+def android_workspace():
+    {}
+    {}
+    """.format(sdk_rule, ndk_rule))
+
+android_configure = repository_rule(
+    implementation = _android_autoconf_impl,
+    environ = [
+        _ANDROID_NDK_HOME,
+        _ANDROID_SDK_HOME,
+    ],
+)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,7 @@
 ## Building the Android example app
 
+First make sure that the ANDROID_HOME and ANDROID_NDK_HOME environment variables are set and pointing to working installations of the Android SDK and NDK, respectively.
+
 Build with bazel: `bazel build //examples:android-app`.
 
 Build and deploy to device: `bazel mobile-install //examples:android-app`.


### PR DESCRIPTION
We have the same issue mentioned in https://github.com/Snapchat/djinni/issues/107 (specifically: https://github.com/Snapchat/djinni/issues/107#issuecomment-1502909975).

In short, some of our developers working with the generator are not android developers, and would rather not have to set-up the android SDK/NDK to use djinni, considering those are only needed to build the android examples.

I know nothing about Bazel, but still I decided to try and find a solution to this. I started investigating a way to conditionally trigger the android repo rules for the examples only, when I found this discussion:
https://github.com/bazelbuild/rules_android_ndk/issues/92

From there, I understand that the rule _should_ only be applied in case one tries to build a target that requires the android SDK, but apparently that is not the case yet. In the same discussion, I found a suggestion for a workaround, which amounts to only defining the `android_sdk_repository` and `android_sdk_repository` rules if the environment variables for the paths to the SDK/NDK are set:
https://github.com/envoyproxy/envoy-mobile/pull/2039

I implemented the same, with a trivial tweak, which is printing a warning in case the environment variables are not set, to counterbalance the fact that the build failure message for the `android-app` and `android_sdk_repository` is now less explicit.

It seems to work fine, hopefully it's not too hacky and can be useful upstream.