### PR TITLE
use valdi unicode conversions api instead of deprecated c++ apis

### DIFF
--- a/support-lib/valdi/djinni_valdi.hpp
+++ b/support-lib/valdi/djinni_valdi.hpp
@@ -144,11 +144,7 @@ using String = Primitive<std::string>;
 template<typename T>
 using Enum = Primitive<T, int32_t>;
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 class WString {
-    using Utf8Converter = std::wstring_convert<std::codecvt_utf8<wchar_t>>;
-    using Utf16Converter = std::wstring_convert<std::codecvt_utf16<wchar_t>>;
 public:
     using CppType = std::wstring;
     using ValdiType = Valdi::Value;
@@ -157,28 +153,21 @@ public:
 
     static CppType toCpp(const ValdiType& v) {
         if (v.isInternedString()) {
-            auto utf8str = v.toStringBox().toStringView();
-            return Utf8Converter{}.from_bytes(utf8str.data(), utf8str.data() + utf8str.size());
+            return Valdi::StaticString::utf8ToWString(v.toStringBox().toStringView());
         } else {
-            const auto* sstr = v.getStaticString();
-            if (sstr->encoding() == Valdi::StaticString::Encoding::UTF8) {
-                return Utf8Converter{}.from_bytes(sstr->utf8Data(), sstr->utf8Data() + sstr->size());
-            } else {
-                const auto* begin = reinterpret_cast<const char*>(sstr->utf16Data());
-                const auto* end = reinterpret_cast<const char*>(sstr->utf16Data() + sstr->size());
-                return Utf16Converter{}.from_bytes(begin, end);
-            }
+            return v.getStaticString()->toStdWString();
         }
     }
+
     static ValdiType fromCpp(const CppType& c) {
-        return ValdiType(Utf8Converter{}.to_bytes(c));
+        return ValdiType(Valdi::StaticString::makeWithWideChars(c.data(), c.size()));
     }
+
     static const Valdi::ValueSchema& schema() noexcept {
         static auto schema = Valdi::ValueSchema::string();
         return schema;
     }
 };
-#pragma clang diagnostic pop
 
 class Binary {
 public:


### PR DESCRIPTION
This change updates the string conversions API for Valdi to use the the Valdi native unicode helpers instead of the deprecated C++ APIs. This change was checked in in master but got overriden a few days ago because the unicode change was not part of upstream. This PR fixes this by bringing the change upstream.

Changes:
- Using `StaticString::utf8ToWString()` to convert a Valdi interned string to a C++ wstring. Under the hood, it detects at compile time the representation of wstring (utf16 or utf32) and uses the right conversion.
- Using `StaticString::makeWithWideChars()` to create a StaticString from a C++ wstring.