### PR TITLE
C++ wrapper classes for generated C API

### DIFF
--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -249,6 +249,15 @@ class CGenerator(spec: Spec) extends Generator(spec) {
       if (spec.cWrapperCppNamespace.isDefined) {
         w.wl
         writeCppWrapperClass(ident, w, (w: IndentWriter) => {
+          w.w(s"static ${ident.name} make(")
+          writeParamListWithResolvedFields(w, resolvedFields)
+          w.w(")")
+          w.braced {
+            w.w(s"return ${prefix}_new(")
+            w.w(resolvedFields.map(p => p.field.ident.name).mkString(", "))
+            w.wl(");")
+          }
+          w.wl
           for (resolvedField <- resolvedFields) {
             val fieldName = resolvedField.field.ident.name
             val fieldTypename = resolvedField.translator.typename

--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -44,14 +44,19 @@ class CGenerator(spec: Spec) extends Generator(spec) {
 
   def privateHeader(t: TypeDecl): String = q(spec.cppIncludePrefix + spec.cppFileIdentStyle(t.ident.name) + "." + spec.cppHeaderExt)
 
-  private def wrapExternC(w: IndentWriter, f: IndentWriter => Unit) = {
+  private def wrapIfCpp(w: IndentWriter, f: IndentWriter => Unit) = {
     w.wl("#ifdef __cplusplus")
-    w.wl("extern \"C\" {")
-    w.wl("#endif // __cplusplus")
     f(w)
-    w.wl("#ifdef __cplusplus")
-    w.wl("} // extern \"C\"")
     w.wl("#endif // __cplusplus")
+  }
+  private def wrapExternC(w: IndentWriter, f: IndentWriter => Unit) = {
+    wrapIfCpp(w, (w: IndentWriter) => {
+      w.wl("extern \"C\" {")
+    })
+    f(w)
+    wrapIfCpp(w, (w: IndentWriter) => {
+      w.wl("} // extern \"C\"")
+    })
   }
 
   private def writeCFile(origin: String, ident: Ident, ext: String, f: IndentWriter => Unit): Unit = {
@@ -143,17 +148,36 @@ class CGenerator(spec: Spec) extends Generator(spec) {
     }
   }
 
-  private def writeCppWrapperClass(ident: Ident, cppClassName: String, w: IndentWriter, body: IndentWriter => Unit): Unit = {
+  private def writeCppWrapperClass(ident: Ident, cppClassName: String, w: IndentWriter, methods: IndentWriter => Unit): Unit = {
     val typeName = resolveRefSymbolTypeName(ident)
-    wrapNamespace(w, spec.cppNamespace + "::c_wrappers", (w: IndentWriter) => {
-        w.w(s"template <template <typename> class Ref> class ${cppClassName}").bracedSemi {
-          w.wlOutdent("public:")
-          body(w)
-          w.wl
-          w.wlOutdent("private:")
-          w.wl(s"Ref<${typeName}> _ref;")
-        }
-      })
+    wrapIfCpp(w, (w: IndentWriter) => {
+      wrapNamespace(w, spec.cppNamespace + "::c_wrappers", (w: IndentWriter) => {
+          w.w(s"template <template <typename> class Ref> class ${cppClassName}").bracedSemi {
+            w.wlOutdent("public:")
+            w.wl(s"using RefType = Ref<${typeName}>;")
+            w.wl
+            w.wl(s"explicit ${cppClassName}(const RefType& ref) : _ref(ref) {}")
+            w.wl
+            w.wl(s"${cppClassName}(const ${cppClassName}&) = default;")
+            w.wl
+            w.wl(s"${cppClassName}(${cppClassName}&&) = default;")
+            w.wl
+            w.wl(s"${cppClassName}& operator=(const ${cppClassName}&) = default;")
+            w.wl
+            w.wl(s"${cppClassName}& operator=(${cppClassName}&&) = default;")
+            w.wl
+            w.wl(s"operator const RefType&() const { return _ref; }")
+            w.wl
+            w.wl(s"operator ${typeName}() const { return _ref.get(); }")
+            w.wl
+            w.wl(s"${typeName} _djinni_ref() const { return _ref.get(); }")
+            w.wl
+            methods(w)
+            w.wlOutdent("private:")
+            w.wl(s"RefType _ref;")
+          }
+        })
+    })
   }
 
   override def generateRecord(origin: String, ident: Ident, doc: Doc, params: Seq[TypeParam], r: ast.Record): Unit = {
@@ -197,12 +221,12 @@ class CGenerator(spec: Spec) extends Generator(spec) {
           val fieldTypename = resolvedField.translator.typename
           w.w(s"${fieldTypename} ${fieldName}() const")
           w.braced {
-            w.wl(s"return ${prefix}_get_${fieldName}(_ref.get);")
+            w.wl(s"return ${prefix}_get_${fieldName}(_ref.get());")
           }
           w.wl
           w.w(s"${fieldTypename} ${fieldName}(${fieldTypename} value)")
           w.braced {
-            w.wl(s"${prefix}_set_${fieldName}(_ref.get, value);")
+            w.wl(s"${prefix}_set_${fieldName}(_ref.get(), value);")
           }
           w.wl
         }
@@ -406,14 +430,19 @@ class CGenerator(spec: Spec) extends Generator(spec) {
         w.wl
         writeCppWrapperClass(ident, selfCppClass, w, (w: IndentWriter) => {
           for (resolvedMethod <- resolvedMethods) {
+            if (resolvedMethod.method.static) {
+              w.w("static ")
+            }
             w.w(s"${resolvedMethod.retTypename} ${resolvedMethod.resolvedName}(")
             writeParamList(w, resolvedMethod.parameters.map(p => (p.translator.typename, p.field.ident.name)))
             w.w(") ")
             w.braced {
-              val returnStr = if (resolvedMethod.retTypename != "void") "return " else ""
               val argsList = resolvedMethod.parameters.map(p => (p.field.ident.name))
               val fullArgsList = if (resolvedMethod.method.static) argsList else "_ref.get()" +: argsList
-              w.wl(s"${returnStr}${prefix}_${resolvedMethod.resolvedName}(${fullArgsList.mkString(", ")});")
+              if (resolvedMethod.retTypename != "void") {
+                w.w("return ")
+              }
+              w.wl(s"${prefix}_${resolvedMethod.resolvedName}(${fullArgsList.mkString(", ")});")
             }
             w.wl
             }

--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -44,13 +44,11 @@ class CGenerator(spec: Spec) extends Generator(spec) {
 
   def privateHeader(t: TypeDecl): String = q(spec.cppIncludePrefix + spec.cppFileIdentStyle(t.ident.name) + "." + spec.cppHeaderExt)
 
-  private def writeExternCBegin(w: IndentWriter): Unit = {
+  private def wrapExternC(w: IndentWriter, f: IndentWriter => Unit) = {
     w.wl("#ifdef __cplusplus")
     w.wl("extern \"C\" {")
     w.wl("#endif // __cplusplus")
-  }
-
-  private def writeExternCEnd(w: IndentWriter): Unit = {
+    f(w)
     w.wl("#ifdef __cplusplus")
     w.wl("} // extern \"C\"")
     w.wl("#endif // __cplusplus")
@@ -76,13 +74,7 @@ class CGenerator(spec: Spec) extends Generator(spec) {
       publicIncludes.foreach(w.wl)
 
       w.wl
-
-      writeExternCBegin(w)
-      w.wl
-
       header(w)
-
-      writeExternCEnd(w)
     })
 
     writeCFile(origin, ident, "cpp", (w: IndentWriter) => {
@@ -151,6 +143,19 @@ class CGenerator(spec: Spec) extends Generator(spec) {
     }
   }
 
+  private def writeCppWrapperClass(ident: Ident, cppClassName: String, w: IndentWriter, body: IndentWriter => Unit): Unit = {
+    val typeName = resolveRefSymbolTypeName(ident)
+    wrapNamespace(w, spec.cppNamespace + "::c_wrappers", (w: IndentWriter) => {
+        w.w(s"template <template <typename> class Ref> class ${cppClassName}").bracedSemi {
+          w.wlOutdent("public:")
+          body(w)
+          w.wl
+          w.wlOutdent("private:")
+          w.wl(s"Ref<${typeName}> _ref;")
+        }
+      })
+  }
+
   override def generateRecord(origin: String, ident: Ident, doc: Doc, params: Seq[TypeParam], r: ast.Record): Unit = {
     val selfCpp = cppMarshal.fqTypename(ident, r)
 
@@ -162,25 +167,27 @@ class CGenerator(spec: Spec) extends Generator(spec) {
     val resolvedConsts = r.consts.map(r => new ResolvedConst(r, typeResolver.resolve(r.ty.resolved)))
 
     writeCFilePair(origin, ident, typeResolver.publicImports.toSeq, typeResolver.privateImports.toSeq)((w: IndentWriter) => {
-      writeDoc(w, doc)
-      w.wl(s"""typedef djinni_record_ref ${typeName};""")
-      w.wl
-
-      w.w(s"""${typeName} ${prefix}_new(""")
-      writeParamListWithResolvedFields(w, resolvedFields)
-      w.wl(");")
-      w.wl
-
-      generateConstsHeader(prefix, resolvedConsts, w)
-
-      for (resolvedField <- resolvedFields) {
-        val fieldName = resolvedField.field.ident.name
-        val fieldTypename = resolvedField.translator.typename
-        writeDoc(w, resolvedField.field.doc)
-        w.wl(s"""${fieldTypename} ${prefix}_get_${fieldName}(${typeName} instance);""")
-        w.wl(s"""void ${prefix}_set_${fieldName}(${typeName} instance, ${fieldTypename} value);""")
+      wrapExternC(w, (w: IndentWriter) => {
+        writeDoc(w, doc)
+        w.wl(s"""typedef djinni_record_ref ${typeName};""")
         w.wl
-      }
+
+        w.w(s"""${typeName} ${prefix}_new(""")
+        writeParamListWithResolvedFields(w, resolvedFields)
+        w.wl(");")
+        w.wl
+
+        generateConstsHeader(prefix, resolvedConsts, w)
+
+        for (resolvedField <- resolvedFields) {
+          val fieldName = resolvedField.field.ident.name
+          val fieldTypename = resolvedField.translator.typename
+          writeDoc(w, resolvedField.field.doc)
+          w.wl(s"""${fieldTypename} ${prefix}_get_${fieldName}(${typeName} instance);""")
+          w.wl(s"""void ${prefix}_set_${fieldName}(${typeName} instance, ${fieldTypename} value);""")
+          w.wl
+        }
+      })
     }, (w: IndentWriter) => {
       w.w(s"""${typeName} ${prefix}_new(""")
       writeParamListWithResolvedFields(w, resolvedFields)
@@ -217,7 +224,6 @@ class CGenerator(spec: Spec) extends Generator(spec) {
         }
         w.wl
       }
-
     })
   }
 
@@ -307,6 +313,7 @@ class CGenerator(spec: Spec) extends Generator(spec) {
 
   override def generateInterface(origin: String, ident: Ident, doc: Doc, typeParams: Seq[TypeParam], i: Interface): Unit = {
     val selfCpp = cppMarshal.fqTypename(ident, i)
+    val selfCppClass = cppMarshal.typename(ident, i)
     val typeResolver = new CTypeResolver(ident, spec, cppMarshal)
     val resolvedMethods = i.methods.map(m =>
       new ResolvedMethod(
@@ -327,53 +334,70 @@ class CGenerator(spec: Spec) extends Generator(spec) {
     val proxyClassName = s"${resolveSymbolName(ident)}_proxy_class_ref"
     val methodDefsStructName = s"${resolveSymbolName(ident)}_method_defs"
     writeCFilePair(origin, ident, typeResolver.publicImports.toSeq, typeResolver.privateImports.toSeq)((w: IndentWriter) => {
-      writeDoc(w, doc)
-      w.wl(s"""typedef djinni_interface_ref ${typeName};""")
+      wrapExternC(w, (w: IndentWriter) => {
+        writeDoc(w, doc)
+        w.wl(s"""typedef djinni_interface_ref ${typeName};""")
 
-      if (i.ext.cc) {
-        w.wl(s"""typedef djinni_proxy_class_ref ${proxyClassName};""")
-        w.wl
+        if (i.ext.cc) {
+          w.wl(s"""typedef djinni_proxy_class_ref ${proxyClassName};""")
+          w.wl
 
-        w.wl(s"""typedef struct """)
-        w.bracedEnd(s" ${methodDefsStructName};") {
+          w.wl(s"""typedef struct """)
+          w.bracedEnd(s" ${methodDefsStructName};") {
 
-          if (resolvedMethods.isEmpty) {
-            w.wl("void *reserved[1];")
-          } else {
-            for (resolvedMethod <- resolvedMethods) {
-              w.w(s"""${resolvedMethod.retTypename} (*${resolvedMethod.method.ident.name})(""")
-              writeDelimited(w, "void *" +: resolvedMethod.parameters.map(p => p.translator.typename), ", ")(s => w.w(s))
-              w.wl(");")
+            if (resolvedMethods.isEmpty) {
+              w.wl("void *reserved[1];")
+            } else {
+              for (resolvedMethod <- resolvedMethods) {
+                w.w(s"""${resolvedMethod.retTypename} (*${resolvedMethod.method.ident.name})(""")
+                writeDelimited(w, "void *" +: resolvedMethod.parameters.map(p => p.translator.typename), ", ")(s => w.w(s))
+                w.wl(");")
+              }
             }
           }
-        }
-        w.wl
+          w.wl
 
-        w.wl(s"${proxyClassName} ${prefix}_proxy_class_new(const ${methodDefsStructName} *method_defs, djinni_opaque_deallocator opaque_deallocator);")
-        w.wl
-        w.wl(s"${typeName} ${prefix}_new(${proxyClassName} proxy_class, void *opaque);")
-        w.wl("")
-      } else {
-        w.wl
-      }
-
-      generateConstsHeader(prefix, resolvedConsts, w)
-
-      for (resolvedMethod <- resolvedMethods) {
-        writeDoc(w, resolvedMethod.method.doc)
-        w.w(s"${resolvedMethod.retTypename} ${prefix}_${resolvedMethod.resolvedName}(")
-
-        if (resolvedMethod.method.static) {
-          writeParamList(w, resolvedMethod.parameters.map(p => (p.translator.typename, p.field.ident.name)))
+          w.wl(s"${proxyClassName} ${prefix}_proxy_class_new(const ${methodDefsStructName} *method_defs, djinni_opaque_deallocator opaque_deallocator);")
+          w.wl
+          w.wl(s"${typeName} ${prefix}_new(${proxyClassName} proxy_class, void *opaque);")
+          w.wl("")
         } else {
-          writeParamList(w, (typeName, "instance") +: resolvedMethod.parameters.map(p => (p.translator.typename, p.field.ident.name)))
+          w.wl
         }
 
-        w.wl(");")
+        generateConstsHeader(prefix, resolvedConsts, w)
 
-        w.wl
-      }
+        for (resolvedMethod <- resolvedMethods) {
+          writeDoc(w, resolvedMethod.method.doc)
+          w.w(s"${resolvedMethod.retTypename} ${prefix}_${resolvedMethod.resolvedName}(")
 
+          if (resolvedMethod.method.static) {
+            writeParamList(w, resolvedMethod.parameters.map(p => (p.translator.typename, p.field.ident.name)))
+          } else {
+            writeParamList(w, (typeName, "instance") +: resolvedMethod.parameters.map(p => (p.translator.typename, p.field.ident.name)))
+          }
+
+          w.wl(");")
+
+          w.wl
+        }
+      })
+
+      w.wl
+      writeCppWrapperClass(ident, selfCppClass, w, (w: IndentWriter) => {
+        for (resolvedMethod <- resolvedMethods) {
+            w.w(s"${resolvedMethod.retTypename} ${resolvedMethod.resolvedName}(")
+            writeParamList(w, resolvedMethod.parameters.map(p => (p.translator.typename, p.field.ident.name)))
+            w.w(") ")
+            w.braced {
+              val returnStr = if (resolvedMethod.retTypename != "void") "return " else ""
+              val argsList = resolvedMethod.parameters.map(p => (p.field.ident.name))
+              val fullArgsList = if (resolvedMethod.method.static) argsList else "_ref.get()" +: argsList
+              w.wl(s"${returnStr}${prefix}_${resolvedMethod.resolvedName}(${fullArgsList.mkString(", ")});")
+            }
+            w.wl
+          }
+      })
     }, (w: IndentWriter) => {
       if (i.ext.cc) {
         val proxyClassNameCpp = writeProxyClass(w, ident, methodDefsStructName, resolvedMethods)

--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -158,6 +158,7 @@ class CGenerator(spec: Spec) extends Generator(spec) {
 
   override def generateRecord(origin: String, ident: Ident, doc: Doc, params: Seq[TypeParam], r: ast.Record): Unit = {
     val selfCpp = cppMarshal.fqTypename(ident, r)
+    val selfCppClass = cppMarshal.typename(ident, r)
 
     val typeResolver = new CTypeResolver(ident, spec, cppMarshal)
     val prefix = resolveSymbolName(ident.name)
@@ -185,6 +186,24 @@ class CGenerator(spec: Spec) extends Generator(spec) {
           writeDoc(w, resolvedField.field.doc)
           w.wl(s"""${fieldTypename} ${prefix}_get_${fieldName}(${typeName} instance);""")
           w.wl(s"""void ${prefix}_set_${fieldName}(${typeName} instance, ${fieldTypename} value);""")
+          w.wl
+        }
+      })
+
+      w.wl
+      writeCppWrapperClass(ident, selfCppClass, w, (w: IndentWriter) => {
+        for (resolvedField <- resolvedFields) {
+          val fieldName = resolvedField.field.ident.name
+          val fieldTypename = resolvedField.translator.typename
+          w.w(s"${fieldTypename} ${fieldName}() const")
+          w.braced {
+            w.wl(s"return ${prefix}_get_${fieldName}(_ref.get);")
+          }
+          w.wl
+          w.w(s"${fieldTypename} ${fieldName}(${fieldTypename} value)")
+          w.braced {
+            w.wl(s"${prefix}_set_${fieldName}(_ref.get, value);")
+          }
           w.wl
         }
       })
@@ -383,9 +402,10 @@ class CGenerator(spec: Spec) extends Generator(spec) {
         }
       })
 
-      w.wl
-      writeCppWrapperClass(ident, selfCppClass, w, (w: IndentWriter) => {
-        for (resolvedMethod <- resolvedMethods) {
+      if (i.ext.cpp) {
+        w.wl
+        writeCppWrapperClass(ident, selfCppClass, w, (w: IndentWriter) => {
+          for (resolvedMethod <- resolvedMethods) {
             w.w(s"${resolvedMethod.retTypename} ${resolvedMethod.resolvedName}(")
             writeParamList(w, resolvedMethod.parameters.map(p => (p.translator.typename, p.field.ident.name)))
             w.w(") ")
@@ -396,8 +416,9 @@ class CGenerator(spec: Spec) extends Generator(spec) {
               w.wl(s"${returnStr}${prefix}_${resolvedMethod.resolvedName}(${fullArgsList.mkString(", ")});")
             }
             w.wl
-          }
-      })
+            }
+        })
+      }
     }, (w: IndentWriter) => {
       if (i.ext.cc) {
         val proxyClassNameCpp = writeProxyClass(w, ident, methodDefsStructName, resolvedMethods)

--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -148,10 +148,12 @@ class CGenerator(spec: Spec) extends Generator(spec) {
     }
   }
 
-  private def writeCppWrapperClass(ident: Ident, cppClassName: String, w: IndentWriter, methods: IndentWriter => Unit): Unit = {
+  private def writeCppWrapperClass(ident: Ident, w: IndentWriter, methods: IndentWriter => Unit): Unit = {
     val typeName = resolveRefSymbolTypeName(ident)
+    val cppClassName = ident.name
+    val cppNamespace = spec.cWrapperCppNamespace.getOrElse(spec.cppNamespace + "::c_wrappers")
     wrapIfCpp(w, (w: IndentWriter) => {
-      wrapNamespace(w, spec.cppNamespace + "::c_wrappers", (w: IndentWriter) => {
+      wrapNamespace(w, cppNamespace, (w: IndentWriter) => {
           w.w(s"template <template <typename> class Ref> class ${cppClassName}").bracedSemi {
             w.wlOutdent("public:")
             w.wl(s"using RefType = Ref<${typeName}>;")
@@ -214,23 +216,25 @@ class CGenerator(spec: Spec) extends Generator(spec) {
         }
       })
 
-      w.wl
-      writeCppWrapperClass(ident, selfCppClass, w, (w: IndentWriter) => {
-        for (resolvedField <- resolvedFields) {
-          val fieldName = resolvedField.field.ident.name
-          val fieldTypename = resolvedField.translator.typename
-          w.w(s"${fieldTypename} ${fieldName}() const")
-          w.braced {
-            w.wl(s"return ${prefix}_get_${fieldName}(_ref.get());")
+      if (spec.cWrapperCppNamespace.isDefined) {
+        w.wl
+        writeCppWrapperClass(ident, w, (w: IndentWriter) => {
+          for (resolvedField <- resolvedFields) {
+            val fieldName = resolvedField.field.ident.name
+            val fieldTypename = resolvedField.translator.typename
+            w.w(s"${fieldTypename} ${fieldName}() const")
+            w.braced {
+              w.wl(s"return ${prefix}_get_${fieldName}(_ref.get());")
+            }
+            w.wl
+            w.w(s"${fieldTypename} ${fieldName}(${fieldTypename} value)")
+            w.braced {
+              w.wl(s"${prefix}_set_${fieldName}(_ref.get(), value);")
+            }
+            w.wl
           }
-          w.wl
-          w.w(s"${fieldTypename} ${fieldName}(${fieldTypename} value)")
-          w.braced {
-            w.wl(s"${prefix}_set_${fieldName}(_ref.get(), value);")
-          }
-          w.wl
-        }
-      })
+        })
+      }
     }, (w: IndentWriter) => {
       w.w(s"""${typeName} ${prefix}_new(""")
       writeParamListWithResolvedFields(w, resolvedFields)
@@ -426,9 +430,9 @@ class CGenerator(spec: Spec) extends Generator(spec) {
         }
       })
 
-      if (i.ext.cpp) {
+      if (i.ext.cpp && spec.cWrapperCppNamespace.isDefined) {
         w.wl
-        writeCppWrapperClass(ident, selfCppClass, w, (w: IndentWriter) => {
+        writeCppWrapperClass(ident, w, (w: IndentWriter) => {
           for (resolvedMethod <- resolvedMethods) {
             if (resolvedMethod.method.static) {
               w.w("static ")

--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -155,25 +155,24 @@ class CGenerator(spec: Spec) extends Generator(spec) {
     val cppClassName = ident.name
     val cppNamespace = spec.cWrapperCppNamespace.getOrElse(spec.cppNamespace + "::c_wrappers")
     wrapIfCpp(w, (w: IndentWriter) => {
+      w.wl("#include <utility>")
       wrapNamespace(w, cppNamespace, (w: IndentWriter) => {
           w.w(s"template <template <typename> class Ref> class ${cppClassName}").bracedSemi {
             w.wlOutdent("public:")
             w.wl(s"using RefType = Ref<${typeName}>;")
             w.wl
-            w.wl(s"explicit ${cppClassName}(const RefType& ref) : _ref(ref) {}")
-            w.wl
+            w.wl(s"${cppClassName}(const RefType& ref) : _ref(ref) {}")
+            w.wl(s"${cppClassName}(const ${typeName}& ref) : _ref(ref) {}")
+            w.wl(s"${cppClassName}(${typeName}&& ref) : _ref(std::move(ref)) {}")
             w.wl(s"${cppClassName}(const ${cppClassName}&) = default;")
-            w.wl
             w.wl(s"${cppClassName}(${cppClassName}&&) = default;")
-            w.wl
             w.wl(s"${cppClassName}& operator=(const ${cppClassName}&) = default;")
-            w.wl
             w.wl(s"${cppClassName}& operator=(${cppClassName}&&) = default;")
+            w.wl(s"${cppClassName}& operator=(const ${typeName}& ref) { _ref = ref; return *this; }")
+            w.wl(s"${cppClassName}& operator=(${typeName}&& ref) { _ref = std::move(ref); return *this; }")
             w.wl
             w.wl(s"operator const RefType&() const { return _ref; }")
-            w.wl
             w.wl(s"operator ${typeName}() const { return _ref.get(); }")
-            w.wl
             w.wl(s"${typeName} _djinni_ref() const { return _ref.get(); }")
             w.wl
             methods(w)
@@ -228,9 +227,10 @@ class CGenerator(spec: Spec) extends Generator(spec) {
               w.wl(s"return ${prefix}_get_${fieldName}(_ref.get());")
             }
             w.wl
-            w.w(s"${fieldTypename} ${fieldName}(${fieldTypename} value)")
+            w.w(s"${ident.name}& ${fieldName}(${fieldTypename} value)")
             w.braced {
               w.wl(s"${prefix}_set_${fieldName}(_ref.get(), value);")
+              w.wl("return *this;")
             }
             w.wl
           }

--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -157,27 +157,57 @@ class CGenerator(spec: Spec) extends Generator(spec) {
     wrapIfCpp(w, (w: IndentWriter) => {
       w.wl("#include <utility>")
       wrapNamespace(w, cppNamespace, (w: IndentWriter) => {
-          w.w(s"template <template <typename> class Ref> class ${cppClassName}").bracedSemi {
+          w.w(s"class ${cppClassName}").bracedSemi {
             w.wlOutdent("public:")
-            w.wl(s"using RefType = Ref<${typeName}>;")
             w.wl
-            w.wl(s"${cppClassName}(const RefType& ref) : _ref(ref) {}")
-            w.wl(s"${cppClassName}(const ${typeName}& ref) : _ref(ref) {}")
-            w.wl(s"${cppClassName}(${typeName}&& ref) : _ref(std::move(ref)) {}")
-            w.wl(s"${cppClassName}(const ${cppClassName}&) = default;")
-            w.wl(s"${cppClassName}(${cppClassName}&&) = default;")
-            w.wl(s"${cppClassName}& operator=(const ${cppClassName}&) = default;")
-            w.wl(s"${cppClassName}& operator=(${cppClassName}&&) = default;")
-            w.wl(s"${cppClassName}& operator=(const ${typeName}& ref) { _ref = ref; return *this; }")
-            w.wl(s"${cppClassName}& operator=(${typeName}&& ref) { _ref = std::move(ref); return *this; }")
+            w.wl(s"${cppClassName}(const ${typeName}& ref) : _ref(ref) { djinni_ref_retain(_ref); }")
+            w.wl(s"${cppClassName}(${typeName}&& ref) noexcept : _ref(std::move(ref)) {}")
+            w.wl(s"${cppClassName}(const ${cppClassName}& other) : _ref(other._ref) { djinni_ref_retain(_ref); }")
+            w.wl(s"${cppClassName}(${cppClassName}&& other) : _ref(std::move(other._ref)) { other._ref = nullptr; }")
+            w.wl(s"~${cppClassName}() { djinni_ref_release(_ref); }")
+
+            val assignOps =
+              s"""${cppClassName}& operator=(const ${cppClassName}& other) {
+                |  if (&other != this) {
+                |      auto old = _ref;
+                |      _ref = other._ref;
+                |      djinni_ref_retain(_ref);
+                |      djinni_ref_release(old);
+                |   }
+                |   return *this;
+                |}
+                |${cppClassName}& operator=(${cppClassName}&& other) noexcept {
+                |  if (&other != this) {
+                |    auto old = _ref;
+                |    _ref = other._ref;
+                |    other._ref = nullptr;
+                |
+                |    djinni_ref_release(old);
+                |  }
+                |  return *this;
+                |}
+                |${cppClassName}& operator=(${typeName}&& ref) {
+                |  auto old = _ref;
+                |  _ref = ref;
+                |  djinni_ref_release(old);
+                |  return *this;
+                |}
+                |${cppClassName}& operator=(const ${typeName}& ref) {
+                |  auto old = _ref;
+                |  _ref = ref;
+                |  djinni_ref_retain(ref);
+                |  djinni_ref_release(old);
+                |  return *this;
+                |}""".stripMargin
+            assignOps.split("\n").toSeq.foreach(line => w.wl(line))
+
             w.wl
-            w.wl(s"operator const RefType&() const { return _ref; }")
-            w.wl(s"operator ${typeName}() const { return _ref.get(); }")
-            w.wl(s"${typeName} _djinni_ref() const { return _ref.get(); }")
+            w.wl(s"operator ${typeName}() const { return _ref; }")
+            w.wl(s"${typeName} _djinni_ref() const { return _ref; }")
             w.wl
             methods(w)
             w.wlOutdent("private:")
-            w.wl(s"RefType _ref;")
+            w.wl(s"${typeName} _ref;")
           }
         })
     })
@@ -224,12 +254,12 @@ class CGenerator(spec: Spec) extends Generator(spec) {
             val fieldTypename = resolvedField.translator.typename
             w.w(s"${fieldTypename} ${fieldName}() const")
             w.braced {
-              w.wl(s"return ${prefix}_get_${fieldName}(_ref.get());")
+              w.wl(s"return ${prefix}_get_${fieldName}(_ref);")
             }
             w.wl
             w.w(s"${ident.name}& ${fieldName}(${fieldTypename} value)")
             w.braced {
-              w.wl(s"${prefix}_set_${fieldName}(_ref.get(), value);")
+              w.wl(s"${prefix}_set_${fieldName}(_ref, value);")
               w.wl("return *this;")
             }
             w.wl
@@ -442,7 +472,7 @@ class CGenerator(spec: Spec) extends Generator(spec) {
             w.w(") ")
             w.braced {
               val argsList = resolvedMethod.parameters.map(p => (p.field.ident.name))
-              val fullArgsList = if (resolvedMethod.method.static) argsList else "_ref.get()" +: argsList
+              val fullArgsList = if (resolvedMethod.method.static) argsList else "_ref" +: argsList
               if (resolvedMethod.retTypename != "void") {
                 w.w("return ")
               }

--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -53,6 +53,7 @@ class CGenerator(spec: Spec) extends Generator(spec) {
     wrapIfCpp(w, (w: IndentWriter) => {
       w.wl("extern \"C\" {")
     })
+    w.wl
     f(w)
     wrapIfCpp(w, (w: IndentWriter) => {
       w.wl("} // extern \"C\"")
@@ -96,14 +97,15 @@ class CGenerator(spec: Spec) extends Generator(spec) {
     writeCFilePair(origin, ident, List.empty[String], List.empty[String])((w: IndentWriter) => {
       val symbolName = resolveSymbolName(ident.name)
       val enumCasePrefix = symbolName + "_"
-      writeDoc(w, doc)
-      w.w("typedef enum")
-      w.bracedEnd(s" ${symbolName};") {
-        writeEnumOptionNone(w, e, idCpp.enum, "=", enumCasePrefix)
-        writeEnumOptions(w, e, idCpp.enum, "=", enumCasePrefix)
-        writeEnumOptionAll(w, e, idCpp.enum, "=", enumCasePrefix)
-      }
-
+      wrapExternC(w, (w: IndentWriter) => {
+        writeDoc(w, doc)
+        w.w("typedef enum")
+        w.bracedEnd(s" ${symbolName};") {
+          writeEnumOptionNone(w, e, idCpp.enum, "=", enumCasePrefix)
+          writeEnumOptions(w, e, idCpp.enum, "=", enumCasePrefix)
+          writeEnumOptionAll(w, e, idCpp.enum, "=", enumCasePrefix)
+        }
+      })
     }, (w: IndentWriter) => {
     })
   }

--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -184,7 +184,6 @@ class CGenerator(spec: Spec) extends Generator(spec) {
 
   override def generateRecord(origin: String, ident: Ident, doc: Doc, params: Seq[TypeParam], r: ast.Record): Unit = {
     val selfCpp = cppMarshal.fqTypename(ident, r)
-    val selfCppClass = cppMarshal.typename(ident, r)
 
     val typeResolver = new CTypeResolver(ident, spec, cppMarshal)
     val prefix = resolveSymbolName(ident.name)
@@ -360,7 +359,6 @@ class CGenerator(spec: Spec) extends Generator(spec) {
 
   override def generateInterface(origin: String, ident: Ident, doc: Doc, typeParams: Seq[TypeParam], i: Interface): Unit = {
     val selfCpp = cppMarshal.fqTypename(ident, i)
-    val selfCppClass = cppMarshal.typename(ident, i)
     val typeResolver = new CTypeResolver(ident, spec, cppMarshal)
     val resolvedMethods = i.methods.map(m =>
       new ResolvedMethod(

--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -202,8 +202,8 @@ class CGenerator(spec: Spec) extends Generator(spec) {
             assignOps.split("\n").toSeq.foreach(line => w.wl(line))
 
             w.wl
-            w.wl(s"operator ${typeName}() const { return _ref; }")
-            w.wl(s"${typeName} _djinni_ref() const { return _ref; }")
+            w.wl(s"operator const ${typeName}&() const { return _ref; }")
+            w.wl(s"const ${typeName}& _djinni_ref() const { return _ref; }")
             w.wl
             methods(w)
             w.wlOutdent("private:")

--- a/src/source/Main.scala
+++ b/src/source/Main.scala
@@ -116,6 +116,7 @@ object Main {
     var cNamespace: String = ""
     var cBaseLibIncludePrefix: String = ""
     var cIncludePrefix: String = ""
+    var cWrapperCppNamespace: Option[String] = None
     var swiftOutFolder: Option[File] = None
     var swiftModule: String = "Module"
     var swiftIdentStyle = IdentStyle.swiftDefault
@@ -316,6 +317,8 @@ object Main {
         .text("The C base library's include path, relative to the C files.")
       opt[String]("c-include-prefix").valueName("...").foreach(x => cIncludePrefix = x)
         .text("The prefix for #includes of header files from C++ files.")
+      opt[String]("c-wrapper-cpp-namespace").valueName("...").foreach(x => cWrapperCppNamespace = Some(x))
+        .text("The C++ namespace to use for C API wrapper convenience classes.")
       opt[File]("swift-out").valueName("<out-folder>").foreach(x => swiftOutFolder = Some(x))
         .text("The output folder for Swift files (Generator disabled if unspecified).")
       opt[String]("swift-module").valueName("<name>").foreach(swiftModule = _)
@@ -541,6 +544,7 @@ object Main {
       cNamespace,
       cBaseLibIncludePrefix,
       cIncludePrefix,
+      cWrapperCppNamespace,
       swiftOutFolder,
       swiftIdentStyle,
       swiftModule,

--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -118,6 +118,7 @@ package object generatorTools {
                    cNamespace: String,
                    cBaseLibIncludePrefix: String,
                    cIncludePrefix: String,
+                   cWrapperCppNamespace: Option[String],
                    swiftOutFolder: Option[File],
                    swiftIdentStyle: SwiftIdentStyle,
                    swiftModule: String,

--- a/support-lib/cpp/djinni_c_ref.hpp
+++ b/support-lib/cpp/djinni_c_ref.hpp
@@ -41,7 +41,7 @@ public:
     return *this;
   }
 
-  T get() const { return _ref; }
+  const T& get() const { return _ref; }
 
 private:
   T _ref;


### PR DESCRIPTION
Add option to generate C++ wrapper classes for use with the C API. These can be used if you intend to use the C API from another C++ environment, eg across an ABI boundary.

The wrapper classes are generated if the `--c-wrapper-cpp-namespace` CLI argument is provided - this is the namespace for the wrappers.

Example using `--c-wrapper-cpp-namespace snap::test::c_wrappers` :

`my_module.djinni` :
```
Size = record {
  width: i32;
  height: i32;
}

Window = interface +c {
  static create(): Window;
  show();
  hide();
  setSize(size: Size);
  setTitle(title: string);
}
```

Generated `Size.h`
```
// AUTOGENERATED FILE - DO NOT MODIFY!
// This file was generated by Djinni from test.djinni

#pragma once

#include "djinni/cpp/djinni_c.h"

#ifdef __cplusplus
extern "C" {
#endif // __cplusplus

typedef djinni_record_ref test_test_Size_ref;

test_test_Size_ref test_test_Size_new(int32_t width, int32_t height);

int32_t test_test_Size_get_width(test_test_Size_ref instance);
void test_test_Size_set_width(test_test_Size_ref instance, int32_t value);

int32_t test_test_Size_get_height(test_test_Size_ref instance);
void test_test_Size_set_height(test_test_Size_ref instance, int32_t value);

#ifdef __cplusplus
} // extern "C"
#endif // __cplusplus

#ifdef __cplusplus
#include <utility>
namespace snap::test::c_wrappers {

class Size {
public:

    Size(const test_test_Size_ref& ref) : _ref(ref) { djinni_ref_retain(_ref); }
    Size(test_test_Size_ref&& ref) noexcept : _ref(std::move(ref)) {}
    Size(const Size& other) : _ref(other._ref) { djinni_ref_retain(_ref); }
    Size(Size&& other) : _ref(std::move(other._ref)) { other._ref = nullptr; }
    ~Size() { djinni_ref_release(_ref); }
    Size& operator=(const Size& other) {
      if (&other != this) {
          auto old = _ref;
          _ref = other._ref;
          djinni_ref_retain(_ref);
          djinni_ref_release(old);
       }
       return *this;
    }
    Size& operator=(Size&& other) noexcept {
      if (&other != this) {
        auto old = _ref;
        _ref = other._ref;
        other._ref = nullptr;
    
        djinni_ref_release(old);
      }
      return *this;
    }
    Size& operator=(test_test_Size_ref&& ref) {
      auto old = _ref;
      _ref = ref;
      djinni_ref_release(old);
      return *this;
    }
    Size& operator=(const test_test_Size_ref& ref) {
      auto old = _ref;
      _ref = ref;
      djinni_ref_retain(ref);
      djinni_ref_release(old);
      return *this;
    }

    operator const test_test_Size_ref&() const { return _ref; }
    const test_test_Size_ref& _djinni_ref() const { return _ref; }

    int32_t width() const {
        return test_test_Size_get_width(_ref);
    }

    Size& width(int32_t value) {
        test_test_Size_set_width(_ref, value);
        return *this;
    }

    int32_t height() const {
        return test_test_Size_get_height(_ref);
    }

    Size& height(int32_t value) {
        test_test_Size_set_height(_ref, value);
        return *this;
    }

private:
    test_test_Size_ref _ref;
};

} // namespace snap::test::c_wrappers
#endif // __cplusplus
```

Generated `Window.h` :
```
// AUTOGENERATED FILE - DO NOT MODIFY!
// This file was generated by Djinni from test.djinni

#pragma once

#include "djinni/cpp/djinni_c.h"
#include "test/Size.h"
#include "test/Window.h"

#ifdef __cplusplus
extern "C" {
#endif // __cplusplus

typedef djinni_interface_ref test_test_Window_ref;

test_test_Window_ref test_test_Window_create();

void test_test_Window_show(test_test_Window_ref instance);

void test_test_Window_hide(test_test_Window_ref instance);

void test_test_Window_setSize(test_test_Window_ref instance, test_test_Size_ref size);

void test_test_Window_setTitle(test_test_Window_ref instance, djinni_string_ref title);

#ifdef __cplusplus
} // extern "C"
#endif // __cplusplus

#ifdef __cplusplus
#include <utility>
namespace snap::test::c_wrappers {

class Window {
public:

    Window(const test_test_Window_ref& ref) : _ref(ref) { djinni_ref_retain(_ref); }
    Window(test_test_Window_ref&& ref) noexcept : _ref(std::move(ref)) {}
    Window(const Window& other) : _ref(other._ref) { djinni_ref_retain(_ref); }
    Window(Window&& other) : _ref(std::move(other._ref)) { other._ref = nullptr; }
    ~Window() { djinni_ref_release(_ref); }
    Window& operator=(const Window& other) {
      if (&other != this) {
          auto old = _ref;
          _ref = other._ref;
          djinni_ref_retain(_ref);
          djinni_ref_release(old);
       }
       return *this;
    }
    Window& operator=(Window&& other) noexcept {
      if (&other != this) {
        auto old = _ref;
        _ref = other._ref;
        other._ref = nullptr;
    
        djinni_ref_release(old);
      }
      return *this;
    }
    Window& operator=(test_test_Window_ref&& ref) {
      auto old = _ref;
      _ref = ref;
      djinni_ref_release(old);
      return *this;
    }
    Window& operator=(const test_test_Window_ref& ref) {
      auto old = _ref;
      _ref = ref;
      djinni_ref_retain(ref);
      djinni_ref_release(old);
      return *this;
    }

    operator const test_test_Window_ref&() const { return _ref; }
    const test_test_Window_ref& _djinni_ref() const { return _ref; }

    static test_test_Window_ref create()  {
        return test_test_Window_create();
    }

    void show()  {
        test_test_Window_show(_ref);
    }

    void hide()  {
        test_test_Window_hide(_ref);
    }

    void setSize(test_test_Size_ref size)  {
        test_test_Window_setSize(_ref, size);
    }

    void setTitle(djinni_string_ref title)  {
        test_test_Window_setTitle(_ref, title);
    }

private:
    test_test_Window_ref _ref;
};

} // namespace snap::test::c_wrappers
#endif // __cplusplus
```

The wrappers can then be used to simplify C API usage:

```
#include "djinni/cpp/djinni_c_ref.hpp"

#include "my_module/Size.h"
#include "my_module/Window.h"

#include <stdio.h>

void testFunc() {
  using namespace snap::test::c_wrappers;

  Window win = Window::create();
  Size size = win.getSize();
  printf("size is %d x %d\n", size.width(), size.height());

  size.width(size.width() + 10);
  win.setSize(size);
  win.setTitle(djinni_string_new("foo", 3));
  win.show();
}
```
