### PR TITLE
Support C API dynamic loading using dlsym()

### DIFF
--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -162,9 +162,9 @@ class CGenerator(spec: Spec) extends Generator(spec) {
     val prefix = resolveSymbolName(ident.name)
     val libHandleDefine = s"DJINNI_LIB_HANDLE_${prefix}"
     wrapIfCpp(w, (w: IndentWriter) => {
-      w.wl("#include <cassert>")
       w.wl("#include <utility>")
       if (spec.cWrapperUseDlsym) {
+        w.wl("#include <cassert>")
         w.wl("#include <dlfcn.h>")
         w.wl(s"#if !defined(${libHandleDefine})")
         w.wl(s"#if defined(DJINNI_C_DEFAULT_LIB_HANDLE)")
@@ -226,7 +226,7 @@ class CGenerator(spec: Spec) extends Generator(spec) {
             methods(w)
             w.wlOutdent("private:")
 
-            w.wl(s"${typeName} _ref{nullptr};")
+            w.wl(s"${typeName} _ref;")
             if (spec.cWrapperUseDlsym) {
               w.wl
               // function table

--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -155,7 +155,7 @@ class CGenerator(spec: Spec) extends Generator(spec) {
     }
   }
 
-  private def writeCppWrapperClass(ident: Ident, w: IndentWriter, methods: IndentWriter => Unit, functionNames: Seq[String] = Seq.empty): Unit = {
+  private def writeCppWrapperClass(ident: Ident, w: IndentWriter, methods: IndentWriter => Unit, functionNames: Seq[String]): Unit = {
     val typeName = resolveRefSymbolTypeName(ident)
     val cppClassName = ident.name
     val cppNamespace = spec.cWrapperCppNamespace.getOrElse(spec.cppNamespace + "::c_wrappers")
@@ -225,7 +225,6 @@ class CGenerator(spec: Spec) extends Generator(spec) {
             w.wl
             methods(w)
             w.wlOutdent("private:")
-
             w.wl(s"${typeName} _ref;")
             if (spec.cWrapperUseDlsym) {
               w.wl

--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -150,12 +150,14 @@ class CGenerator(spec: Spec) extends Generator(spec) {
     }
   }
 
-  private def writeCppWrapperClass(ident: Ident, w: IndentWriter, methods: IndentWriter => Unit): Unit = {
+  private def writeCppWrapperClass(ident: Ident, w: IndentWriter, methods: IndentWriter => Unit, functionNames: Seq[String] = Seq.empty): Unit = {
     val typeName = resolveRefSymbolTypeName(ident)
     val cppClassName = ident.name
     val cppNamespace = spec.cWrapperCppNamespace.getOrElse(spec.cppNamespace + "::c_wrappers")
     wrapIfCpp(w, (w: IndentWriter) => {
+      w.wl("#include <cassert>")
       w.wl("#include <utility>")
+      w.wl("#include <dlfcn.h>")
       wrapNamespace(w, cppNamespace, (w: IndentWriter) => {
           w.w(s"class ${cppClassName}").bracedSemi {
             w.wlOutdent("public:")
@@ -207,7 +209,31 @@ class CGenerator(spec: Spec) extends Generator(spec) {
             w.wl
             methods(w)
             w.wlOutdent("private:")
-            w.wl(s"${typeName} _ref;")
+
+            w.wl(s"${typeName} _ref{nullptr};")
+            w.wl
+            // function table
+            w.w(s"struct Funcs").bracedSemi {
+              for (functionName <- functionNames) {
+                w.wl(s"decltype(&${functionName}) ${functionName};")
+              }
+            }
+            w.wl
+            val functionLoads = functionNames.map(functionName =>
+              s"""|    reinterpret_cast<decltype(&${functionName})>(loadAndAssert("${functionName}")),""").mkString("\n")
+            val functionLoader =
+              s"""static inline Funcs* _loadFuncs() {
+              |  auto loadAndAssert = [](const char* funcName) {
+              |    auto* ptr = dlsym(RTLD_DEFAULT, funcName);
+              |    assert(ptr && "dlsym failed");
+              |    return ptr;
+              |  };
+              |  static Funcs funcs {
+              ${functionLoads}
+              |  };
+              |  return &funcs;
+              |}""".stripMargin
+            functionLoader.split("\n").toSeq.foreach(line => w.wl(line))
           }
         })
     })
@@ -248,12 +274,16 @@ class CGenerator(spec: Spec) extends Generator(spec) {
 
       if (spec.cWrapperCppNamespace.isDefined) {
         w.wl
+        val functionNames = Seq(s"${prefix}_new") ++ resolvedFields.flatMap(resolvedField => {
+          val fieldName = resolvedField.field.ident.name
+          Seq(s"${prefix}_get_${fieldName}", s"${prefix}_set_${fieldName}")
+        })
         writeCppWrapperClass(ident, w, (w: IndentWriter) => {
           w.w(s"static ${ident.name} make(")
           writeParamListWithResolvedFields(w, resolvedFields)
           w.w(")")
           w.braced {
-            w.w(s"return ${prefix}_new(")
+            w.w(s"return _loadFuncs()->${prefix}_new(")
             w.w(resolvedFields.map(p => p.field.ident.name).mkString(", "))
             w.wl(");")
           }
@@ -263,17 +293,17 @@ class CGenerator(spec: Spec) extends Generator(spec) {
             val fieldTypename = resolvedField.translator.typename
             w.w(s"${fieldTypename} ${fieldName}() const")
             w.braced {
-              w.wl(s"return ${prefix}_get_${fieldName}(_ref);")
+              w.wl(s"return _loadFuncs()->${prefix}_get_${fieldName}(_ref);")
             }
             w.wl
             w.w(s"${ident.name}& ${fieldName}(${fieldTypename} value)")
             w.braced {
-              w.wl(s"${prefix}_set_${fieldName}(_ref, value);")
+              w.wl(s"_loadFuncs()->${prefix}_set_${fieldName}(_ref, value);")
               w.wl("return *this;")
             }
             w.wl
           }
-        })
+        }, functionNames)
       }
     }, (w: IndentWriter) => {
       w.w(s"""${typeName} ${prefix}_new(""")
@@ -471,6 +501,8 @@ class CGenerator(spec: Spec) extends Generator(spec) {
 
       if (i.ext.cpp && spec.cWrapperCppNamespace.isDefined) {
         w.wl
+        val functionNames = resolvedMethods.map(resolvedMethod =>
+          s"${prefix}_${resolvedMethod.resolvedName}")
         writeCppWrapperClass(ident, w, (w: IndentWriter) => {
           for (resolvedMethod <- resolvedMethods) {
             if (resolvedMethod.method.static) {
@@ -485,11 +517,11 @@ class CGenerator(spec: Spec) extends Generator(spec) {
               if (resolvedMethod.retTypename != "void") {
                 w.w("return ")
               }
-              w.wl(s"${prefix}_${resolvedMethod.resolvedName}(${fullArgsList.mkString(", ")});")
+              w.wl(s"_loadFuncs()->${prefix}_${resolvedMethod.resolvedName}(${fullArgsList.mkString(", ")});")
             }
             w.wl
             }
-        })
+        }, functionNames)
       }
     }, (w: IndentWriter) => {
       if (i.ext.cc) {

--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -160,7 +160,7 @@ class CGenerator(spec: Spec) extends Generator(spec) {
     val cppClassName = ident.name
     val cppNamespace = spec.cWrapperCppNamespace.getOrElse(spec.cppNamespace + "::c_wrappers")
     val prefix = resolveSymbolName(ident.name)
-    val libHandleDefine = s"DJINNI_LIB_HANDLE_${prefix}"
+    val libHandleDefine = s"DJINNI_C_LIB_HANDLE_${prefix}"
     wrapIfCpp(w, (w: IndentWriter) => {
       w.wl("#include <utility>")
       if (spec.cWrapperUseDlsym) {

--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -59,6 +59,11 @@ class CGenerator(spec: Spec) extends Generator(spec) {
       w.wl("} // extern \"C\"")
     })
   }
+  private def writeFunctionVisiblity(w: IndentWriter) = {
+    if (spec.cWrapperUseDlsym) {
+      w.wl(s"""__attribute__((visibility("default")))""")
+    }
+  }
 
   private def writeCFile(origin: String, ident: Ident, ext: String, f: IndentWriter => Unit): Unit = {
     val targetDir = if (ext == "h") spec.cHeaderOutFolder else spec.cOutFolder
@@ -154,10 +159,21 @@ class CGenerator(spec: Spec) extends Generator(spec) {
     val typeName = resolveRefSymbolTypeName(ident)
     val cppClassName = ident.name
     val cppNamespace = spec.cWrapperCppNamespace.getOrElse(spec.cppNamespace + "::c_wrappers")
+    val prefix = resolveSymbolName(ident.name)
+    val libHandleDefine = s"DJINNI_LIB_HANDLE_${prefix}"
     wrapIfCpp(w, (w: IndentWriter) => {
       w.wl("#include <cassert>")
       w.wl("#include <utility>")
-      w.wl("#include <dlfcn.h>")
+      if (spec.cWrapperUseDlsym) {
+        w.wl("#include <dlfcn.h>")
+        w.wl(s"#if !defined(${libHandleDefine})")
+        w.wl(s"#if defined(DJINNI_C_DEFAULT_LIB_HANDLE)")
+        w.wl(s"#define ${libHandleDefine} DJINNI_C_DEFAULT_LIB_HANDLE")
+        w.wl(s"#else")
+        w.wl(s"#define ${libHandleDefine} RTLD_DEFAULT")
+        w.wl(s"#endif // DJINNI_C_DEFAULT_LIB_HANDLE")
+        w.wl(s"#endif // !${libHandleDefine}")
+      }
       wrapNamespace(w, cppNamespace, (w: IndentWriter) => {
           w.w(s"class ${cppClassName}").bracedSemi {
             w.wlOutdent("public:")
@@ -211,29 +227,31 @@ class CGenerator(spec: Spec) extends Generator(spec) {
             w.wlOutdent("private:")
 
             w.wl(s"${typeName} _ref{nullptr};")
-            w.wl
-            // function table
-            w.w(s"struct Funcs").bracedSemi {
-              for (functionName <- functionNames) {
-                w.wl(s"decltype(&${functionName}) ${functionName};")
+            if (spec.cWrapperUseDlsym) {
+              w.wl
+              // function table
+              w.w(s"struct Funcs").bracedSemi {
+                for (functionName <- functionNames) {
+                  w.wl(s"decltype(&${functionName}) ${functionName};")
+                }
               }
+              w.wl
+              val functionLoads = functionNames.map(functionName =>
+                s"""|    reinterpret_cast<decltype(&${functionName})>(loadAndAssert("${functionName}")),""").mkString("\n")
+              val functionLoader =
+                s"""static inline Funcs* _loadFuncs() {
+                |  auto loadAndAssert = [](const char* funcName) {
+                |    auto* ptr = dlsym(${libHandleDefine}, funcName);
+                |    assert(ptr && "dlsym() failed loading djinni C functions for class ${cppNamespace}::${cppClassName}");
+                |    return ptr;
+                |  };
+                |  static Funcs funcs {
+                ${functionLoads}
+                |  };
+                |  return &funcs;
+                |}""".stripMargin
+              functionLoader.split("\n").toSeq.foreach(line => w.wl(line))
             }
-            w.wl
-            val functionLoads = functionNames.map(functionName =>
-              s"""|    reinterpret_cast<decltype(&${functionName})>(loadAndAssert("${functionName}")),""").mkString("\n")
-            val functionLoader =
-              s"""static inline Funcs* _loadFuncs() {
-              |  auto loadAndAssert = [](const char* funcName) {
-              |    auto* ptr = dlsym(RTLD_DEFAULT, funcName);
-              |    assert(ptr && "dlsym failed");
-              |    return ptr;
-              |  };
-              |  static Funcs funcs {
-              ${functionLoads}
-              |  };
-              |  return &funcs;
-              |}""".stripMargin
-            functionLoader.split("\n").toSeq.foreach(line => w.wl(line))
           }
         })
     })
@@ -255,6 +273,7 @@ class CGenerator(spec: Spec) extends Generator(spec) {
         w.wl(s"""typedef djinni_record_ref ${typeName};""")
         w.wl
 
+        writeFunctionVisiblity(w)
         w.w(s"""${typeName} ${prefix}_new(""")
         writeParamListWithResolvedFields(w, resolvedFields)
         w.wl(");")
@@ -266,13 +285,16 @@ class CGenerator(spec: Spec) extends Generator(spec) {
           val fieldName = resolvedField.field.ident.name
           val fieldTypename = resolvedField.translator.typename
           writeDoc(w, resolvedField.field.doc)
+          writeFunctionVisiblity(w)
           w.wl(s"""${fieldTypename} ${prefix}_get_${fieldName}(${typeName} instance);""")
+          writeFunctionVisiblity(w)
           w.wl(s"""void ${prefix}_set_${fieldName}(${typeName} instance, ${fieldTypename} value);""")
           w.wl
         }
       })
 
       if (spec.cWrapperCppNamespace.isDefined) {
+        val loadFuncPtr = if (spec.cWrapperUseDlsym) "_loadFuncs()->" else ""
         w.wl
         val functionNames = Seq(s"${prefix}_new") ++ resolvedFields.flatMap(resolvedField => {
           val fieldName = resolvedField.field.ident.name
@@ -283,7 +305,7 @@ class CGenerator(spec: Spec) extends Generator(spec) {
           writeParamListWithResolvedFields(w, resolvedFields)
           w.w(")")
           w.braced {
-            w.w(s"return _loadFuncs()->${prefix}_new(")
+            w.w(s"return ${loadFuncPtr}${prefix}_new(")
             w.w(resolvedFields.map(p => p.field.ident.name).mkString(", "))
             w.wl(");")
           }
@@ -293,12 +315,12 @@ class CGenerator(spec: Spec) extends Generator(spec) {
             val fieldTypename = resolvedField.translator.typename
             w.w(s"${fieldTypename} ${fieldName}() const")
             w.braced {
-              w.wl(s"return _loadFuncs()->${prefix}_get_${fieldName}(_ref);")
+              w.wl(s"return ${loadFuncPtr}${prefix}_get_${fieldName}(_ref);")
             }
             w.wl
             w.w(s"${ident.name}& ${fieldName}(${fieldTypename} value)")
             w.braced {
-              w.wl(s"_loadFuncs()->${prefix}_set_${fieldName}(_ref, value);")
+              w.wl(s"${loadFuncPtr}${prefix}_set_${fieldName}(_ref, value);")
               w.wl("return *this;")
             }
             w.wl
@@ -473,8 +495,10 @@ class CGenerator(spec: Spec) extends Generator(spec) {
           }
           w.wl
 
+          writeFunctionVisiblity(w)
           w.wl(s"${proxyClassName} ${prefix}_proxy_class_new(const ${methodDefsStructName} *method_defs, djinni_opaque_deallocator opaque_deallocator);")
           w.wl
+          writeFunctionVisiblity(w)
           w.wl(s"${typeName} ${prefix}_new(${proxyClassName} proxy_class, void *opaque);")
           w.wl("")
         } else {
@@ -485,6 +509,7 @@ class CGenerator(spec: Spec) extends Generator(spec) {
 
         for (resolvedMethod <- resolvedMethods) {
           writeDoc(w, resolvedMethod.method.doc)
+          writeFunctionVisiblity(w)
           w.w(s"${resolvedMethod.retTypename} ${prefix}_${resolvedMethod.resolvedName}(")
 
           if (resolvedMethod.method.static) {
@@ -500,9 +525,9 @@ class CGenerator(spec: Spec) extends Generator(spec) {
       })
 
       if (i.ext.cpp && spec.cWrapperCppNamespace.isDefined) {
+        val loadFuncPtr = if (spec.cWrapperUseDlsym) "_loadFuncs()->" else ""
         w.wl
-        val functionNames = resolvedMethods.map(resolvedMethod =>
-          s"${prefix}_${resolvedMethod.resolvedName}")
+        val functionNames = resolvedMethods.map(resolvedMethod => s"${prefix}_${resolvedMethod.resolvedName}")
         writeCppWrapperClass(ident, w, (w: IndentWriter) => {
           for (resolvedMethod <- resolvedMethods) {
             if (resolvedMethod.method.static) {
@@ -517,7 +542,7 @@ class CGenerator(spec: Spec) extends Generator(spec) {
               if (resolvedMethod.retTypename != "void") {
                 w.w("return ")
               }
-              w.wl(s"_loadFuncs()->${prefix}_${resolvedMethod.resolvedName}(${fullArgsList.mkString(", ")});")
+              w.wl(s"${loadFuncPtr}${prefix}_${resolvedMethod.resolvedName}(${fullArgsList.mkString(", ")});")
             }
             w.wl
             }

--- a/src/source/CGenerator.scala
+++ b/src/source/CGenerator.scala
@@ -166,6 +166,9 @@ class CGenerator(spec: Spec) extends Generator(spec) {
       if (spec.cWrapperUseDlsym) {
         w.wl("#include <cassert>")
         w.wl("#include <dlfcn.h>")
+        w.wl(s"#if !defined(DJINNI_C_LOAD_SYM_FUNC)")
+        w.wl(s"#define DJINNI_C_LOAD_SYM_FUNC dlsym")
+        w.wl(s"#endif // !DJINNI_C_LOAD_SYM_FUNC")
         w.wl(s"#if !defined(${libHandleDefine})")
         w.wl(s"#if defined(DJINNI_C_DEFAULT_LIB_HANDLE)")
         w.wl(s"#define ${libHandleDefine} DJINNI_C_DEFAULT_LIB_HANDLE")
@@ -240,8 +243,8 @@ class CGenerator(spec: Spec) extends Generator(spec) {
               val functionLoader =
                 s"""static inline Funcs* _loadFuncs() {
                 |  auto loadAndAssert = [](const char* funcName) {
-                |    auto* ptr = dlsym(${libHandleDefine}, funcName);
-                |    assert(ptr && "dlsym() failed loading djinni C functions for class ${cppNamespace}::${cppClassName}");
+                |    auto* ptr = DJINNI_C_LOAD_SYM_FUNC(${libHandleDefine}, funcName);
+                |    assert(ptr && "Failed to load djinni C functions for class ${cppNamespace}::${cppClassName}");
                 |    return ptr;
                 |  };
                 |  static Funcs funcs {

--- a/src/source/Main.scala
+++ b/src/source/Main.scala
@@ -117,6 +117,7 @@ object Main {
     var cBaseLibIncludePrefix: String = ""
     var cIncludePrefix: String = ""
     var cWrapperCppNamespace: Option[String] = None
+    var cWrapperUseDlsym: Boolean = false
     var swiftOutFolder: Option[File] = None
     var swiftModule: String = "Module"
     var swiftIdentStyle = IdentStyle.swiftDefault
@@ -325,6 +326,8 @@ object Main {
         .text("The prefix for #includes of header files from C++ files.")
       opt[String]("c-wrapper-cpp-namespace").valueName("...").foreach(x => cWrapperCppNamespace = Some(x))
         .text("The C++ namespace to use for C API wrapper convenience classes.")
+      opt[Boolean]( "c-wrapper-use-dlsym").valueName("<true/false>").foreach(x => cWrapperUseDlsym = x)
+        .text("In C wrapper, resolve functions at runtime using dlsym() instead of directly linking at build-time. (default: false)")
       opt[File]("swift-out").valueName("<out-folder>").foreach(x => swiftOutFolder = Some(x))
         .text("The output folder for Swift files (Generator disabled if unspecified).")
       opt[String]("swift-module").valueName("<name>").foreach(swiftModule = _)
@@ -551,6 +554,7 @@ object Main {
       cBaseLibIncludePrefix,
       cIncludePrefix,
       cWrapperCppNamespace,
+      cWrapperUseDlsym,
       swiftOutFolder,
       swiftIdentStyle,
       swiftModule,

--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -119,6 +119,7 @@ package object generatorTools {
                    cBaseLibIncludePrefix: String,
                    cIncludePrefix: String,
                    cWrapperCppNamespace: Option[String],
+                   cWrapperUseDlsym: Boolean,
                    swiftOutFolder: Option[File],
                    swiftIdentStyle: SwiftIdentStyle,
                    swiftModule: String,


### PR DESCRIPTION
Currently the C wrapper classes link directly to the underlying C functions, meaning the library must be present at build-time. Add support for lazy-loading the C functions at runtime using `dlsym()`, enabled with a new `--c-wrapper-use-dlsym=true` generator argument.

Example djinni (namespace `test`):
```
Foo = interface {
    bar(n: i32);
    baz(s: string): bool;
}
```

C wrapper functions before:
```
    void bar(int32_t n)  {
        test_Foo_bar(_ref, n);
    }

    bool baz(djinni_string_ref s)  {
        return test_Foo_baz(_ref, s);
    }
```

C wrapper functions after:
```
    void bar(int32_t n)  {
        _loadFuncs()->test_Foo_bar(_ref, n);
    }

    bool baz(djinni_string_ref s)  {
        return _loadFuncs()->test_Foo_baz(_ref, s);
    }

private:
    struct Funcs {
        decltype(&test_Foo_bar) test_Foo_bar;
        decltype(&test_Foo_baz) test_Foo_baz;
    };

    static inline Funcs* _loadFuncs() {
      auto loadAndAssert = [](const char* funcName) {
        auto* ptr = DJINNI_C_LOAD_SYM_FUNC(DJINNI_C_LIB_HANDLE_test_Foo, funcName);
        assert(ptr && "Failed to load djinni C functions for class test::c_wrappers::Foo");
        return ptr;
      };
      static Funcs funcs {
        reinterpret_cast<decltype(&test_Foo_bar)>(loadAndAssert("test_Foo_bar")),
        reinterpret_cast<decltype(&test_Foo_baz)>(loadAndAssert("test_Foo_baz")),
      };
      return &funcs;
    }
```
`DJINNI_C_LOAD_SYM_FUNC(libHandle, functionName)` can be defined by the platform to provide a symbol loader function similar to `dlsym()`. If it is not explicitly defined `dlsym()` will be used by default.
`DJINNI_C_LIB_HANDLE_test_Foo` can be defined to reference a specific handle opened with `DJINNI_C_LOAD_SYM_FUNC()`. Also `DJINNI_C_DEFAULT_LIB_HANDLE` can be defined as a global default (individual wrapper classes can still use their own definitions overriding the default). If neither of these is defined `RTLD_DEFAULT` will be used as the handle.

If the `--c-wrapper-use-dlsym=true` argument is not supplied, the generated code is identical to the current version.