### PR TITLE
Adding cli option to remove interfaces constraints on records.

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,9 +302,9 @@ Notable differences when comparing to the Java/ObjC support:
   easily add extension methods (by add functions to prototype) without having to
   derive from a base class.
 
-The command to run Wasm/TypeScript unit tests is `bazel run
-//test-suite:server-ts`. You will need the `tsc` compiler and the `browserify`
-tool to run these tests.
+Use `bazel run //test-suite:server-ts` to run the Wasm/TypeScript unit tests.
+You will need `npm` and run `npm install` in the `test-suite` folder.
+You need as well the `tsc` compiler and the `browserify` tool to run these tests.
 
 ## Async interface support
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ verify the build and binary from the command line.
  - Local flags with `@flag` directive
  - DataView for copy free data passing
  - DateRef for copy free data passing with ownership
+ - Allows for not null interfaces references in records
  - Generating string names for C++ enums
  - Bug fixes
 

--- a/src/source/Main.scala
+++ b/src/source/Main.scala
@@ -101,6 +101,7 @@ object Main {
     var inFileListPath: Option[File] = None
     var outFileListPath: Option[File] = None
     var skipGeneration: Boolean = false
+    var allowInterfacesInRecords: Boolean = false
     var yamlOutFolder: Option[File] = None
     var yamlOutFile: Option[String] = None
     var yamlPrefix: String = ""
@@ -265,6 +266,8 @@ object Main {
         .text("Optional file in which to write the list of output files produced.")
       opt[Boolean]("skip-generation").valueName("<true/false>").foreach(x => skipGeneration = x)
         .text("Way of specifying if file generation should be skipped (default: false)")
+      opt[Boolean]("allow-interfaces-in-records").valueName("<true/false>").foreach(x => allowInterfacesInRecords = x)
+        .text("Allows for records to contain interfaces.")
 
       note("\nIdentifier styles (ex: \"FooBar\", \"fooBar\", \"foo_bar\", \"FOO_BAR\", \"m_fooBar\")\nUse an exclamation mark to apply stricty, even on ALL_CAPS identifiers (ex: \"FooBar!\")\n")
       identStyle("ident-java-enum",      c => { javaIdentStyle = javaIdentStyle.copy(enum = c) })
@@ -341,7 +344,7 @@ object Main {
 
     // Resolve names in IDL file, check types.
     System.out.println("Resolving...")
-    resolver.resolve(meta.defaults, idl) match {
+    resolver.resolve(meta.defaults, idl, allowInterfacesInRecords) match {
       case Some(err) =>
         System.err.println(err)
         System.exit(1); return
@@ -435,6 +438,7 @@ object Main {
       jsIdentStyle,
       tsOutFolder,
       tsModule,
+      allowInterfacesInRecords,
       outFileListWriter,
       skipGeneration,
       yamlOutFolder,

--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -100,6 +100,7 @@ package object generatorTools {
                    jsIdentStyle: JsIdentStyle,
                    tsOutFolder: Option[File],
                    tsModule: String,
+                   allowInterfacesInRecords: Boolean,
                    outFileListWriter: Option[Writer],
                    skipGeneration: Boolean,
                    yamlOutFolder: Option[File],


### PR DESCRIPTION
### Context
The motivation for this change is that often you want to pass a set of interfaces in a record instead of different parameters in a function.
This helps for the code to be more scalable/maintainable as we can separate the creation of the parameters from the calling and handling of them.

Example:
```cpp
class Instance /* ... */

struct Callbacks {
   std::nn_shared_pointer<TasteDescriptor> tasteDescriptor;
   std::nn_shared_pointer<CostDescriptor> costsDescriptor;
   std::nn_shared_pointer<LocalizationDescriptor> localizationDescriptor;      
   std::shared_pointer<LogDescriptor> logDescriptor;      /* optional */
};

class SDK {
    std::shared_ptr<Instance> createInstance( const Callbacks& callbacks );
};
```

Then the caller can do:
```cpp
auto instance = SDK::createInstance( createAndConfigureCallbacks() );
```

Please notice that you were able to pass optional interfaces using the `optional<>` wrapper (which was properly interpreted and generated), and some users made used of a `notnull<>` extension to pass not null interfaces as a workaround. However, the extension workaround has a few weakness that are better to avoided (more boilerplate code, less readable code, some tricky implementation of this notnull extension).

### Changes
This PR adds an option to remove the constraint, though, we should consider to directly always enable it as I see no reason to disallow them. My rationale is the following (please check for any wrong assumptions):

Records only go from one language to another during function calls, function calls can have parameters or return values that are interfaces. There is no environments where records are transmitted in a situation where interfaces are not supported.

Remote invocations are not a problem, for the same reasons explained above.

I imagine that if we use records for serialization to permanent storage, then interfaces wouldn't fly, but I believe the correct behavior would be to only restrict interfaces for this specific case, and not for the other cases.
On the same line, I guess DataRefs disallowed serialization to permanent storage already, so this case should not be concerning.

Admins, please let me know if you prefer the change as it is or if you prefer to always relax it.

### Testing
I have tested the changes by extending the examples to use records holding interfaces instead of passing them directly. You can compare the diff to this branch [here](https://github.com/jpogachasnap/djinni/compare/jf/removing_interface_constrains...jpogachasnap:djinni:jf/removing_interface_constrains_test).

Both Android and iOS examples built and executed correctly.
