### PR TITLE
Clean up jniFindClass() local string ASAP so multiple calls from a single JNI invocation don't exhaust the local ref table

### DIFF
--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -304,8 +304,8 @@ GlobalRef<jclass> jniFindClass(const char * name) {
     if (!clazz) {
         env->ExceptionClear();
         // Use cached class loader, needed for our classes on non-Java thread
-        jstring jname = env->NewStringUTF(name);
-        clazz = static_cast<jclass>(env->CallObjectMethod(g_ourClassLoader, g_loadClassMethodID, jname));
+        LocalRef<jstring> jname(env->NewStringUTF(name));
+        clazz = static_cast<jclass>(env->CallObjectMethod(g_ourClassLoader, g_loadClassMethodID, jname.get()));
         jniExceptionCheck(env);
     }
     GlobalRef<jclass> guard(env, LocalRef<jclass>(env, clazz).get());


### PR DESCRIPTION
`jniFindClass()` allocates a jstring for the class name but doesn't explicitly free it. Usually this is fine because it will be freed automatically when the current JNI invocation completes. But if the JNI function calls `jniFindClass()` many times before completing, it can exhaust the local reference table (max 512 slots on older Android devices).

Fix: add a `LocalRef` wrapper to free the jstring immediately after use.