### PR TITLE
Finish futures when their promise is broken

### DIFF
--- a/test-suite/handwritten-src/objc/tests/DBCppFutureTests.mm
+++ b/test-suite/handwritten-src/objc/tests/DBCppFutureTests.mm
@@ -67,4 +67,36 @@ djinni::Future<void> outer_coroutine(std::vector<int>& cleanup_ids, int id, djin
 }
 #endif
 
+- (void) testFuture_brokenPromise {
+    std::optional<djinni::Promise<void>> promise{std::in_place};
+    auto future = promise->getFuture();
+    XCTAssertFalse(future.isReady());
+
+    auto promise2 = std::make_optional(std::move(*promise));
+    XCTAssertFalse(future.isReady());
+
+    promise.reset();
+    XCTAssertFalse(future.isReady());
+
+    promise2.reset();
+    XCTAssertTrue(future.isReady());
+    if (future.isReady()) {
+        XCTAssertThrowsSpecific(future.get(), djinni::BrokenPromiseException);
+    }
+}
+
+- (void) testFuture_brokenPromiseAssignment {
+    djinni::Promise<void> promise{};
+    auto future = promise.getFuture();
+    XCTAssertFalse(future.isReady());
+
+    promise = djinni::Promise<void>{};
+    XCTAssertTrue(future.isReady());
+    if (future.isReady()) {
+        XCTAssertThrowsSpecific(future.get(), djinni::BrokenPromiseException);
+    }
+
+    XCTAssertFalse(promise.getFuture().isReady());
+}
+
 @end


### PR DESCRIPTION
Accidentally discarding a `djinni::Promise` leads the associated future(s) to block forever in `get`. This is unrecoverable when it happens. Instead, I'm applying the behavior of `std::promise::~promise` to `djinni::Promise`: if the promise is not finished, we set a `BrokenPromiseException` into the shared state.

This is (kind of) a breaking change. But it only changes behavior for users, who rely on futures that never complete when the promise is discarded. In my opinion, that was buggy behavior.