### PR TITLE
Fix coroutine continuation cleanup

### DIFF
--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -27,22 +27,26 @@
 #include <cassert>
 #include <exception>
 
-#if defined(__cpp_coroutines) || defined(__cpp_impl_coroutine)
-#if __has_include(<coroutine>)
+#ifdef __has_include
+#if __has_include(<version>)
+#include <version>
+#endif
+#endif
+
+#if defined(__cpp_impl_coroutine) && defined(__cpp_lib_coroutine)
     #include <coroutine>
     namespace djinni::detail {
         template <typename Promise = void> using CoroutineHandle = std::coroutine_handle<Promise>;
         using SuspendNever = std::suspend_never;
     }
     #define DJINNI_FUTURE_HAS_COROUTINE_SUPPORT 1
-#elif __has_include(<experimental/coroutine>)
+#elif defined(__cpp_coroutines) && __has_include(<experimental/coroutine>)
     #include <experimental/coroutine>
     namespace djinni::detail {
         template <typename Promise = void> using CoroutineHandle = std::experimental::coroutine_handle<Promise>;
         using SuspendNever = std::experimental::suspend_never;
     }
     #define DJINNI_FUTURE_HAS_COROUTINE_SUPPORT 1
-#endif
 #endif
 
 namespace djinni {
@@ -375,7 +379,7 @@ public:
             constexpr bool await_ready() const noexcept {
                 return false;
             }
-            bool await_suspend(std::coroutine_handle<ConcretePromise> finished) const noexcept {
+            bool await_suspend(detail::CoroutineHandle<ConcretePromise> finished) const noexcept {
                 auto& promise_type = finished.promise();
                 if (*promise_type._result) {
                     if constexpr (std::is_void_v<T>) {

--- a/support-lib/cpp/expected.hpp
+++ b/support-lib/cpp/expected.hpp
@@ -17,6 +17,7 @@ namespace djinni {
 
 using ::std::expected;
 using ::std::unexpected;
+inline constexpr ::std::unexpect_t unexpect{};
 
 }
 
@@ -28,6 +29,7 @@ namespace djinni {
 
 using ::tl::unexpected;
 using ::tl::expected;
+inline constexpr ::tl::unexpect_t unexpect{};
 
 }
 

--- a/test-suite/handwritten-src/objc/tests/DBCppFutureTests.mm
+++ b/test-suite/handwritten-src/objc/tests/DBCppFutureTests.mm
@@ -1,0 +1,70 @@
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#include <Future.hpp>
+
+#ifdef DJINNI_FUTURE_HAS_COROUTINE_SUPPORT
+
+namespace {
+
+template<typename Functor>
+struct OnCleanup {
+    OnCleanup(Functor&& functor)
+    :functor{std::move(functor)}
+    {}
+    ~OnCleanup() {
+        functor();
+    }
+    Functor functor;
+};
+
+djinni::Future<void> inner_coroutine(std::vector<int>& cleanup_ids, int id, djinni::Future<void> suspendOn) {
+    OnCleanup cleanup{
+        [&] {
+            cleanup_ids.push_back(id);
+        }
+    };
+
+    co_await suspendOn;
+    co_return; // do not remove!
+}
+
+djinni::Future<void> outer_coroutine(std::vector<int>& cleanup_ids, int id, djinni::Future<void> suspendOn) {
+    OnCleanup cleanup{
+        [&] {
+            cleanup_ids.push_back(id);
+        }
+    };
+
+    co_await inner_coroutine(cleanup_ids, id + 1, std::move(suspendOn));
+    co_return; // do not remove!
+}
+
+}
+
+#endif
+
+@interface DBCppFutureTests : XCTestCase
+@end
+
+@implementation DBCppFutureTests
+
+#ifdef DJINNI_FUTURE_HAS_COROUTINE_SUPPORT
+- (void) testFutureCoroutines_cleanupOrder {
+    std::vector<int> cleanupIds{};
+
+    djinni::Promise<void> djinniPromise{};
+
+    auto coroutineFuture = outer_coroutine(cleanupIds, 0, djinniPromise.getFuture());
+    XCTAssertFalse(coroutineFuture.isReady());
+
+    djinniPromise.setValue();
+    XCTAssertTrue(coroutineFuture.isReady());
+
+    XCTAssertEqual(cleanupIds.size(), 2);
+    XCTAssertEqual(cleanupIds[0], 1); // the inner coroutine should be cleaned up first
+    XCTAssertEqual(cleanupIds[1], 0); // ... then the outer
+}
+#endif
+
+@end


### PR DESCRIPTION
C++ coroutines clean up their local variables _after_ invoking `return_value`, `return_void` or `unhandled_exception`. This means that executing a continuation in one of these methods basically inverts the cleanup order. Example:
```c++
#include <Future.hpp>
#include <iostream>
#include <thread>

struct LogOnDestruct {
    std::string message;
    ~LogOnDestruct() { std::cout << message << "\n"; }
};

djinni::Future<void> foo() {
    LogOnDestruct log{"~foo"};

    // The issue only occurs when we suspend
    // So make sure to suspend on another future
    djinni::Promise<void> promise;
    std::thread{[&promise] {
        std::this_thread::sleep_for(std::chrono::milliseconds(10));
        promise.setValue();
    }}.detach();
    co_return co_await promise.getFuture();
}

djinni::Future<void> bar() {
    LogOnDestruct log{"~bar"};
    co_await foo();
}

int main() {
    bar().get();
    return 0;
}
```
Before this PR, the above code produced:
```
~bar
~foo
```
Which is inverted (caller gets cleaned up before callee). This can even lead to crashes etc, if a reference to a local variable from `bar` is used during cleanup in `foo` - because that local variable in `bar` was already cleaned up!

After this PR the code produces:
```
~foo
~bar
```
As it should.

## Merge considerations

- I use a `requires`, which is a C++20 feature. I decided that this is acceptable, since coroutines themselves are also a C++20 feature. If this is not okay, let me know and I'll change it to a more compatible SFINAE approach.
- I'd like to add a test for this, but I'm not sure how. There is no dedicated C++ test suite and it would take me a while to create one as I have zero bazel experience. Should I just add an XCTest, or what's the preferred way?