### PR TITLE
Fix compiler warnings in Future implementation

### DIFF
--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -23,6 +23,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <cassert>
+#include <exception>
 
 #ifdef __cpp_coroutines
 #if __has_include(<coroutine>)
@@ -414,7 +415,7 @@ Future<void> combine(U&& futures, size_t c) {
         return future;
     }
     for (auto& f: futures) {
-        f.then([context] (auto f) {
+        f.then([context] (auto) {
             if (--(context->counter) == 0) {
                 context->promise.setValue();
             }

--- a/support-lib/objc/Future_objc.hpp
+++ b/support-lib/objc/Future_objc.hpp
@@ -82,7 +82,7 @@ public:
 
         __block auto p = std::make_unique<NativePromiseType>();
         auto f = p->getFuture();
-        [o then: ^id(DJFuture* res) {
+        [o then: ^id(DJFuture*) {
                 @try {
                     p->setValue();
                 } @catch (NSException* e) {
@@ -98,7 +98,7 @@ public:
         DJPromise<NSNull*>* promise = [[DJPromise alloc] init];
         DJFuture<NSNull*>* future = [promise getFuture];
 
-        c.then([promise] (Future<void> res) {
+        c.then([promise] (Future<void>) {
                 try {
                     [promise setValue:[NSNull null]];
                 } catch (const std::exception& e) {


### PR DESCRIPTION
- Unused parameters caused warnings in my project, so I removed them
- I think `Future.get()` is intended to return a non-nullable - unless I'm missing some reason why it shouldn't?