### PR TITLE
Use std::expected for outcome when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ outcome<RESULT, ERROR>
 Where RESULT and ERROR can be any Djinni types (primitives or records).
 
 
-In C++, the `outcome<>` type maps to the template class `djinni::expected<>`.
+In C++, the `outcome<>` type maps to the template `djinni::expected<>`,
+which is an alias of `std::expected<>` if supported or a drop-in replacement otherwise.
 In Java, it maps to the generic class `com.snapchat.djinni.Outcome<>`. In ObjC,
 it maps to the generic class `DJOutcome<>`.
 

--- a/support-lib/cpp/expected.hpp
+++ b/support-lib/cpp/expected.hpp
@@ -1,5 +1,20 @@
 #pragma once
 
+#include <version>
+
+#ifdef __cpp_lib_expected
+
+#include <expected>
+
+namespace djinni {
+
+using ::std::expected;
+using ::std::unexpected;
+
+}
+
+#else
+
 #include "tl_expected.hpp"
 
 namespace djinni {
@@ -7,9 +22,6 @@ namespace djinni {
 using ::tl::unexpected;
 using ::tl::expected;
 
-template <class E>
-unexpected<typename std::decay<E>::type> make_unexpected(E &&e) {
-    return tl::unexpected<typename std::decay<E>::type>(std::forward<E>(e));
 }
 
-}
+#endif

--- a/support-lib/jni/Outcome_jni.hpp
+++ b/support-lib/jni/Outcome_jni.hpp
@@ -55,7 +55,7 @@ public:
             auto e = LocalRef<jobject>(jniEnv, jniEnv->CallObjectMethod(j, outcomeJniInfo.method_error_or_null));
             jniExceptionCheck(jniEnv);
             // if result is not present then error must be present, we can skip the present check
-            return make_unexpected(ERROR::Boxed::toCpp(jniEnv, reinterpret_cast<typename ERROR::Boxed::JniType>(e.get())));
+            return unexpected {ERROR::Boxed::toCpp(jniEnv, reinterpret_cast<typename ERROR::Boxed::JniType>(e.get()))};
         }
     }
 

--- a/support-lib/objc/Outcome_objc.hpp
+++ b/support-lib/objc/Outcome_objc.hpp
@@ -41,7 +41,7 @@ public:
             return RESULT::Boxed::toCpp(r);
         } else {
             ErrorObjcType e = [o error];
-            return make_unexpected(ERROR::Boxed::toCpp(e));
+            return unexpected {ERROR::Boxed::toCpp(e)};
         }
     }
 

--- a/support-lib/wasm/Outcome_wasm.hpp
+++ b/support-lib/wasm/Outcome_wasm.hpp
@@ -39,7 +39,7 @@ struct Outcome
         } else {
             em::val err = j["error"];
             assert(!err.isUndefined());
-            return make_unexpected(Error::Boxed::toCpp(err));
+            return unexpected {Error::Boxed::toCpp(err)};
         }
     }
     static JsType fromCpp(const CppType& c) {

--- a/test-suite/handwritten-src/cpp/outcome_test_helpers.cpp
+++ b/test-suite/handwritten-src/cpp/outcome_test_helpers.cpp
@@ -9,7 +9,7 @@ djinni::expected<std::string, int> TestOutcome::getSuccessOutcome() {
 }
 
 djinni::expected<std::string, int> TestOutcome::getErrorOutcome() {
-    return djinni::make_unexpected(42);
+    return djinni::unexpected(42);
 }
 
 std::string TestOutcome::putSuccessOutcome(const djinni::expected<std::string, int>& x) {
@@ -26,7 +26,7 @@ NestedOutcome TestOutcome::getNestedSuccessOutcome() {
 
 NestedOutcome TestOutcome::getNestedErrorOutcome() {
     return {
-        djinni::make_unexpected(std::string("hello"))
+        djinni::unexpected(std::string("hello"))
     };
 }
 


### PR DESCRIPTION
## Motivation

Using `std` types when possible increases compatibility with other codebases.

## Considerations

- I've removed `make_unexpected` because it is unnecessary in my environment. Are there issues on other compilers with type deduction for `unexpected`?
- I tested the code with real devices on iOS
- I was unable to test the code with a compiler that does not support `std::expected` (ie does not define the feature flag). I can offer a [godbolt](https://godbolt.org/z/zncxPqEvP) link to show the basic feature check works (just switch to -std=c++20 to see that supported changes to false). I can probably create a setup to test this properly, but if someone else already has such a setup I would greatly appreciate some support.
- I did not test the JNI, wasm and ts adapters.
- This changes behavior of existing code in environments where `std::expected` is available. I'd argue it does so in unproblematic ways:
    - The codebase used `djinni::expected` everywhere - the change should be unnoticable.
    - The codebase used `std::expected` in some places and `djinni::expected` in others. This change would make any conversion code between the two types obsolete, but should not break anything, since `djinni::expected` now just maps to `std::expected`.
    - The codebase used `tl::expected` in some places and `djinni::expected` in others. This is the only problematic case, though the solution is simple: use `std::expected` or `djinni::expected`.