### PR TITLE
Fix exception propagation to JS for async void functions 

### DIFF
--- a/support-lib/wasm/Future_wasm.hpp
+++ b/support-lib/wasm/Future_wasm.hpp
@@ -96,6 +96,7 @@ public:
         void doResolve() {
             try {
                 if constexpr (std::is_void_v<typename RESULT::CppType>) {
+                    _future->get();
                     _resolveFunc(em::val::undefined());
                 } else {
                     _resolveFunc(RESULT::Boxed::fromCpp(_future->get()));


### PR DESCRIPTION
Hey,

We encountered an issue where exceptions were not properly propagated for functions returning `future<void>`. It's because future was never resolved in the `doResolve` for void types and exception was never raised there so it could be caught and translated using `djinni_native_exception_to_js`