### PR TITLE
Added supports for constants in C codegen

### DIFF
--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -100,8 +100,8 @@ class CGenerator(spec: Spec) extends Generator(spec) {
       val symbolName = resolveSymbolName(ident.name)
       val enumCasePrefix = symbolName + "_"
       writeDoc(w, doc)
-      w.w("enum " + symbolName)
-      w.bracedSemi {
+      w.w("typedef enum")
+      w.bracedEnd(s" ${symbolName};") {
         writeEnumOptionNone(w, e, idCpp.enum, "=", enumCasePrefix)
         writeEnumOptions(w, e, idCpp.enum, "=", enumCasePrefix)
         writeEnumOptionAll(w, e, idCpp.enum, "=", enumCasePrefix)

--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -10,6 +10,7 @@ class CGenerator(spec: Spec) extends Generator(spec) {
   private val cppMarshal = new CppMarshal(spec)
 
   private class ResolvedField(val field: Field, val translator: CTypeTranslator)
+  private class ResolvedConst(val const: ast.Const, val translator: CTypeTranslator)
 
   private class ResolvedMethod(val resolvedName: String, val method: Interface.Method, val parameters: Seq[ResolvedField], val returnType: Option[CTypeTranslator]) {
     def retTypename: String = if (returnType.isDefined) returnType.get.typename else "void"
@@ -131,6 +132,25 @@ class CGenerator(spec: Spec) extends Generator(spec) {
     writeParamList(w, params.map(p => (p.translator.typename, p.field.ident.name)))
   }
 
+  private def generateConstsHeader(typename: String, consts: Seq[ResolvedConst], w: IndentWriter): Unit = {
+    for (const <- consts) {
+      writeDoc(w, const.const.doc)
+      w.wl(s"""${const.translator.typename} ${typename}_get_${const.const.ident.name}();""")
+      w.wl
+    }
+  }
+
+  private def generateConstsImpl(cppTypename: String, typename: String, consts: Seq[ResolvedConst], w: IndentWriter): Unit = {
+    for (const <- consts) {
+      w.w(s"""${const.translator.typename} ${typename}_get_${const.const.ident.name}()""")
+      w.braced {
+        val cppValue = s"${cppTypename}::${idCpp.const(const.const.ident)}"
+        w.wl(s"""return ${const.translator.fromCpp(cppValue)};""")
+      }
+      w.wl
+    }
+  }
+
   override def generateRecord(origin: String, ident: Ident, doc: Doc, params: Seq[TypeParam], r: ast.Record): Unit = {
     val selfCpp = cppMarshal.fqTypename(ident, r)
 
@@ -139,6 +159,7 @@ class CGenerator(spec: Spec) extends Generator(spec) {
     val typeName = resolveRefSymbolTypeName(ident)
 
     val resolvedFields = r.fields.map(f => (new ResolvedField(f, typeResolver.resolve(f.ty.resolved))))
+    val resolvedConsts = r.consts.map(r => new ResolvedConst(r, typeResolver.resolve(r.ty.resolved)))
 
     writeCFilePair(origin, ident, typeResolver.publicImports.toSeq, typeResolver.privateImports.toSeq)((w: IndentWriter) => {
       writeDoc(w, doc)
@@ -148,6 +169,9 @@ class CGenerator(spec: Spec) extends Generator(spec) {
       w.w(s"""${typeName} ${prefix}_new(""")
       writeParamListWithResolvedFields(w, resolvedFields)
       w.wl(");")
+      w.wl
+
+      generateConstsHeader(prefix, resolvedConsts, w)
 
       for (resolvedField <- resolvedFields) {
         val fieldName = resolvedField.field.ident.name
@@ -173,6 +197,8 @@ class CGenerator(spec: Spec) extends Generator(spec) {
       }
 
       w.wl
+
+      generateConstsImpl(selfCpp, prefix, resolvedConsts, w)
 
       val toCppExpr = s"::djinni::c_api::RecordTranslator<${selfCpp}>::toCpp(instance)"
       for (resolvedField <- resolvedFields) {
@@ -293,6 +319,7 @@ class CGenerator(spec: Spec) extends Generator(spec) {
         ),
         m.ret.map(r => typeResolver.resolve(r.resolved))
       ))
+    val resolvedConsts = i.consts.map(r => new ResolvedConst(r, typeResolver.resolve(r.ty.resolved)))
 
     val prefix = resolveSymbolName(ident.name)
     val typeName = resolveRefSymbolTypeName(ident)
@@ -330,6 +357,8 @@ class CGenerator(spec: Spec) extends Generator(spec) {
         w.wl
       }
 
+      generateConstsHeader(prefix, resolvedConsts, w)
+
       for (resolvedMethod <- resolvedMethods) {
         writeDoc(w, resolvedMethod.method.doc)
         w.w(s"${resolvedMethod.retTypename} ${prefix}_${resolvedMethod.resolvedName}(")
@@ -360,6 +389,8 @@ class CGenerator(spec: Spec) extends Generator(spec) {
         }
         w.wl
       }
+
+      generateConstsImpl(selfCpp, prefix, resolvedConsts, w)
 
       for (resolvedMethod <- resolvedMethods) {
         writeDoc(w, resolvedMethod.method.doc)

--- a/test-suite/generated-src/c/RecordWithEmbeddedCppProto.h
+++ b/test-suite/generated-src/c/RecordWithEmbeddedCppProto.h
@@ -12,6 +12,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_RecordWithEmbeddedCppProto_ref;
 
 testsuite_RecordWithEmbeddedCppProto_ref testsuite_RecordWithEmbeddedCppProto_new(djinni_binary_ref state);
+
 djinni_binary_ref testsuite_RecordWithEmbeddedCppProto_get_state(testsuite_RecordWithEmbeddedCppProto_ref instance);
 void testsuite_RecordWithEmbeddedCppProto_set_state(testsuite_RecordWithEmbeddedCppProto_ref instance, djinni_binary_ref value);
 

--- a/test-suite/generated-src/c/RecordWithEmbeddedProto.h
+++ b/test-suite/generated-src/c/RecordWithEmbeddedProto.h
@@ -12,6 +12,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_RecordWithEmbeddedProto_ref;
 
 testsuite_RecordWithEmbeddedProto_ref testsuite_RecordWithEmbeddedProto_new(djinni_binary_ref person);
+
 djinni_binary_ref testsuite_RecordWithEmbeddedProto_get_person(testsuite_RecordWithEmbeddedProto_ref instance);
 void testsuite_RecordWithEmbeddedProto_set_person(testsuite_RecordWithEmbeddedProto_ref instance, djinni_binary_ref value);
 

--- a/test-suite/generated-src/c/_varname_record_.h
+++ b/test-suite/generated-src/c/_varname_record_.h
@@ -17,6 +17,7 @@ extern "C" {
 typedef djinni_record_ref testsuite__varname_record__ref;
 
 testsuite__varname_record__ref testsuite__varname_record__new(int8_t _field_);
+
 int8_t testsuite__varname_record__get__field_(testsuite__varname_record__ref instance);
 void testsuite__varname_record__set__field_(testsuite__varname_record__ref instance, int8_t value);
 

--- a/test-suite/generated-src/c/access_flags.h
+++ b/test-suite/generated-src/c/access_flags.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif // __cplusplus
 
-enum testsuite_access_flags {
+typedef enum {
     testsuite_access_flags_NOBODY = 0,
     testsuite_access_flags_OWNER_READ = 1 << 0,
     testsuite_access_flags_OWNER_WRITE = 1 << 1,
@@ -21,7 +21,7 @@ enum testsuite_access_flags {
     testsuite_access_flags_SYSTEM_WRITE = 1 << 7,
     testsuite_access_flags_SYSTEM_EXECUTE = 1 << 8,
     testsuite_access_flags_EVERYBODY = 0 | (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4) | (1 << 5) | (1 << 6) | (1 << 7) | (1 << 8),
-};
+} testsuite_access_flags;
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/test-suite/generated-src/c/assorted_primitives.h
+++ b/test-suite/generated-src/c/assorted_primitives.h
@@ -12,6 +12,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_assorted_primitives_ref;
 
 testsuite_assorted_primitives_ref testsuite_assorted_primitives_new(bool b, int8_t eight, int16_t sixteen, int32_t thirtytwo, int64_t sixtyfour, float fthirtytwo, double fsixtyfour, djinni_optional_bool o_b, djinni_optional_int8 o_eight, djinni_optional_int16 o_sixteen, djinni_optional_int32 o_thirtytwo, djinni_optional_int64 o_sixtyfour, djinni_optional_float o_fthirtytwo, djinni_optional_double o_fsixtyfour);
+
 bool testsuite_assorted_primitives_get_b(testsuite_assorted_primitives_ref instance);
 void testsuite_assorted_primitives_set_b(testsuite_assorted_primitives_ref instance, bool value);
 

--- a/test-suite/generated-src/c/client_returned_record.h
+++ b/test-suite/generated-src/c/client_returned_record.h
@@ -13,6 +13,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_client_returned_record_ref;
 
 testsuite_client_returned_record_ref testsuite_client_returned_record_new(int64_t record_id, djinni_string_ref content, djinni_string_ref misc);
+
 int64_t testsuite_client_returned_record_get_record_id(testsuite_client_returned_record_ref instance);
 void testsuite_client_returned_record_set_record_id(testsuite_client_returned_record_ref instance, int64_t value);
 

--- a/test-suite/generated-src/c/color.h
+++ b/test-suite/generated-src/c/color.h
@@ -10,7 +10,7 @@ extern "C" {
 #endif // __cplusplus
 
 /** This is a test */
-enum testsuite_color {
+typedef enum {
     testsuite_color_RED = 0,
     testsuite_color_ORANGE = 1,
     testsuite_color_YELLOW = 2,
@@ -23,7 +23,7 @@ enum testsuite_color {
      */
     testsuite_color_INDIGO = 5,
     testsuite_color_VIOLET = 6,
-};
+} testsuite_color;
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/test-suite/generated-src/c/constant_enum.h
+++ b/test-suite/generated-src/c/constant_enum.h
@@ -10,10 +10,10 @@ extern "C" {
 #endif // __cplusplus
 
 /** enum for use in constants */
-enum testsuite_constant_enum {
+typedef enum {
     testsuite_constant_enum_SOME_VALUE = 0,
     testsuite_constant_enum_SOME_OTHER_VALUE = 1,
-};
+} testsuite_constant_enum;
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/test-suite/generated-src/c/constant_interface_with_enum.cpp
+++ b/test-suite/generated-src/c/constant_interface_with_enum.cpp
@@ -3,6 +3,11 @@
 
 #include "constant_interface_with_enum.h"
 #include "djinni_c_translators.hpp"
+#include "constant_enum.hpp"
 #include "constant_interface_with_enum.hpp"
+
+testsuite_constant_enum testsuite_constant_interface_with_enum_get_const_enum() {
+    return ::djinni::c_api::EnumTranslator<::testsuite::constant_enum, testsuite_constant_enum>::fromCpp(::testsuite::ConstantInterfaceWithEnum::CONST_ENUM);
+}
 
 

--- a/test-suite/generated-src/c/constant_interface_with_enum.h
+++ b/test-suite/generated-src/c/constant_interface_with_enum.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "djinni_c.h"
+#include "constant_enum.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,6 +12,8 @@ extern "C" {
 
 /** Interface containing enum constant */
 typedef djinni_interface_ref testsuite_constant_interface_with_enum_ref;
+
+testsuite_constant_enum testsuite_constant_interface_with_enum_get_const_enum();
 
 #ifdef __cplusplus
 } // extern "C"

--- a/test-suite/generated-src/c/constant_record.h
+++ b/test-suite/generated-src/c/constant_record.h
@@ -13,6 +13,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_constant_record_ref;
 
 testsuite_constant_record_ref testsuite_constant_record_new(int32_t some_integer, djinni_string_ref some_string);
+
 int32_t testsuite_constant_record_get_some_integer(testsuite_constant_record_ref instance);
 void testsuite_constant_record_set_some_integer(testsuite_constant_record_ref instance, int32_t value);
 

--- a/test-suite/generated-src/c/constant_with_enum.cpp
+++ b/test-suite/generated-src/c/constant_with_enum.cpp
@@ -3,11 +3,16 @@
 
 #include "constant_with_enum.h"
 #include "djinni_c_translators.hpp"
+#include "constant_enum.hpp"
 #include "constant_with_enum.hpp"
 
 testsuite_constant_with_enum_ref testsuite_constant_with_enum_new() 
 {
     return ::djinni::c_api::RecordTranslator<::testsuite::ConstantWithEnum>::make();
+}
+
+testsuite_constant_enum testsuite_constant_with_enum_get_const_enum() {
+    return ::djinni::c_api::EnumTranslator<::testsuite::constant_enum, testsuite_constant_enum>::fromCpp(::testsuite::ConstantWithEnum::CONST_ENUM);
 }
 
 

--- a/test-suite/generated-src/c/constant_with_enum.h
+++ b/test-suite/generated-src/c/constant_with_enum.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "djinni_c.h"
+#include "constant_enum.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,6 +14,9 @@ extern "C" {
 typedef djinni_record_ref testsuite_constant_with_enum_ref;
 
 testsuite_constant_with_enum_ref testsuite_constant_with_enum_new();
+
+testsuite_constant_enum testsuite_constant_with_enum_get_const_enum();
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/test-suite/generated-src/c/constants.cpp
+++ b/test-suite/generated-src/c/constants.cpp
@@ -3,11 +3,84 @@
 
 #include "constants.h"
 #include "djinni_c_translators.hpp"
+#include "constant_record.hpp"
 #include "constants.hpp"
 
 testsuite_constants_ref testsuite_constants_new() 
 {
     return ::djinni::c_api::RecordTranslator<::testsuite::Constants>::make();
+}
+
+bool testsuite_constants_get_bool_constant() {
+    return ::testsuite::Constants::BOOL_CONSTANT;
+}
+
+int8_t testsuite_constants_get_i8_constant() {
+    return ::testsuite::Constants::I8_CONSTANT;
+}
+
+int16_t testsuite_constants_get_i16_constant() {
+    return ::testsuite::Constants::I16_CONSTANT;
+}
+
+int32_t testsuite_constants_get_i32_constant() {
+    return ::testsuite::Constants::I32_CONSTANT;
+}
+
+int64_t testsuite_constants_get_i64_constant() {
+    return ::testsuite::Constants::I64_CONSTANT;
+}
+
+float testsuite_constants_get_f32_constant() {
+    return ::testsuite::Constants::F32_CONSTANT;
+}
+
+double testsuite_constants_get_f64_constant() {
+    return ::testsuite::Constants::F64_CONSTANT;
+}
+
+djinni_optional_bool testsuite_constants_get_opt_bool_constant() {
+    return ::djinni::c_api::PrimitiveOptionalTranslator<std::experimental::optional<bool>, djinni_optional_bool>::fromCpp(::testsuite::Constants::OPT_BOOL_CONSTANT);
+}
+
+djinni_optional_int8 testsuite_constants_get_opt_i8_constant() {
+    return ::djinni::c_api::PrimitiveOptionalTranslator<std::experimental::optional<int8_t>, djinni_optional_int8>::fromCpp(::testsuite::Constants::OPT_I8_CONSTANT);
+}
+
+djinni_optional_int16 testsuite_constants_get_opt_i16_constant() {
+    return ::djinni::c_api::PrimitiveOptionalTranslator<std::experimental::optional<int16_t>, djinni_optional_int16>::fromCpp(::testsuite::Constants::OPT_I16_CONSTANT);
+}
+
+djinni_optional_int32 testsuite_constants_get_opt_i32_constant() {
+    return ::djinni::c_api::PrimitiveOptionalTranslator<std::experimental::optional<int32_t>, djinni_optional_int32>::fromCpp(::testsuite::Constants::OPT_I32_CONSTANT);
+}
+
+djinni_optional_int64 testsuite_constants_get_opt_i64_constant() {
+    return ::djinni::c_api::PrimitiveOptionalTranslator<std::experimental::optional<int64_t>, djinni_optional_int64>::fromCpp(::testsuite::Constants::OPT_I64_CONSTANT);
+}
+
+djinni_optional_float testsuite_constants_get_opt_f32_constant() {
+    return ::djinni::c_api::PrimitiveOptionalTranslator<std::experimental::optional<float>, djinni_optional_float>::fromCpp(::testsuite::Constants::OPT_F32_CONSTANT);
+}
+
+djinni_optional_double testsuite_constants_get_opt_f64_constant() {
+    return ::djinni::c_api::PrimitiveOptionalTranslator<std::experimental::optional<double>, djinni_optional_double>::fromCpp(::testsuite::Constants::OPT_F64_CONSTANT);
+}
+
+djinni_string_ref testsuite_constants_get_string_constant() {
+    return ::djinni::c_api::StringTranslator::fromCpp(::testsuite::Constants::STRING_CONSTANT);
+}
+
+djinni_string_ref testsuite_constants_get_opt_string_constant() {
+    return ::djinni::c_api::OptionalTranslator<std::experimental::optional<std::string>, ::djinni::c_api::StringTranslator>::fromCpp(::testsuite::Constants::OPT_STRING_CONSTANT);
+}
+
+testsuite_constant_record_ref testsuite_constants_get_object_constant() {
+    return ::djinni::c_api::RecordTranslator<::testsuite::ConstantRecord>::fromCpp(::testsuite::Constants::OBJECT_CONSTANT);
+}
+
+bool testsuite_constants_get_dummy() {
+    return ::testsuite::Constants::DUMMY;
 }
 
 

--- a/test-suite/generated-src/c/constants.h
+++ b/test-suite/generated-src/c/constants.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "djinni_c.h"
+#include "constant_record.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,6 +14,60 @@ extern "C" {
 typedef djinni_record_ref testsuite_constants_ref;
 
 testsuite_constants_ref testsuite_constants_new();
+
+/** bool_constant has documentation. */
+bool testsuite_constants_get_bool_constant();
+
+int8_t testsuite_constants_get_i8_constant();
+
+int16_t testsuite_constants_get_i16_constant();
+
+int32_t testsuite_constants_get_i32_constant();
+
+int64_t testsuite_constants_get_i64_constant();
+
+float testsuite_constants_get_f32_constant();
+
+/**
+ * f64_constant has long documentation.
+ * (Second line of multi-line documentation.
+ *   Indented third line of multi-line documentation.)
+ */
+double testsuite_constants_get_f64_constant();
+
+djinni_optional_bool testsuite_constants_get_opt_bool_constant();
+
+djinni_optional_int8 testsuite_constants_get_opt_i8_constant();
+
+/** opt_i16_constant has documentation. */
+djinni_optional_int16 testsuite_constants_get_opt_i16_constant();
+
+djinni_optional_int32 testsuite_constants_get_opt_i32_constant();
+
+djinni_optional_int64 testsuite_constants_get_opt_i64_constant();
+
+/**
+ * opt_f32_constant has long documentation.
+ * (Second line of multi-line documentation.
+ *   Indented third line of multi-line documentation.)
+ */
+djinni_optional_float testsuite_constants_get_opt_f32_constant();
+
+djinni_optional_double testsuite_constants_get_opt_f64_constant();
+
+djinni_string_ref testsuite_constants_get_string_constant();
+
+djinni_string_ref testsuite_constants_get_opt_string_constant();
+
+testsuite_constant_record_ref testsuite_constants_get_object_constant();
+
+/**
+ * No support for null optional constants
+ * No support for optional constant records
+ * No support for constant binary, list, set, map
+ */
+bool testsuite_constants_get_dummy();
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/test-suite/generated-src/c/constants_interface.cpp
+++ b/test-suite/generated-src/c/constants_interface.cpp
@@ -3,7 +3,80 @@
 
 #include "constants_interface.h"
 #include "djinni_c_translators.hpp"
+#include "constant_record.hpp"
 #include "constants_interface.hpp"
+
+bool testsuite_constants_interface_get_bool_constant() {
+    return ::testsuite::ConstantsInterface::BOOL_CONSTANT;
+}
+
+int8_t testsuite_constants_interface_get_i8_constant() {
+    return ::testsuite::ConstantsInterface::I8_CONSTANT;
+}
+
+int16_t testsuite_constants_interface_get_i16_constant() {
+    return ::testsuite::ConstantsInterface::I16_CONSTANT;
+}
+
+int32_t testsuite_constants_interface_get_i32_constant() {
+    return ::testsuite::ConstantsInterface::I32_CONSTANT;
+}
+
+int64_t testsuite_constants_interface_get_i64_constant() {
+    return ::testsuite::ConstantsInterface::I64_CONSTANT;
+}
+
+float testsuite_constants_interface_get_f32_constant() {
+    return ::testsuite::ConstantsInterface::F32_CONSTANT;
+}
+
+double testsuite_constants_interface_get_f64_constant() {
+    return ::testsuite::ConstantsInterface::F64_CONSTANT;
+}
+
+djinni_optional_bool testsuite_constants_interface_get_opt_bool_constant() {
+    return ::djinni::c_api::PrimitiveOptionalTranslator<std::experimental::optional<bool>, djinni_optional_bool>::fromCpp(::testsuite::ConstantsInterface::OPT_BOOL_CONSTANT);
+}
+
+djinni_optional_int8 testsuite_constants_interface_get_opt_i8_constant() {
+    return ::djinni::c_api::PrimitiveOptionalTranslator<std::experimental::optional<int8_t>, djinni_optional_int8>::fromCpp(::testsuite::ConstantsInterface::OPT_I8_CONSTANT);
+}
+
+djinni_optional_int16 testsuite_constants_interface_get_opt_i16_constant() {
+    return ::djinni::c_api::PrimitiveOptionalTranslator<std::experimental::optional<int16_t>, djinni_optional_int16>::fromCpp(::testsuite::ConstantsInterface::OPT_I16_CONSTANT);
+}
+
+djinni_optional_int32 testsuite_constants_interface_get_opt_i32_constant() {
+    return ::djinni::c_api::PrimitiveOptionalTranslator<std::experimental::optional<int32_t>, djinni_optional_int32>::fromCpp(::testsuite::ConstantsInterface::OPT_I32_CONSTANT);
+}
+
+djinni_optional_int64 testsuite_constants_interface_get_opt_i64_constant() {
+    return ::djinni::c_api::PrimitiveOptionalTranslator<std::experimental::optional<int64_t>, djinni_optional_int64>::fromCpp(::testsuite::ConstantsInterface::OPT_I64_CONSTANT);
+}
+
+djinni_optional_float testsuite_constants_interface_get_opt_f32_constant() {
+    return ::djinni::c_api::PrimitiveOptionalTranslator<std::experimental::optional<float>, djinni_optional_float>::fromCpp(::testsuite::ConstantsInterface::OPT_F32_CONSTANT);
+}
+
+djinni_optional_double testsuite_constants_interface_get_opt_f64_constant() {
+    return ::djinni::c_api::PrimitiveOptionalTranslator<std::experimental::optional<double>, djinni_optional_double>::fromCpp(::testsuite::ConstantsInterface::OPT_F64_CONSTANT);
+}
+
+djinni_string_ref testsuite_constants_interface_get_string_constant() {
+    return ::djinni::c_api::StringTranslator::fromCpp(::testsuite::ConstantsInterface::STRING_CONSTANT);
+}
+
+djinni_string_ref testsuite_constants_interface_get_opt_string_constant() {
+    return ::djinni::c_api::OptionalTranslator<std::experimental::optional<std::string>, ::djinni::c_api::StringTranslator>::fromCpp(::testsuite::ConstantsInterface::OPT_STRING_CONSTANT);
+}
+
+testsuite_constant_record_ref testsuite_constants_interface_get_object_constant() {
+    return ::djinni::c_api::RecordTranslator<::testsuite::ConstantRecord>::fromCpp(::testsuite::ConstantsInterface::OBJECT_CONSTANT);
+}
+
+djinni_string_ref testsuite_constants_interface_get_UPPER_CASE_CONSTANT() {
+    return ::djinni::c_api::StringTranslator::fromCpp(::testsuite::ConstantsInterface::UPPER_CASE_CONSTANT);
+}
 
 /**
  * No support for null optional constants

--- a/test-suite/generated-src/c/constants_interface.h
+++ b/test-suite/generated-src/c/constants_interface.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "djinni_c.h"
+#include "constant_record.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,6 +12,58 @@ extern "C" {
 
 /** Interface containing constants */
 typedef djinni_interface_ref testsuite_constants_interface_ref;
+
+bool testsuite_constants_interface_get_bool_constant();
+
+int8_t testsuite_constants_interface_get_i8_constant();
+
+int16_t testsuite_constants_interface_get_i16_constant();
+
+/** i32_constant has documentation. */
+int32_t testsuite_constants_interface_get_i32_constant();
+
+/**
+ * i64_constant has long documentation.
+ * (Second line of multi-line documentation.
+ *   Indented third line of multi-line documentation.)
+ */
+int64_t testsuite_constants_interface_get_i64_constant();
+
+float testsuite_constants_interface_get_f32_constant();
+
+double testsuite_constants_interface_get_f64_constant();
+
+djinni_optional_bool testsuite_constants_interface_get_opt_bool_constant();
+
+djinni_optional_int8 testsuite_constants_interface_get_opt_i8_constant();
+
+/** opt_i16_constant has documentation. */
+djinni_optional_int16 testsuite_constants_interface_get_opt_i16_constant();
+
+djinni_optional_int32 testsuite_constants_interface_get_opt_i32_constant();
+
+djinni_optional_int64 testsuite_constants_interface_get_opt_i64_constant();
+
+/**
+ * opt_f32_constant has long documentation.
+ * (Second line of multi-line documentation.
+ *   Indented third line of multi-line documentation.)
+ */
+djinni_optional_float testsuite_constants_interface_get_opt_f32_constant();
+
+djinni_optional_double testsuite_constants_interface_get_opt_f64_constant();
+
+djinni_string_ref testsuite_constants_interface_get_string_constant();
+
+djinni_string_ref testsuite_constants_interface_get_opt_string_constant();
+
+testsuite_constant_record_ref testsuite_constants_interface_get_object_constant();
+
+/**
+ * This constant will not be generated correctly with style FooBar
+ * to get it correct we would have to use "FooBar!" (see ident_explicit)
+ */
+djinni_string_ref testsuite_constants_interface_get_UPPER_CASE_CONSTANT();
 
 /**
  * No support for null optional constants

--- a/test-suite/generated-src/c/date_record.h
+++ b/test-suite/generated-src/c/date_record.h
@@ -13,6 +13,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_date_record_ref;
 
 testsuite_date_record_ref testsuite_date_record_new(djinni_date_ref created_at);
+
 djinni_date_ref testsuite_date_record_get_created_at(testsuite_date_record_ref instance);
 void testsuite_date_record_set_created_at(testsuite_date_record_ref instance, djinni_date_ref value);
 

--- a/test-suite/generated-src/c/empty_flags.h
+++ b/test-suite/generated-src/c/empty_flags.h
@@ -9,10 +9,10 @@
 extern "C" {
 #endif // __cplusplus
 
-enum testsuite_empty_flags {
+typedef enum {
     testsuite_empty_flags_NONE = 0,
     testsuite_empty_flags_ALL = 0,
-};
+} testsuite_empty_flags;
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/test-suite/generated-src/c/empty_record.h
+++ b/test-suite/generated-src/c/empty_record.h
@@ -17,6 +17,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_empty_record_ref;
 
 testsuite_empty_record_ref testsuite_empty_record_new();
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/test-suite/generated-src/c/enum_usage_record.h
+++ b/test-suite/generated-src/c/enum_usage_record.h
@@ -13,6 +13,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_enum_usage_record_ref;
 
 testsuite_enum_usage_record_ref testsuite_enum_usage_record_new(testsuite_color e, djinni_number_ref o, djinni_array_ref l, djinni_array_ref s, djinni_keyval_array_ref m);
+
 testsuite_color testsuite_enum_usage_record_get_e(testsuite_enum_usage_record_ref instance);
 void testsuite_enum_usage_record_set_e(testsuite_enum_usage_record_ref instance, testsuite_color value);
 

--- a/test-suite/generated-src/c/extended_record.cpp
+++ b/test-suite/generated-src/c/extended_record.cpp
@@ -10,6 +10,10 @@ testsuite_extended_record_ref testsuite_extended_record_new(bool foo)
     return ::djinni::c_api::RecordTranslator<::testsuite::ExtendedRecord>::make(foo);
 }
 
+testsuite_extended_record_ref testsuite_extended_record_get_extended_record_const() {
+    return ::djinni::c_api::RecordTranslator<::testsuite::ExtendedRecord>::fromCpp(::testsuite::ExtendedRecord::EXTENDED_RECORD_CONST);
+}
+
 bool testsuite_extended_record_get_foo(testsuite_extended_record_ref instance)
 {
     return ::djinni::c_api::RecordTranslator<::testsuite::ExtendedRecord>::toCpp(instance).foo;

--- a/test-suite/generated-src/c/extended_record.h
+++ b/test-suite/generated-src/c/extended_record.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "djinni_c.h"
+#include "extended_record.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,6 +14,9 @@ extern "C" {
 typedef djinni_record_ref testsuite_extended_record_ref;
 
 testsuite_extended_record_ref testsuite_extended_record_new(bool foo);
+
+testsuite_extended_record_ref testsuite_extended_record_get_extended_record_const();
+
 bool testsuite_extended_record_get_foo(testsuite_extended_record_ref instance);
 void testsuite_extended_record_set_foo(testsuite_extended_record_ref instance, bool value);
 

--- a/test-suite/generated-src/c/interface_using_extended_record.cpp
+++ b/test-suite/generated-src/c/interface_using_extended_record.cpp
@@ -5,6 +5,11 @@
 #include "djinni_c_translators.hpp"
 #include "../../handwritten-src/cpp/extended_record.hpp"
 #include "interface_using_extended_record.hpp"
+#include "record_using_extended_record.hpp"
+
+testsuite_record_using_extended_record_ref testsuite_interface_using_extended_record_get_cr() {
+    return ::djinni::c_api::RecordTranslator<::testsuite::RecordUsingExtendedRecord>::fromCpp(::testsuite::InterfaceUsingExtendedRecord::CR);
+}
 
 testsuite_extended_record_ref testsuite_interface_using_extended_record_meth(testsuite_interface_using_extended_record_ref instance, testsuite_extended_record_ref er)
 {

--- a/test-suite/generated-src/c/interface_using_extended_record.h
+++ b/test-suite/generated-src/c/interface_using_extended_record.h
@@ -5,12 +5,15 @@
 
 #include "djinni_c.h"
 #include "extended_record.h"
+#include "record_using_extended_record.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
 typedef djinni_interface_ref testsuite_interface_using_extended_record_ref;
+
+testsuite_record_using_extended_record_ref testsuite_interface_using_extended_record_get_cr();
 
 testsuite_extended_record_ref testsuite_interface_using_extended_record_meth(testsuite_interface_using_extended_record_ref instance, testsuite_extended_record_ref er);
 

--- a/test-suite/generated-src/c/map_date_record.h
+++ b/test-suite/generated-src/c/map_date_record.h
@@ -13,6 +13,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_map_date_record_ref;
 
 testsuite_map_date_record_ref testsuite_map_date_record_new(djinni_keyval_array_ref dates_by_id);
+
 djinni_keyval_array_ref testsuite_map_date_record_get_dates_by_id(testsuite_map_date_record_ref instance);
 void testsuite_map_date_record_set_dates_by_id(testsuite_map_date_record_ref instance, djinni_keyval_array_ref value);
 

--- a/test-suite/generated-src/c/map_list_record.h
+++ b/test-suite/generated-src/c/map_list_record.h
@@ -12,6 +12,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_map_list_record_ref;
 
 testsuite_map_list_record_ref testsuite_map_list_record_new(djinni_array_ref map_list);
+
 djinni_array_ref testsuite_map_list_record_get_map_list(testsuite_map_list_record_ref instance);
 void testsuite_map_list_record_set_map_list(testsuite_map_list_record_ref instance, djinni_array_ref value);
 

--- a/test-suite/generated-src/c/map_record.h
+++ b/test-suite/generated-src/c/map_record.h
@@ -12,6 +12,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_map_record_ref;
 
 testsuite_map_record_ref testsuite_map_record_new(djinni_keyval_array_ref map, djinni_keyval_array_ref imap);
+
 djinni_keyval_array_ref testsuite_map_record_get_map(testsuite_map_record_ref instance);
 void testsuite_map_record_set_map(testsuite_map_record_ref instance, djinni_keyval_array_ref value);
 

--- a/test-suite/generated-src/c/nested_collection.h
+++ b/test-suite/generated-src/c/nested_collection.h
@@ -12,6 +12,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_nested_collection_ref;
 
 testsuite_nested_collection_ref testsuite_nested_collection_new(djinni_array_ref set_list);
+
 djinni_array_ref testsuite_nested_collection_get_set_list(testsuite_nested_collection_ref instance);
 void testsuite_nested_collection_set_set_list(testsuite_nested_collection_ref instance, djinni_array_ref value);
 

--- a/test-suite/generated-src/c/nested_outcome.h
+++ b/test-suite/generated-src/c/nested_outcome.h
@@ -13,6 +13,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_nested_outcome_ref;
 
 testsuite_nested_outcome_ref testsuite_nested_outcome_new(djinni_outcome_ref o);
+
 djinni_outcome_ref testsuite_nested_outcome_get_o(testsuite_nested_outcome_ref instance);
 void testsuite_nested_outcome_set_o(testsuite_nested_outcome_ref instance, djinni_outcome_ref value);
 

--- a/test-suite/generated-src/c/primitive_list.h
+++ b/test-suite/generated-src/c/primitive_list.h
@@ -12,6 +12,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_primitive_list_ref;
 
 testsuite_primitive_list_ref testsuite_primitive_list_new(djinni_array_ref list, djinni_array_ref optional_list);
+
 djinni_array_ref testsuite_primitive_list_get_list(testsuite_primitive_list_ref instance);
 void testsuite_primitive_list_set_list(testsuite_primitive_list_ref instance, djinni_array_ref value);
 

--- a/test-suite/generated-src/c/record_using_extended_record.cpp
+++ b/test-suite/generated-src/c/record_using_extended_record.cpp
@@ -11,6 +11,10 @@ testsuite_record_using_extended_record_ref testsuite_record_using_extended_recor
     return ::djinni::c_api::RecordTranslator<::testsuite::RecordUsingExtendedRecord>::make(::djinni::c_api::RecordTranslator<::testsuite::ExtendedRecord>::toCpp(er));
 }
 
+testsuite_record_using_extended_record_ref testsuite_record_using_extended_record_get_cr() {
+    return ::djinni::c_api::RecordTranslator<::testsuite::RecordUsingExtendedRecord>::fromCpp(::testsuite::RecordUsingExtendedRecord::CR);
+}
+
 testsuite_extended_record_ref testsuite_record_using_extended_record_get_er(testsuite_record_using_extended_record_ref instance)
 {
     return ::djinni::c_api::RecordTranslator<::testsuite::ExtendedRecord>::fromCpp(::djinni::c_api::RecordTranslator<::testsuite::RecordUsingExtendedRecord>::toCpp(instance).er);

--- a/test-suite/generated-src/c/record_using_extended_record.h
+++ b/test-suite/generated-src/c/record_using_extended_record.h
@@ -5,6 +5,7 @@
 
 #include "djinni_c.h"
 #include "extended_record.h"
+#include "record_using_extended_record.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,6 +14,9 @@ extern "C" {
 typedef djinni_record_ref testsuite_record_using_extended_record_ref;
 
 testsuite_record_using_extended_record_ref testsuite_record_using_extended_record_new(testsuite_extended_record_ref er);
+
+testsuite_record_using_extended_record_ref testsuite_record_using_extended_record_get_cr();
+
 testsuite_extended_record_ref testsuite_record_using_extended_record_get_er(testsuite_record_using_extended_record_ref instance);
 void testsuite_record_using_extended_record_set_er(testsuite_record_using_extended_record_ref instance, testsuite_extended_record_ref value);
 

--- a/test-suite/generated-src/c/record_with_derivings.h
+++ b/test-suite/generated-src/c/record_with_derivings.h
@@ -12,6 +12,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_record_with_derivings_ref;
 
 testsuite_record_with_derivings_ref testsuite_record_with_derivings_new(int8_t eight, int16_t sixteen, int32_t thirtytwo, int64_t sixtyfour, float fthirtytwo, double fsixtyfour, djinni_date_ref d, djinni_string_ref s);
+
 int8_t testsuite_record_with_derivings_get_eight(testsuite_record_with_derivings_ref instance);
 void testsuite_record_with_derivings_set_eight(testsuite_record_with_derivings_ref instance, int8_t value);
 

--- a/test-suite/generated-src/c/record_with_duration_and_derivings.h
+++ b/test-suite/generated-src/c/record_with_duration_and_derivings.h
@@ -13,6 +13,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_record_with_duration_and_derivings_ref;
 
 testsuite_record_with_duration_and_derivings_ref testsuite_record_with_duration_and_derivings_new(djinni_number_ref dt);
+
 djinni_number_ref testsuite_record_with_duration_and_derivings_get_dt(testsuite_record_with_duration_and_derivings_ref instance);
 void testsuite_record_with_duration_and_derivings_set_dt(testsuite_record_with_duration_and_derivings_ref instance, djinni_number_ref value);
 

--- a/test-suite/generated-src/c/record_with_flags.h
+++ b/test-suite/generated-src/c/record_with_flags.h
@@ -13,6 +13,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_record_with_flags_ref;
 
 testsuite_record_with_flags_ref testsuite_record_with_flags_new(testsuite_access_flags access);
+
 testsuite_access_flags testsuite_record_with_flags_get_access(testsuite_record_with_flags_ref instance);
 void testsuite_record_with_flags_set_access(testsuite_record_with_flags_ref instance, testsuite_access_flags value);
 

--- a/test-suite/generated-src/c/record_with_nested_derivings.h
+++ b/test-suite/generated-src/c/record_with_nested_derivings.h
@@ -13,6 +13,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_record_with_nested_derivings_ref;
 
 testsuite_record_with_nested_derivings_ref testsuite_record_with_nested_derivings_new(int32_t key, testsuite_record_with_derivings_ref rec);
+
 int32_t testsuite_record_with_nested_derivings_get_key(testsuite_record_with_nested_derivings_ref instance);
 void testsuite_record_with_nested_derivings_set_key(testsuite_record_with_nested_derivings_ref instance, int32_t value);
 

--- a/test-suite/generated-src/c/set_record.h
+++ b/test-suite/generated-src/c/set_record.h
@@ -12,6 +12,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_set_record_ref;
 
 testsuite_set_record_ref testsuite_set_record_new(djinni_array_ref set, djinni_array_ref iset);
+
 djinni_array_ref testsuite_set_record_get_set(testsuite_set_record_ref instance);
 void testsuite_set_record_set_set(testsuite_set_record_ref instance, djinni_array_ref value);
 

--- a/test-suite/generated-src/c/support_copying.h
+++ b/test-suite/generated-src/c/support_copying.h
@@ -12,6 +12,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_support_copying_ref;
 
 testsuite_support_copying_ref testsuite_support_copying_new(int32_t x);
+
 int32_t testsuite_support_copying_get_x(testsuite_support_copying_ref instance);
 void testsuite_support_copying_set_x(testsuite_support_copying_ref instance, int32_t value);
 

--- a/test-suite/generated-src/c/vec2.h
+++ b/test-suite/generated-src/c/vec2.h
@@ -12,6 +12,7 @@ extern "C" {
 typedef djinni_record_ref testsuite_vec2_ref;
 
 testsuite_vec2_ref testsuite_vec2_new(int32_t x, int32_t y);
+
 int32_t testsuite_vec2_get_x(testsuite_vec2_ref instance);
 void testsuite_vec2_set_x(testsuite_vec2_ref instance, int32_t value);
 

--- a/test-suite/handwritten-src/c/tests/DjinniCAPI_tests.cpp
+++ b/test-suite/handwritten-src/c/tests/DjinniCAPI_tests.cpp
@@ -3,6 +3,8 @@
 #include "assorted_primitives.h"
 #include "client_interface.h"
 #include "client_returned_record.h"
+#include "constant_with_enum.h"
+#include "constants.h"
 #include "enum_usage_record.h"
 #include "map_record.h"
 #include "primitive_list.h"
@@ -697,6 +699,30 @@ TEST(DjinniCAPI, supportsPropagatingErrorInFuture) {
 
   ASSERT_EQ(std::string("Error"),
             std::string(djinni_string_get_data(result.error)));
+}
+
+TEST(DjinniCAPI, supportsConstants) {
+  ASSERT_EQ(true, testsuite_constants_get_bool_constant());
+  ASSERT_EQ(4, testsuite_constants_get_i64_constant());
+  ASSERT_EQ(5.0f, testsuite_constants_get_f32_constant());
+  ASSERT_EQ(5.0, testsuite_constants_get_f64_constant());
+
+  auto opt = testsuite_constants_get_opt_f64_constant();
+  ASSERT_TRUE(opt.has_value);
+  ASSERT_EQ(5.0, opt.value);
+
+  ASSERT_EQ(testsuite_constant_enum_SOME_VALUE,
+            testsuite_constant_with_enum_get_const_enum());
+}
+
+TEST(DjinniCAPI, supportsConstantsRecord) {
+  auto constant = CRef(testsuite_constants_get_object_constant());
+
+  ASSERT_EQ(3, testsuite_constant_record_get_some_integer(constant.value));
+
+  auto str = CRef(testsuite_constant_record_get_some_string(constant.value));
+  ASSERT_EQ(std::string("string-constant"),
+            std::string(djinni_string_get_data(str.value)));
 }
 
 } // namespace djinni


### PR DESCRIPTION
This change adds supports for constants in C codegen. It generates getters that fetches the constants from C++, and performs the conversions appropriately. It supports primitives, strings, optionals, records etc...