### PR TITLE
Use official C++ 20 coroutine feature test macro

### DIFF
--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -25,7 +25,7 @@
 #include <cassert>
 #include <exception>
 
-#ifdef __cpp_coroutines
+#if defined(__cpp_coroutines) || defined(__cpp_impl_coroutine)
 #if __has_include(<coroutine>)
     #include <coroutine>
     namespace djinni::detail {


### PR DESCRIPTION
The djinni::Future coroutine support stops working at clang 17, see the reason here: https://stackoverflow.com/a/78027460/1480324

In this PR I use the updated the feature test macro as well as the outdated one.