### PR TITLE
Workaround for known GCC bug regarding explicit specialization in non namespace scope

### DIFF
--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -383,15 +383,17 @@ public:
             this->_promise.setValue(std::forward<V>(value));
         }
     };
-    template <>
-    struct PromiseType<void>: PromiseTypeBase {
-        void return_void() {
-            this->_promise.setValue();
-        }
-    };
     using promise_type = PromiseType<T>;
 #endif
 };
+
+#if defined(DJINNI_FUTURE_HAS_COROUTINE_SUPPORT)
+template<> template<> struct Future<void>::PromiseType<void>:PromiseTypeBase {
+    void return_void() {
+        this->_promise.setValue();
+    }
+};
+#endif
 
 template <typename T>
 Future<T> detail::PromiseBase<T>::getFuture() {


### PR DESCRIPTION
Hey,

This is a workaround for a [known bug in GCC](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85282). 

[Similar issue on StackOverflow](https://stackoverflow.com/questions/49707184/explicit-specialization-in-non-namespace-scope-does-not-compile-in-gcc)