### PR TITLE
Adding the option for customs constexpr string constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ verify the build and binary from the command line.
  - DataView for copy free data passing
  - DateRef for copy free data passing with ownership
  - Generating string names for C++ enums
+ - Support for custom constexpr strings such as "string_view" and "const char*"
  - Bug fixes
 
 ## Using new features

--- a/src/source/CppMarshal.scala
+++ b/src/source/CppMarshal.scala
@@ -67,12 +67,15 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
   override def toCpp(tm: MExpr, expr: String): String = throw new AssertionError("cpp to cpp conversion")
   override def fromCpp(tm: MExpr, expr: String): String = throw new AssertionError("cpp to cpp conversion")
 
-  def hppReferences(m: Meta, exclude: String, forwardDeclareOnly: Boolean): Seq[SymbolReference] = m match {
+  def hppReferences(m: Meta, exclude: String, forwardDeclareOnly: Boolean, constant: Boolean): Seq[SymbolReference] = m match {
     case p: MPrimitive => p.idlName match {
       case "i8" | "i16" | "i32" | "i64" => List(ImportRef("<cstdint>"))
       case _ => List()
     }
-    case MString => List(ImportRef("<string>"))
+    case MString => 
+      if( constant &&  spec.cppStringConstexpr.isDefined ) {
+        if( spec.cppStringConstexprHeader.isDefined ) List(ImportRef(spec.cppStringConstexprHeader.get)) else List()
+      } else List(ImportRef("<string>"))
     case MDate => List(ImportRef("<chrono>"))
     case MBinary => List(ImportRef("<vector>"), ImportRef("<cstdint>"))
     case MOptional => List(ImportRef(spec.cppOptionalHeader))

--- a/src/source/Main.scala
+++ b/src/source/Main.scala
@@ -29,6 +29,8 @@ object Main {
     var idlIncludePaths: List[String] = List("")
     var cppOutFolder: Option[File] = None
     var cppNamespace: String = ""
+    var cppStringConstexpr: Option[String] = None
+    var cppStringConstexprHeader: Option[String] = None
     var cppIncludePrefix: String = ""
     var cppExtendedRecordIncludePrefix: String = ""
     var cppFileIdentStyle: IdentConverter = IdentStyle.underLower
@@ -154,6 +156,10 @@ object Main {
         .text("The C++ base library's include path, relative to the C++ classes.")
       opt[String]("cpp-namespace").valueName("...").foreach(x => cppNamespace = x)
         .text("The namespace name to use for generated C++ classes.")
+      opt[String]("cpp-string-constexpr").valueName("<class>").foreach(x => cppStringConstexpr = Some(x))
+        .text("The type for string constants for generated C++ classes.")
+      opt[String]("cpp-string-constexpr-header").valueName("<header>>").foreach(x => cppStringConstexprHeader = Some(x))
+        .text("The header file to be included for string constants for generated C++ classes.")
       opt[String]("cpp-ext").valueName("<ext>").foreach(cppExt = _)
         .text("The filename extension for C++ files (default: \"cpp\").")
       opt[String]("hpp-ext").valueName("<ext>").foreach(cppHeaderExt = _)
@@ -382,6 +388,8 @@ object Main {
       cppIncludePrefix,
       cppExtendedRecordIncludePrefix,
       cppNamespace,
+      cppStringConstexpr,
+      cppStringConstexprHeader,
       cppIdentStyle,
       cppFileIdentStyle,
       cppBaseLibIncludePrefix,

--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -47,6 +47,8 @@ package object generatorTools {
                    cppIncludePrefix: String,
                    cppExtendedRecordIncludePrefix: String,
                    cppNamespace: String,
+                   cppStringConstexpr: Option[String],
+                   cppStringConstexprHeader: Option[String],
                    cppIdentStyle: CppIdentStyle,
                    cppFileIdentStyle: IdentConverter,
                    cppBaseLibIncludePrefix: String,


### PR DESCRIPTION
### Context
The motivation for this change is that string constants are defined in C++ as static const std::strings, which during the program startup they do allocations on the heap and copy data.

### Changes
This PR adds a couple cli options which will allow the user to specify a constexpr string constant type, for example, `std::string_view` and `const char*`.
As well it allows to optional include a header file (for example `<string_view>`). In the case of using `const char*` the optional header can be undefined and no header file will be included.

### Testing
-[x] I added a string constant to the example IDL, and observed how the `static const std::string` was defined in the generated header, the `<string>` header file included and in the generated source the definition of the constant was added.
-[x] Then I added the options lines to the build script (examples/run_djinni):
```sh
    --cpp-string-constexpr "std::string_view" \
    --cpp-string-constexpr-header "<string_view>" \
```
-[x] Build again, observed how the string constant is only defined in the header with the proper include file.
-[x] Changed it for `const char*` and removed the header option from the build script, observed how the string constant was defined with the primitive type and no include files were added.
-[x] Built and launch both iOs and Android projects with all these configurations and observed proper functionality.