### PR TITLE
Make DataView assignable to support use in C records

### DIFF
--- a/support-lib/cpp/DataView.hpp
+++ b/support-lib/cpp/DataView.hpp
@@ -29,6 +29,10 @@ public:
 
     DataView(const DataView&) = default;
 
+    DataView& operator=(DataView&&) = default;
+    
+    DataView& operator=(const DataView&) = default;
+
     uint8_t* buf() const {
         return _buf;
     }
@@ -38,7 +42,7 @@ public:
 
 private:
     uint8_t* _buf;
-    const size_t _len;
+    size_t _len;
 };
 
 } // namespace djinni


### PR DESCRIPTION
The C code generator creates setters for record fields, so the field types must be assignable, but `DataView` is not currently.
Add copy/move assign operators.
