### PR TITLE
Size optimizations for Composer

### DIFF
--- a/src/source/ComposerGenerator.scala
+++ b/src/source/ComposerGenerator.scala
@@ -344,8 +344,8 @@ class ComposerGenerator(spec: Spec) extends Generator(spec) {
         for (t <- refs.interfaces.filter(t => t != withNs(Some(helperNamespace), helperClass(ident)))) {
           w.wl(s"${t}::registerSchema(resolve);")
         }
-        w.wl("static std::once_flag flag[2];")
-        w.wl("std::call_once(flag[resolve ? 1 : 0], [resolve] { djinni::composer::registerSchemaImpl(unresolvedSchema(), resolve); });")
+        w.wl("static bool flag[2] = {false, false};")
+        w.wl("if (std::exchange(flag[resolve ? 1 : 0], true) == false) { djinni::composer::registerSchemaImpl(unresolvedSchema(), resolve); }")
       }
       // type reference
       w.w(s"const ValueSchema& $helper::schemaRef()").braced {

--- a/src/source/YamlGenerator.scala
+++ b/src/source/YamlGenerator.scala
@@ -72,9 +72,15 @@ class YamlGenerator(spec: Spec) extends Generator(spec) {
     w.wl("objcpp:").nested { write(w, objcpp(td)) }
     w.wl("java:").nested { write(w, java(td)) }
     w.wl("jni:").nested { write(w, jni(td)) }
-    w.wl("wasm:").nested { write(w, wasm(td)) }
-    w.wl("composer:").nested { write(w, composer(td)) }
-    w.wl("ts:").nested {write(w, ts(td)) }
+    if (spec.wasmOutFolder.isDefined) {
+      w.wl("wasm:").nested { write(w, wasm(td)) }
+    }
+    if (spec.composerOutFolder.isDefined) {
+      w.wl("composer:").nested { write(w, composer(td)) }
+    }
+    if (spec.wasmOutFolder.isDefined || spec.composerOutFolder.isDefined) {
+      w.wl("ts:").nested {write(w, ts(td)) }
+    }
   }
 
   private def write(w: IndentWriter, m: Map[String, Any]) {
@@ -307,7 +313,7 @@ object YamlGenerator {
       nested(td, key)(subKey).toString
     } catch {
       case e: java.util.NoSuchElementException => {
-        println(s"Warning: in ${td.origin}, missing field $key/$subKey")
+        // println(s"Warning: in ${td.origin}, missing field $key/$subKey")
         "[unspecified]"
       }
     }

--- a/support-lib/composer/Future_composer.hpp
+++ b/support-lib/composer/Future_composer.hpp
@@ -78,14 +78,14 @@ public:
 
 template<typename U>
 struct ExceptionHandlingTraits<FutureAdaptor<U>> {
-    static Composer::Value handleNativeException(const std::exception& e, const Composer::ValueFunctionCallContext& callContext) {
+    static Composer::Value handleNativeException(const std::exception& e, const Composer::ValueFunctionCallContext& callContext) noexcept {
         // store C++ exception in JS Error and raise in JS runtime
         auto msg = STRING_FORMAT("C++: {}", e.what());
         auto composerPromise = Composer::makeShared<Composer::ResolvablePromise>();
         composerPromise->fulfill(Composer::Result<Composer::Value>(Composer::Error(std::move(msg))));
         return Composer::Value(composerPromise);
     }
-    static Composer::Value handleNativeException(const JsException& e, const Composer::ValueFunctionCallContext& callContext) {
+    static Composer::Value handleNativeException(const JsException& e, const Composer::ValueFunctionCallContext& callContext) noexcept {
         // JS error passthrough
         auto composerPromise = Composer::makeShared<Composer::ResolvablePromise>();
         composerPromise->fulfill(Composer::Result<Composer::Value>(e.cause()));

--- a/support-lib/composer/djinni_composer.cpp
+++ b/support-lib/composer/djinni_composer.cpp
@@ -33,7 +33,7 @@ void checkForNull(void* ptr, const char* context) {
     }
 }
 
-ValueSchema resolveSchema(const ValueSchema& unresolved, std::function<void()> registerSchemaFunc) {
+ValueSchema resolveSchema(const ValueSchema& unresolved, std::function<void()> registerSchemaFunc) noexcept {
     registerSchemaFunc();
     Composer::ValueSchemaTypeResolver resolver(Composer::ValueSchemaRegistry::sharedInstance().get());
     auto result = resolver.resolveTypeReferences(unresolved);
@@ -41,7 +41,7 @@ ValueSchema resolveSchema(const ValueSchema& unresolved, std::function<void()> r
     return result.moveValue();
 }
 
-void registerSchemaImpl(const ValueSchema& schema, bool resolve) {
+void registerSchemaImpl(const ValueSchema& schema, bool resolve) noexcept {
     auto registry = ValueSchemaRegistry::sharedInstance();
     if (!resolve) {
         registry->registerSchema(schema);
@@ -54,35 +54,35 @@ void registerSchemaImpl(const ValueSchema& schema, bool resolve) {
     }
 }
 
-Binary::CppType Binary::toCpp(const Binary::ComposerType& v) {
+Binary::CppType Binary::toCpp(const Binary::ComposerType& v) noexcept {
     auto a = v.getTypedArrayRef();
     auto buffer = a->getBuffer();
     return CppType(buffer.begin(), buffer.end());
 }
 
-Binary::ComposerType Binary::fromCpp(const Binary::CppType& c) {
+Binary::ComposerType Binary::fromCpp(const Binary::CppType& c) noexcept {
     auto bytes = makeShared<Bytes>();
     bytes->assignData(c.data(), c.size());
     auto va = makeShared<ValueTypedArray>(TypedArrayType::Uint8Array, bytes);
     return Value(va);
 }
 
-const ValueSchema& Binary::schema() {
+const ValueSchema& Binary::schema() noexcept {
     static auto schema = ValueSchema::valueTypedArray();
     return schema;
 }
 
-Date::CppType Date::toCpp(const Date::ComposerType& v) {
+Date::CppType Date::toCpp(const Date::ComposerType& v) noexcept {
     auto millisecondsSinceEpoch = std::chrono::milliseconds(static_cast<int64_t>(v.toDouble()));
     return CppType(std::chrono::duration_cast<std::chrono::system_clock::duration>(millisecondsSinceEpoch));
 }
 
-Date::ComposerType Date::fromCpp(const Date::CppType& c) {
+Date::ComposerType Date::fromCpp(const Date::CppType& c) noexcept {
     auto millisecondsSinceEpoch = std::chrono::duration_cast<std::chrono::milliseconds>(c.time_since_epoch());
     return Composer::Value(static_cast<double>(millisecondsSinceEpoch.count()));
 }
 
-const ValueSchema& Date::schema() {
+const ValueSchema& Date::schema() noexcept {
     static auto schema = ValueSchema::date();
     return schema;
 }


### PR DESCRIPTION
* Replace std::call_once with simple bool flag (as this is not supposed to be called concurrently)
* Add noexcept where applicable in support lib and generated code