### PR TITLE
Support optional<future>

### DIFF
--- a/support-lib/composer/djinni_composer.hpp
+++ b/support-lib/composer/djinni_composer.hpp
@@ -222,6 +222,9 @@ struct Optional {
     static ComposerType fromCpp(const OptionalType<typename T::CppType>& c) {
         return c ? T::Boxed::fromCpp(*c) : Composer::Value::undefined();
     }
+    static ComposerType fromCpp(OptionalType<typename T::CppType>&& c) {
+        return c ? T::Boxed::fromCpp(std::move(*c)) : Composer::Value::undefined();
+    }
     template<typename C = T>
     static ComposerType fromCpp(const typename C::CppOptType& cppOpt) {
         return T::Boxed::fromCppOpt(cppOpt);

--- a/support-lib/jni/Marshal.hpp
+++ b/support-lib/jni/Marshal.hpp
@@ -324,6 +324,10 @@ namespace djinni
         {
             return c ? T::Boxed::fromCpp(jniEnv, *c) : LocalRef<JniType>{};
         }
+        static LocalRef<JniType> fromCpp(JNIEnv* jniEnv, OptionalType<typename T::CppType> &&c)
+        {
+            return c ? T::Boxed::fromCpp(jniEnv, std::move(*c)) : LocalRef<JniType>{};
+        }
 
         // fromCpp used for nullable shared_ptr
         template <typename C = T>

--- a/support-lib/objc/DJIMarshal+Private.h
+++ b/support-lib/objc/DJIMarshal+Private.h
@@ -244,6 +244,9 @@ public:
     static ObjcType fromCpp(const OptionalType<typename T::CppType>& opt) {
         return opt ? T::Boxed::fromCpp(*opt) : nil;
     }
+    static ObjcType fromCpp(OptionalType<typename T::CppType>&& opt) {
+        return opt ? T::Boxed::fromCpp(std::move(*opt)) : nil;
+    }
 
     // fromCpp used for nullable shared_ptr
     template <typename C = T>

--- a/support-lib/wasm/djinni_wasm.hpp
+++ b/support-lib/wasm/djinni_wasm.hpp
@@ -154,6 +154,9 @@ struct Optional
     static JsType fromCpp(const OptionalType<typename T::CppType>& c) {
         return c ? T::Boxed::fromCpp(*c) : em::val::undefined();
     }
+    static JsType fromCpp(OptionalType<typename T::CppType>&& c) {
+        return c ? T::Boxed::fromCpp(std::move(*c)) : em::val::undefined();
+    }
     template <typename C = T>
     static JsType fromCpp(const typename C::CppOptType& cppOpt) {
         return T::Boxed::fromCppOpt(cppOpt);


### PR DESCRIPTION
Codegen already supports this by emitting `std::move` for optional that contains a future.  This makes the library accepts it too by adding a r-value reference overload for optional.fromCpp().