### PR TITLE
no hardcoded android sdk version

### DIFF
--- a/bzl/android_configure.bzl
+++ b/bzl/android_configure.bzl
@@ -23,8 +23,6 @@ def _android_autoconf_impl(repository_ctx):
     native.android_sdk_repository(
         name="androidsdk",
         path="{}",
-        api_level=30,
-        build_tools_version="30.0.2",
     )
 """.format(sdk_home)
 


### PR DESCRIPTION
tested `bazel build //examples:android-app` still works after the change

Background: Android sdk is only used for building the Android example app.  `bzl/android_configure.bzl` configures the Android sdk when the environment variable ANDROID_HOME is set.  But it also hardcoded a specific version which is not really necessary.