### PR TITLE
Allow move-only types in Promise<>. (based on contribution from jb-gcx)

### DIFF
--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -57,6 +57,7 @@ struct ValueHolder {
     using type = T;
     std::optional<T> value;
     T getValueUnsafe() const {return *value;}
+    T getValueUnsafe() {return std::move(*value);}
 };
 template <>
 struct ValueHolder<void> {

--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -56,7 +56,6 @@ template <typename T>
 struct ValueHolder {
     using type = T;
     std::optional<T> value;
-    T getValueUnsafe() const {return *value;}
     T getValueUnsafe() {return std::move(*value);}
 };
 template <>

--- a/test-suite/handwritten-src/cpp/test_helpers.cpp
+++ b/test-suite/handwritten-src/cpp/test_helpers.cpp
@@ -19,6 +19,11 @@
 
 namespace testsuite {
 
+// verify we we can put move only types in futures
+std::unique_ptr<int> testFutureMove() {
+    return djinni::Promise<std::unique_ptr<int>>::resolve(nullptr).get();
+}
+
 SetRecord TestHelpers::get_set_record() {
     return SetRecord { {
         "StringA",


### PR DESCRIPTION
A slight variation of the original fix from @jb-gcx  https://github.com/Snapchat/djinni/pull/177