### PR TITLE
Feedback request: Future cancellation

### DIFF
--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -374,12 +374,11 @@ public:
         sharedState = std::atomic_exchange(&_sharedState, sharedState);
         return Future<T>(sharedState).get();
     }
-    bool await_suspend(detail::CoroutineHandle<> h) {
+    void await_suspend(detail::CoroutineHandle<> h) {
         this->then([h, this] (Future<T> x) mutable {
             std::atomic_store(&_sharedState, x._sharedState);
             h();
         });
-        return true;
     }
 
     struct PromiseTypeBase {

--- a/support-lib/cpp/stop_token.cpp
+++ b/support-lib/cpp/stop_token.cpp
@@ -1,0 +1,105 @@
+#include "stop_token.hpp"
+
+#ifdef DJINNI_STOP_SOURCE_USE_CUSTOM_IMPL
+
+namespace djinni {
+
+bool inplace_stop_token::stop_requested() const noexcept {
+    return stop_possible() && _stop_source->stop_requested();
+}
+
+bool inplace_stop_token::stop_possible() const noexcept {
+    return _stop_source != nullptr;
+}
+
+void inplace_stop_token::swap(inplace_stop_token& other) noexcept {
+    std::swap(other._stop_source, _stop_source);
+}
+
+
+bool inplace_stop_source::stop_requested() const noexcept {
+    return _stopping_thread != std::thread::id{};
+}
+
+bool inplace_stop_source::request_stop() noexcept {
+    std::unique_lock lock{_mtx};
+    if (_stopping_thread != std::thread::id{}) {
+        return false;
+    }
+
+    _stopping_thread = std::this_thread::get_id();
+
+    for (; _cb_node != nullptr; _cb_node = _cb_node->next) {
+        lock.unlock();
+        (*_cb_node->callback)(_cb_node->arg);
+        lock.lock();
+    }
+    return true;
+}
+
+void inplace_stop_source::_register_callback(details::stop_callback_node* node) const noexcept {
+    std::unique_lock lock{_mtx};
+    if (_stopping_thread != std::thread::id{}) {
+        lock.unlock();
+        (*node->callback)(node->arg);
+        return;
+    }
+
+    node->next = _cb_node;
+    _cb_node = node->next;
+}
+
+void inplace_stop_source::_unregister_callback(details::stop_callback_node* node) const noexcept {
+    std::unique_lock lock{_mtx};
+    if (_stopping_thread != std::thread::id{} && _cb_node == node) {
+        // we're currently being stopped and the given callback is the one that is currently being executed
+        if (_stopping_thread == std::this_thread::get_id()) {
+            // the current callback is removing itself during its execution, so nothing to do
+            return;
+        } else {
+            // another thread is currently executing the callback, we have to block until it completes
+            // so we insert a phony callback that will alert us once the current callback is finished
+            bool finished{false};
+            std::condition_variable cv{};
+            auto finish = [this, &finished, &cv] { 
+                {
+                    std::lock_guard<std::mutex> lock{_mtx};
+                    finished = true;
+                }
+                cv.notify_one();
+            };
+            using FinishFunctor = decltype(finish);
+
+            void(*finished_callback)(void*) = [](void* arg) {
+                auto& finish{*reinterpret_cast<FinishFunctor*>(arg)};
+                finish();
+            };
+
+
+            details::stop_callback_node node {
+                .callback = finished_callback,
+                .arg = &finish,
+                .next = _cb_node->next,
+            };
+            _cb_node->next = &node;
+
+            // Wait until the phony callback was invoked
+            cv.wait(lock, [&finished] {
+                return finished;
+            });
+
+            return;
+        }
+    }
+
+    for (auto* prev_node = _cb_node; prev_node->next != nullptr; prev_node = prev_node->next) {
+        if (prev_node->next == node) {
+            prev_node->next = node->next;
+            return;
+        }
+    }
+}
+
+}
+
+#endif

--- a/support-lib/cpp/stop_token.hpp
+++ b/support-lib/cpp/stop_token.hpp
@@ -1,0 +1,155 @@
+#pragma once
+
+#ifdef __has_include
+#if __has_include(<version>)
+#include <version>
+#endif
+#endif
+
+// At the time of writing, P2300R10 only defines __cpp_lib_senders as a feature-test, nothing specific to whether inplace_stop_token is available
+#ifndef __cpp_lib_senders
+#ifndef DJINNI_STOP_SOURCE_USE_CUSTOM_IMPL
+#define DJINNI_STOP_SOURCE_USE_CUSTOM_IMPL
+#endif
+#endif
+
+#ifndef DJINNI_STOP_SOURCE_USE_CUSTOM_IMPL
+
+// Standard implementation is available
+
+#include <stop_token>
+
+namespace djinni {
+
+using inplace_stop_token = std::inplace_stop_token;
+using inplace_stop_source = std::inplace_stop_source;
+template<typename Callback>
+using inplace_stop_callback = std::inplace_stop_callback<Callback>;
+
+}
+
+#else
+
+// Standard implementation unavailable, we roll our own implementation of what we need
+
+#include <memory>
+#include <functional>
+#include <thread>
+
+namespace djinni {
+
+namespace details {
+
+struct stop_callback_node final {
+    void(*callback)(void*);
+    void* arg;
+    stop_callback_node* next;
+};
+
+};
+
+class inplace_stop_source;
+template<typename Callback>
+class inplace_stop_callback;
+
+class inplace_stop_token {
+public:
+    template<class CallbackFn>
+    using callback_type = inplace_stop_callback<CallbackFn>;
+
+    inplace_stop_token() = default;
+    bool operator==(const inplace_stop_token&) const = default;
+
+    [[nodiscard]] bool stop_requested() const noexcept;
+    [[nodiscard]] bool stop_possible() const noexcept;
+    void swap(inplace_stop_token&) noexcept;
+
+private:
+    template<typename T>
+    friend class inplace_stop_callback;
+    friend inplace_stop_source;
+    constexpr inplace_stop_token(const inplace_stop_source* stop_source) noexcept
+    :_stop_source{stop_source} {}
+
+    const inplace_stop_source* _stop_source = nullptr;
+};
+
+class inplace_stop_source {
+public:
+    constexpr inplace_stop_source() noexcept = default;
+
+    inplace_stop_source(inplace_stop_source&&) = delete;
+    inplace_stop_source(const inplace_stop_source&) = delete;
+    inplace_stop_source& operator=(inplace_stop_source&&) = delete;
+    inplace_stop_source& operator=(const inplace_stop_source&) = delete;
+
+    [[nodiscard]] constexpr inplace_stop_token get_token() const noexcept {
+        return {this};
+    }
+    [[nodiscard]] static constexpr bool stop_possible() noexcept { return true; }
+
+    [[nodiscard]] bool stop_requested() const noexcept;
+    bool request_stop() noexcept;
+
+private:
+    template<typename T>
+    friend class inplace_stop_callback;
+    void _register_callback(details::stop_callback_node* callback) const noexcept;
+    void _unregister_callback(details::stop_callback_node* callback) const noexcept;
+
+    mutable std::mutex _mtx{};
+    std::thread::id _stopping_thread{};
+    mutable details::stop_callback_node* _cb_node = nullptr;
+};
+
+template<typename Callback>
+class inplace_stop_callback {
+public:
+    using callback_type = Callback;
+
+    template<typename C>
+    explicit inplace_stop_callback(inplace_stop_token token, C&& callback) noexcept(std::is_nothrow_constructible_v<Callback, C>)
+        :_token(std::move(token))
+        ,_callback(std::forward<C>(callback))
+    {
+        if (_token._stop_source) {
+            _token._stop_source->_register_callback(&_node);
+        }
+    }
+
+    ~inplace_stop_callback() {
+        if (_token._stop_source) {
+            _token._stop_source->_unregister_callback(&_node);
+        }
+    }
+
+    inplace_stop_callback(const inplace_stop_callback&) = delete;
+    inplace_stop_callback& operator=(const inplace_stop_callback&) = delete;
+    inplace_stop_callback(inplace_stop_callback&&) = delete;
+    inplace_stop_callback& operator=(inplace_stop_callback&&) = delete;
+
+private:
+    static void invoke(void* callback) {
+        reinterpret_cast<inplace_stop_callback*>(callback)->_callback();
+    }
+
+    inplace_stop_token _token;
+    Callback _callback;
+    details::stop_callback_node _node {
+        .callback = &inplace_stop_callback<Callback>::invoke,
+        .arg = this,
+        .next = nullptr,
+    };
+};
+
+template<typename C>
+inplace_stop_callback(inplace_stop_token, C callback) -> inplace_stop_callback<C>;
+
+/*
+Ignored the following std requirements for simplicity and C++17 compatibility:
+- template arg of inplace_stop_callback must be std::invocable and std::destructible
+*/
+
+}
+
+#endif


### PR DESCRIPTION
In my project we would greatly benefit from having futures support cancellation requests.

The code in this PR is just a rough outline showing my approach, it is _incomplete and untested_. The goal is to have cancellation bridged between languages as well (ie: your swift/objc code can cancel a future from C++), but I have not implemented this yet.

The reason why I'm creating an incomplete PR is that I'd like early feedback (@li-feng-sc 🙏 ). Concretely:
1. Is there interest in (and time for) supporting this?
    - Cancellation support is complex => Review + Test will need time from you
    - If the answer is no, then please let me know soon so I can redirect my efforts to supporting this internally in my project
2. If there is interest: is it okay with you to build cancellation into `djinni::Future`, or would you prefer a separate class, for example `CancelableFuture`? Do you agree with my implementation approach so far?

### Examples

#### Cancellation forwarding:
```c++
// Some cancellation-aware method
Future<void> foo();

Future<void> bar() {
    // Will forward cancellation of our future to foos future
    co_await foo();
}

int main() {
    auto future = bar();
    future.getStopSource().request_stop(); // this cancels bars future, which is forwarded to foos future as well
    bar.get(); // throws a CanceledException, assuming foo notices the cancellation before finishing
}
```

#### Checking for cancellation

```c++
Future<void> worker_thread() {
    Promise<void> promise{};
    auto future = promise.getFuture();

    std::thread{[promise = std::move(promise)] {
        while (!promise.getStopToken().stop_requested()) {
            // do work
        }
    }}.detach();

    return future;
}
```

```c++
void subscribe_to_event(std::function<void()>);
void unsubscribe_from_event();
Future<void> wait_for_event() {
    auto promise = std::make_shared<Promise<void>>();
    inplace_stop_callback callback{promise.getStopToken(), [promise] {
        unsubscribe_from_event();
        promise->setException(CancelledException{});
    }};
    subscribe_to_event([promise] {
        promise->setValue();
    });
    return promise->getFuture();
}
```

```c++
Future<void> coroutine() {
    while (!co_await check_cancelled()) {
        // ...
    }

    // alternatively, to abort immediately when cancelled:
    co_await abort_if_cancelled();
}
```

### Notes

The implementation is based on `inplace_stop_token`, which is approved for C++26. This allows cancellation with a well defined interface and minimal overhead (no extra heap allocations etc). The token is stored in a futures SharedState.

The overhead could probably be further reduced by replacing the mutex with atomics, but I've decided to go for a simple implementation first