### PR TITLE
Move result out of Future instead of copying it

### DIFF
--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -56,13 +56,13 @@ template <typename T>
 struct ValueHolder {
     using type = T;
     std::optional<T> value;
-    T getValueUnsafe() const {return *value;}
+    T&& getValueUnsafe() && {return std::move(*value);}
 };
 template <>
 struct ValueHolder<void> {
     using type = bool;
     std::optional<bool> value;
-    void getValueUnsafe() const {}
+    void getValueUnsafe() && {}
 };
 
 template<typename T>
@@ -295,7 +295,7 @@ public:
         sharedState->cv.wait(lk, [state = sharedState] {return state->isReady();});
 #endif
         if (!sharedState->exception) {
-            return sharedState->getValueUnsafe();
+            return std::move(*sharedState).getValueUnsafe();
         } else {
             std::rethrow_exception(sharedState->exception);
         }

--- a/test-suite/handwritten-src/objc/tests/DBCppFutureTests.mm
+++ b/test-suite/handwritten-src/objc/tests/DBCppFutureTests.mm
@@ -1,0 +1,29 @@
+#import <XCTest/XCTest.h>
+
+#include <Future.hpp>
+
+@interface DBCppFutureTests : XCTestCase
+
+@end
+
+@implementation DBCppFutureTests
+
+- (void)setUp
+{
+    [super setUp];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+}
+
+- (void)testCppFutureMovesResult
+{
+    auto future = djinni::Promise<std::unique_ptr<int>>::resolve(std::make_unique<int>(5));
+    auto ptr = future.get();
+    XCTAssertTrue(!!ptr);
+    XCTAssertEqual(*ptr, 5);
+}
+
+@end


### PR DESCRIPTION
I noticed that results are copied out of djinni::Futures instead of moved, probably due to a forgotten std::move.

Example: `auto ptr = djinni::Promise<std::unique_ptr<int>>::resolve(nullptr).get();`.
Before this it didn't work (called copy constructor of unique_ptr), now it does.

### Testing

I wanted to add a test to verify this works and doesn't break with future versions, but there are no dedicated C++ tests yet. I don't have experience with bazel, so I just added an XCTest to do this. I hope that's okay with you.