### PR TITLE
remove -fcoroutines-ts complie options for Xcode 16

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,1 @@
-build --cxxopt=-std=c++17 --cxxopt=-fcoroutines-ts --host_cxxopt=-std=c++17 --host_cxxopt=-fcoroutines-ts --incompatible_java_common_parameters=false --define=android_dexmerger_tool=d8_dexmerger --define=android_incremental_dexing_tool=d8_dexbuilder --nouse_workers_with_dexbuilder
+build --cxxopt=-std=c++17 --host_cxxopt=-std=c++17  --incompatible_java_common_parameters=false --define=android_dexmerger_tool=d8_dexmerger --define=android_incremental_dexing_tool=d8_dexbuilder --nouse_workers_with_dexbuilder

--- a/test-suite/BUILD
+++ b/test-suite/BUILD
@@ -55,7 +55,6 @@ objc_library(
     copts = [
         "-ObjC++",
         "-std=c++17",
-        "-fcoroutines-ts"
     ],
     srcs = glob([
         "generated-src/objc/**/*.mm",


### PR DESCRIPTION
I made these simple changes to use the main branch in Xcode 16.0. The lf/swift-support branch is also working but I wanted to stay in the main branch.