### PR TITLE
Default enable checked C API unless disabled by NDEBUG

### DIFF
--- a/support-lib/cpp/djinni_c_types.hpp
+++ b/support-lib/cpp/djinni_c_types.hpp
@@ -4,7 +4,7 @@
 #include <memory>
 
 #ifndef DJINNI_CHECKED_C_API
-#if DEBUG
+#ifndef NDEBUG
 #define DJINNI_CHECKED_C_API 1
 #else
 #define DJINNI_CHECKED_C_API 0


### PR DESCRIPTION
The checked C API (use `dynamic_cast` to validate that a djinni C ref is of the correct type) is only enabled if `DEBUG` is defined but there is not a way to control this. Change to enabled checking by default unless the `NDEBUG` environment is building.