### PR TITLE
Reverts build arg changes from adding SharedFuture

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,1 @@
-build --cxxopt=-std=c++17 --cxxopt=-fcoroutines-ts --host_cxxopt=-std=c++17 --host_cxxopt=-fcoroutines-ts --incompatible_java_common_parameters=false --define=android_dexmerger_tool=d8_dexmerger --define=android_incremental_dexing_tool=d8_dexbuilder --nouse_workers_with_dexbuilder
+build --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --incompatible_java_common_parameters=false --define=android_dexmerger_tool=d8_dexmerger --define=android_incremental_dexing_tool=d8_dexbuilder --nouse_workers_with_dexbuilder


### PR DESCRIPTION
Reverts parts of commit ae855ee0dd43be735156880a72bca08e188040f8

This change was made in #183 and it causes our CI to fail compiling protobuf. The change in `.buildrc` appends  `-fcoroutines-ts` to the compilation of djinni dependencies, which definitely don't need it. As far as I understand it's only needed for tests, so we can test djinni coroutine implementations.

Example error from our CI:
```
  Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
  gcc: error: unrecognized command-line option '-fcoroutines-ts'; did you mean '-fcoroutines'?
  ERROR: /home/runner/.cache/bazel/_bazel_runner/a8bde27687bcb180662e14df4ed3e9b6/external/com_google_protobuf/BUILD:471:10: Compiling src/google/protobuf/compiler/main.cc failed: (Exit 1): gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections ... (remaining 39 arguments skipped)
```